### PR TITLE
Add Session.tracer(_:) and RequestServiceContext for distributed tracing

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -58,6 +58,10 @@ let package = Package(
             url: "https://github.com/apple/swift-system",
             from: "1.8.1"
         ),
+        .package(
+            url: "https://github.com/apple/swift-distributed-tracing",
+            from: "1.1.0"
+        ),
     ],
     targets: [
         .target(
@@ -76,6 +80,7 @@ let package = Package(
                 .product(name: "NIOTransportServices", package: "swift-nio-transport-services"),
                 .product(name: "SystemPackage", package: "swift-system"),
                 .product(name: "Logging", package: "swift-log"),
+                .product(name: "Tracing", package: "swift-distributed-tracing"),
             ],
             swiftSettings: [.defaultIsolation(nil)],
         ),
@@ -98,6 +103,7 @@ let package = Package(
                 .product(name: "SystemPackage", package: "swift-system"),
                 .product(name: "Logging", package: "swift-log"),
                 .product(name: "Collections", package: "swift-collections"),
+                .product(name: "Tracing", package: "swift-distributed-tracing"),
             ],
             swiftSettings: [.defaultIsolation(nil)],
         ),

--- a/Sources/RequestDL/Properties/Sources/Session/Session/Session.swift
+++ b/Sources/RequestDL/Properties/Sources/Session/Session/Session.swift
@@ -4,6 +4,7 @@
 
 import NIOCore
 import RequestDLInternals
+import Tracing
 
 /// The Session object is used to set various properties related to the request context.
 ///
@@ -189,6 +190,21 @@ public struct Session: Property {
     ///
     public func compression(_ algorithm: CompressionAlgorithm) -> Self {
         edit { $0.compression = .enabled(algorithm.build()) }
+    }
+
+    ///
+    /// Sets the tracer used to record distributed tracing spans for requests made through this
+    /// session.
+    ///
+    /// When not set, the session falls back to AsyncHTTPClient's own default, which is whatever
+    /// tracer was globally bootstrapped via `InstrumentationSystem.bootstrap(_:)` (a no-op tracer
+    /// if none was bootstrapped).
+    ///
+    /// - Parameter tracer: The tracer to use for this session.
+    /// - Returns: The modified `Session` instance with the tracer configured.
+    ///
+    public func tracer(_ tracer: any Tracer) -> Self {
+        edit { $0.tracer = tracer }
     }
 
     // MARK: - Private properties

--- a/Sources/RequestDL/Properties/Sources/Session/Session/Session.swift
+++ b/Sources/RequestDL/Properties/Sources/Session/Session/Session.swift
@@ -196,9 +196,9 @@ public struct Session: Property {
     /// Sets the tracer used to record distributed tracing spans for requests made through this
     /// session.
     ///
-    /// When not set, the session falls back to AsyncHTTPClient's own default, which is whatever
-    /// tracer was globally bootstrapped via `InstrumentationSystem.bootstrap(_:)` (a no-op tracer
-    /// if none was bootstrapped).
+    /// When not set, no tracing is performed — the session uses a no-op tracer, regardless of
+    /// whether some other part of the process has globally bootstrapped one via
+    /// `InstrumentationSystem.bootstrap(_:)`. Tracing is opt-in per session, not ambient.
     ///
     /// - Parameter tracer: The tracer to use for this session.
     /// - Returns: The modified `Session` instance with the tracer configured.

--- a/Sources/RequestDL/Properties/Sources/Tracing/Service Context/RequestServiceContext.swift
+++ b/Sources/RequestDL/Properties/Sources/Tracing/Service Context/RequestServiceContext.swift
@@ -1,0 +1,78 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+import Tracing
+
+/// Binds a `ServiceContext` to a single request, overriding whatever `ServiceContext.current`
+/// task-local happens to be ambient at the point the request executes.
+///
+/// - Warning: As of `async-http-client` 1.36.0, this currently has **no observable effect** on the
+///   request `async-http-client` actually sends or on the span its configured `.tracer(_:)`
+///   records. Confirmed empirically (see `RequestServiceContextTests.
+///   dataTask_whenServiceContextSet_shouldBeObservedByTracerDuringExecution`), not merely
+///   suspected: `async-http-client` starts the request's span only after execution hops onto a
+///   SwiftNIO `EventLoop` via `EventLoop.execute(_:)` (`NIOLoopBound+Execute.swift`,
+///   `RequestBag.willExecuteRequest`), and Swift's task-locals — which is what
+///   `ServiceContext.current` is built on — do not cross that hop. This is a bug in
+///   `async-http-client` itself, not something fixable from RequestDL's side; full root-cause
+///   analysis and a suggested upstream fix are written up in `TRACER_SERVICE_CONTEXT_REPORT.md` at
+///   the repository root.
+///
+///   This type, `RequestConfiguration.serviceContext`, and the bind around request execution in
+///   `RawTask.result()` are kept in place — harmless today, and require no further RequestDL
+///   changes to start working once the upstream bug is fixed.
+///
+/// ```swift
+/// DataTask {
+///     BaseURL("example.com")
+///     Session().tracer(myTracer)
+///     RequestServiceContext(context)
+/// }
+/// ```
+public struct RequestServiceContext: Property {
+
+    private struct Node: PropertyNode {
+
+        let context: ServiceContext
+
+        func make(_ make: inout Make) async throws {
+            make.requestConfiguration.serviceContext = context
+        }
+    }
+
+    // MARK: - Public properties
+
+    /// Returns an exception since `Never` is a type that can never be constructed.
+    public var body: Never {
+        bodyException()
+    }
+
+    // MARK: - Internal properties
+
+    let context: ServiceContext
+
+    // MARK: - Inits
+
+    ///
+    /// Initializes a `RequestServiceContext` instance with the given context.
+    ///
+    /// - Parameter context: The `ServiceContext` to bind while this request executes.
+    ///
+    public init(_ context: ServiceContext) {
+        self.context = context
+    }
+
+    // MARK: - Public static methods
+
+    /// This method is used internally and should not be called directly.
+    public static func _makeProperty(
+        property: _GraphValue<RequestServiceContext>,
+        inputs: _PropertyInputs
+    ) async throws -> _PropertyOutputs {
+        property.assertPathway()
+        return .leaf(
+            Node(context: property.context)
+        )
+    }
+}

--- a/Sources/RequestDL/Properties/Sources/Tracing/Service Context/RequestServiceContext.swift
+++ b/Sources/RequestDL/Properties/Sources/Tracing/Service Context/RequestServiceContext.swift
@@ -7,21 +7,15 @@ import Tracing
 /// Binds a `ServiceContext` to a single request, overriding whatever `ServiceContext.current`
 /// task-local happens to be ambient at the point the request executes.
 ///
-/// - Warning: As of `async-http-client` 1.36.0, this currently has **no observable effect** on the
-///   request `async-http-client` actually sends or on the span its configured `.tracer(_:)`
-///   records. Confirmed empirically (see `RequestServiceContextTests.
-///   dataTask_whenServiceContextSet_shouldBeObservedByTracerDuringExecution`), not merely
-///   suspected: `async-http-client` starts the request's span only after execution hops onto a
-///   SwiftNIO `EventLoop` via `EventLoop.execute(_:)` (`NIOLoopBound+Execute.swift`,
-///   `RequestBag.willExecuteRequest`), and Swift's task-locals — which is what
-///   `ServiceContext.current` is built on — do not cross that hop. This is a bug in
-///   `async-http-client` itself, not something fixable from RequestDL's side; full root-cause
-///   analysis and a suggested upstream fix are written up in `TRACER_SERVICE_CONTEXT_REPORT.md` at
-///   the repository root.
-///
-///   This type, `RequestConfiguration.serviceContext`, and the bind around request execution in
-///   `RawTask.result()` are kept in place — harmless today, and require no further RequestDL
-///   changes to start working once the upstream bug is fixed.
+/// RequestDL owns the whole distributed-tracing span lifecycle itself — starting the span, injecting
+/// W3C trace headers, setting attributes, and ending it, all in `RawTask.result()` — rather than
+/// handing `.tracer(_:)`'s tracer to `async-http-client`'s own `HTTPClient.Configuration.tracing
+/// .tracer`. That built-in instrumentation only starts its span after hopping onto a SwiftNIO
+/// `EventLoop`, which loses Swift's task-locals and makes it structurally unable to see a bound
+/// `ServiceContext` (full root cause in `TRACER_SERVICE_CONTEXT_REPORT.md` at the repository root,
+/// filed as an upstream bug). Doing it here instead, one layer up and entirely within the caller's
+/// own task, means this binding has a real, observable effect: it's what the started span picks up
+/// as its parent.
 ///
 /// ```swift
 /// DataTask {

--- a/Sources/RequestDL/Request/RequestConfiguration.swift
+++ b/Sources/RequestDL/Request/RequestConfiguration.swift
@@ -5,6 +5,7 @@
 import AsyncHTTPClient
 import NIOCore
 import RequestDLInternals
+import Tracing
 
 /// Configuration object used to define the parameters for an HTTP request.
 /// This structure holds details like the base URL, path components, query items,
@@ -57,6 +58,11 @@ public struct RequestConfiguration: Sendable {
     /// The strategy to use for handling cached data. Defaults to `.ignoreCachedData`.
     public internal(set) var cacheStrategy: CacheStrategy
 
+    /// The `ServiceContext` to bind while this request executes. Defaults to `nil`, which leaves
+    /// whatever `ServiceContext.current` task-local is already ambient untouched — only set this
+    /// to explicitly override it for this request, independent of the calling task's own state.
+    public internal(set) var serviceContext: ServiceContext?
+
     // MARK: - Internal properties
 
     /// Only a bodyless GET is cacheable.
@@ -84,6 +90,7 @@ public struct RequestConfiguration: Sendable {
         self.readingMode = .length(1_024)
         self.cachePolicy = []
         self.cacheStrategy = .ignoreCachedData
+        self.serviceContext = nil
     }
 
     // MARK: - Internal methods

--- a/Sources/RequestDL/Tasks/Sources/Raw Task/Raw/RawTask.swift
+++ b/Sources/RequestDL/Tasks/Sources/Raw Task/Raw/RawTask.swift
@@ -3,6 +3,7 @@
 //
 
 import RequestDLInternals
+import Tracing
 
 struct RawTask<Content: Property>: RequestTask {
 
@@ -38,21 +39,34 @@ struct RawTask<Content: Property>: RequestTask {
             logger: logger
         )
 
+        func executeSessionTask() async throws -> SessionTask {
+            switch await cacheControl(client) {
+            case .task(let task):
+                return task
+            case .cache(let cache):
+                return try await resolved.session.execute(
+                    client: client,
+                    request: try resolved.requestConfiguration.build(eventLoop: client.eventLoopGroup.any()),
+                    url: resolved.requestConfiguration.url,
+                    readingMode: resolved.requestConfiguration.readingMode,
+                    uploadingBytes: resolved.requestConfiguration.body?.totalSize ?? .zero,
+                    cache: cache,
+                    logger: logger
+                )
+            }
+        }
+
         let sessionTask: SessionTask
 
-        switch await cacheControl(client) {
-        case .task(let task):
-            sessionTask = task
-        case .cache(let cache):
-            sessionTask = try await resolved.session.execute(
-                client: client,
-                request: try resolved.requestConfiguration.build(eventLoop: client.eventLoopGroup.any()),
-                url: resolved.requestConfiguration.url,
-                readingMode: resolved.requestConfiguration.readingMode,
-                uploadingBytes: resolved.requestConfiguration.body?.totalSize ?? .zero,
-                cache: cache,
-                logger: logger
-            )
+        // Only rebinds the task-local when `RequestServiceContext` was actually declared -- leaving
+        // it untouched otherwise preserves whatever `ServiceContext.current` the caller's own task
+        // already carries, which `async-http-client` picks up on its own.
+        if let serviceContext = resolved.requestConfiguration.serviceContext {
+            sessionTask = try await ServiceContext.$current.withValue(serviceContext) {
+                try await executeSessionTask()
+            }
+        } else {
+            sessionTask = try await executeSessionTask()
         }
 
         return AsyncResponse(

--- a/Sources/RequestDL/Tasks/Sources/Raw Task/Raw/RawTask.swift
+++ b/Sources/RequestDL/Tasks/Sources/Raw Task/Raw/RawTask.swift
@@ -80,7 +80,9 @@ struct RawTask<Content: Property>: RequestTask {
                         { result in
                             switch result {
                             case .success(let head):
-                                span.attributes["http.response.status_code"] = SpanAttribute.int64(Int64(head.status.code))
+                                span.attributes["http.response.status_code"] = SpanAttribute.int64(
+                                    Int64(head.status.code)
+                                )
                                 span.attributes["network.protocol.version"] = SpanAttribute.string(
                                     "\(head.version.major).\(head.version.minor)"
                                 )

--- a/Sources/RequestDL/Tasks/Sources/Raw Task/Raw/RawTask.swift
+++ b/Sources/RequestDL/Tasks/Sources/Raw Task/Raw/RawTask.swift
@@ -2,6 +2,7 @@
 // See LICENSE for this package's licensing information.
 //
 
+import NIOHTTP1
 import RequestDLInternals
 import Tracing
 
@@ -39,39 +40,98 @@ struct RawTask<Content: Property>: RequestTask {
             logger: logger
         )
 
-        func executeSessionTask() async throws -> SessionTask {
+        typealias OnResponseHead = @Sendable (Result<Internals.ResponseHead, Error>) -> Void
+
+        // Owns the whole span lifecycle itself -- start, header injection, attributes, and end --
+        // rather than handing `tracer` to `async-http-client`'s own `tracing.tracer`. That built-in
+        // instrumentation only starts its span after hopping onto a SwiftNIO `EventLoop`, which loses
+        // Swift's task-locals and makes it structurally impossible for it to see whatever
+        // `ServiceContext` the caller bound (see `TRACER_SERVICE_CONTEXT_REPORT.md`). Running the
+        // whole thing here, one layer up and entirely within the caller's own task, sidesteps that.
+        //
+        // A cache hit (the `.task` case below) never reaches the network, so it isn't traced.
+        func executeSessionTask() async throws -> (task: SessionTask, onResponseHead: OnResponseHead?) {
             switch await cacheControl(client) {
             case .task(let task):
-                return task
+                return (task, nil)
             case .cache(let cache):
-                return try await resolved.session.execute(
-                    client: client,
-                    request: try resolved.requestConfiguration.build(eventLoop: client.eventLoopGroup.any()),
-                    url: resolved.requestConfiguration.url,
-                    readingMode: resolved.requestConfiguration.readingMode,
-                    uploadingBytes: resolved.requestConfiguration.body?.totalSize ?? .zero,
-                    cache: cache,
-                    logger: logger
-                )
+                var request = try resolved.requestConfiguration.build(eventLoop: client.eventLoopGroup.any())
+
+                let tracer = resolved.session.configuration.tracer
+                let span = tracer.startSpan(request.method.rawValue, ofKind: .client)
+                span.attributes["http.request.method"] = SpanAttribute.string(request.method.rawValue)
+                span.attributes["url.full"] = SpanAttribute.string(resolved.requestConfiguration.url)
+
+                tracer.inject(span.context, into: &request.headers, using: HTTPHeadersInjector())
+
+                do {
+                    let task = try await resolved.session.execute(
+                        client: client,
+                        request: request,
+                        url: resolved.requestConfiguration.url,
+                        readingMode: resolved.requestConfiguration.readingMode,
+                        uploadingBytes: resolved.requestConfiguration.body?.totalSize ?? .zero,
+                        cache: cache,
+                        logger: logger
+                    )
+
+                    return (
+                        task,
+                        { result in
+                            switch result {
+                            case .success(let head):
+                                span.attributes["http.response.status_code"] = SpanAttribute.int64(Int64(head.status.code))
+                                span.attributes["network.protocol.version"] = SpanAttribute.string(
+                                    "\(head.version.major).\(head.version.minor)"
+                                )
+
+                                if head.status.code >= 400 {
+                                    span.setStatus(.init(code: .error))
+                                }
+                            case .failure(let error):
+                                span.recordError(error)
+                                span.setStatus(.init(code: .error))
+                            }
+
+                            span.end()
+                        }
+                    )
+                } catch {
+                    span.recordError(error)
+                    span.setStatus(.init(code: .error))
+                    span.end()
+                    throw error
+                }
             }
         }
 
         let sessionTask: SessionTask
+        let onResponseHead: OnResponseHead?
 
         // Only rebinds the task-local when `RequestServiceContext` was actually declared -- leaving
         // it untouched otherwise preserves whatever `ServiceContext.current` the caller's own task
-        // already carries, which `async-http-client` picks up on its own.
+        // already carries. The span started above reads this same task-local, so both the explicit
+        // and the ambient case are picked up correctly here -- there's no `EventLoop` hop between the
+        // bind and the read.
         if let serviceContext = resolved.requestConfiguration.serviceContext {
-            sessionTask = try await ServiceContext.$current.withValue(serviceContext) {
+            (sessionTask, onResponseHead) = try await ServiceContext.$current.withValue(serviceContext) {
                 try await executeSessionTask()
             }
         } else {
-            sessionTask = try await executeSessionTask()
+            (sessionTask, onResponseHead) = try await executeSessionTask()
         }
 
         return AsyncResponse(
             seed: sessionTask.seed,
-            response: sessionTask.response
+            response: sessionTask.response,
+            onResponseHead: onResponseHead
         )
+    }
+}
+
+private struct HTTPHeadersInjector: Injector {
+
+    func inject(_ value: String, forKey key: String, into headers: inout NIOHTTP1.HTTPHeaders) {
+        headers.add(name: key, value: value)
     }
 }

--- a/Sources/RequestDL/Tasks/Sources/Raw Task/Upload/Models/AsyncResponse.swift
+++ b/Sources/RequestDL/Tasks/Sources/Raw Task/Upload/Models/AsyncResponse.swift
@@ -14,6 +14,7 @@ public struct AsyncResponse: Sendable, AsyncSequence {
 
         fileprivate let seed: Internals.TaskSeed
         fileprivate var iterator: Internals.AsyncResponse.Iterator
+        fileprivate let onResponseHead: (@Sendable (Result<Internals.ResponseHead, Error>) -> Void)?
 
         ///
         /// Returns the next element in the sequence, or nil if there are no more elements.
@@ -21,26 +22,37 @@ public struct AsyncResponse: Sendable, AsyncSequence {
         /// - Returns: The next element in the sequence.
         ///
         mutating public func next() async throws -> Element? {
-            switch try await iterator.next() {
-            case .upload(let step):
-                return .upload(
-                    UploadStep(
-                        chunkSize: step.chunkSize,
-                        totalSize: step.totalSize
-                    )
-                )
-            case .download(let step):
-                return .download(
-                    DownloadStep(
-                        head: .init(step.head),
-                        bytes: AsyncBytes(
-                            seed: seed,
-                            bytes: step.bytes
+            do {
+                switch try await iterator.next() {
+                case .upload(let step):
+                    return .upload(
+                        UploadStep(
+                            chunkSize: step.chunkSize,
+                            totalSize: step.totalSize
                         )
                     )
-                )
-            case .none:
-                return nil
+                case .download(let step):
+                    // Fires at most once: the underlying iterator only ever produces a single
+                    // `.download` case, after which it's exhausted (see
+                    // `Internals.AsyncResponse.Iterator.next()`), so there's no later call this
+                    // could re-fire from.
+                    onResponseHead?(.success(step.head))
+
+                    return .download(
+                        DownloadStep(
+                            head: .init(step.head),
+                            bytes: AsyncBytes(
+                                seed: seed,
+                                bytes: step.bytes
+                            )
+                        )
+                    )
+                case .none:
+                    return nil
+                }
+            } catch {
+                onResponseHead?(.failure(error))
+                throw error
             }
         }
     }
@@ -57,15 +69,18 @@ public struct AsyncResponse: Sendable, AsyncSequence {
 
     private let seed: Internals.TaskSeed
     private let response: Internals.AsyncResponse
+    private let onResponseHead: (@Sendable (Result<Internals.ResponseHead, Error>) -> Void)?
 
     // MARK: - Inits
 
     init(
         seed: Internals.TaskSeed,
-        response: Internals.AsyncResponse
+        response: Internals.AsyncResponse,
+        onResponseHead: (@Sendable (Result<Internals.ResponseHead, Error>) -> Void)? = nil
     ) {
         self.seed = seed
         self.response = response
+        self.onResponseHead = onResponseHead
     }
 
     // MARK: - Public methods
@@ -78,7 +93,8 @@ public struct AsyncResponse: Sendable, AsyncSequence {
     public func makeAsyncIterator() -> Iterator {
         Iterator(
             seed: seed,
-            iterator: response.makeAsyncIterator()
+            iterator: response.makeAsyncIterator(),
+            onResponseHead: onResponseHead
         )
     }
 }

--- a/Sources/RequestDLInternals/Sources/Session/Session Configuration/Internals.Session.Configuration.swift
+++ b/Sources/RequestDLInternals/Sources/Session/Session Configuration/Internals.Session.Configuration.swift
@@ -21,10 +21,19 @@ extension Internals.Session {
         package var proxy: Internals.Proxy?
         package var ignoreUncleanSSLShutdown: Bool = false
 
-        /// Defaults to a no-op tracer rather than inheriting `HTTPClient.Configuration`'s own default
-        /// (whatever tracer some other part of the process happens to have globally bootstrapped via
-        /// `InstrumentationSystem`). RequestDL's API is declarative — a caller that never calls
-        /// `.tracer(_:)` shouldn't have their requests silently traced by ambient global state.
+        /// The tracer RequestDL itself uses to instrument requests -- started, ended, and populated
+        /// with attributes by `RawTask.result()`, not handed to `async-http-client`.
+        /// `async-http-client`'s own built-in tracing (`HTTPClient.Configuration.tracing.tracer`) is
+        /// unconditionally suppressed in `build()` below: its span-start reads `ServiceContext
+        /// .current` only after hopping onto a SwiftNIO `EventLoop`, which loses Swift's task-locals
+        /// and makes it impossible to parent the span correctly (see `TRACER_SERVICE_CONTEXT_REPORT
+        /// .md` at the repository root) -- RequestDL owns the whole span lifecycle itself instead, one
+        /// layer up, entirely within the caller's own task.
+        ///
+        /// Defaults to a no-op tracer rather than inheriting ambient global state: RequestDL's API is
+        /// declarative, so a caller that never calls `.tracer(_:)` shouldn't have their requests
+        /// silently traced just because some other part of the process bootstrapped a tracer via
+        /// `InstrumentationSystem` for unrelated reasons.
         ///
         /// Excluded from `Equatable` — `any Tracer` isn't `Equatable`, same reasoning as
         /// `Internals.Proxy.connectHeaders` being excluded from `Hashable`.
@@ -76,7 +85,9 @@ extension Internals.Session {
                 configuration.httpVersion = httpVersion.build()
             }
 
-            configuration.tracing.tracer = tracer
+            // Always suppressed here, regardless of `tracer` above -- see the doc comment on that
+            // property for why `async-http-client`'s own built-in tracing is never engaged.
+            configuration.tracing.tracer = NoOpTracer()
 
             if case .enabled(let algorithm) = compression {
                 let encoding = algorithm.build()

--- a/Sources/RequestDLInternals/Sources/Session/Session Configuration/Internals.Session.Configuration.swift
+++ b/Sources/RequestDLInternals/Sources/Session/Session Configuration/Internals.Session.Configuration.swift
@@ -21,9 +21,14 @@ extension Internals.Session {
         package var proxy: Internals.Proxy?
         package var ignoreUncleanSSLShutdown: Bool = false
 
+        /// Defaults to a no-op tracer rather than inheriting `HTTPClient.Configuration`'s own default
+        /// (whatever tracer some other part of the process happens to have globally bootstrapped via
+        /// `InstrumentationSystem`). RequestDL's API is declarative — a caller that never calls
+        /// `.tracer(_:)` shouldn't have their requests silently traced by ambient global state.
+        ///
         /// Excluded from `Equatable` — `any Tracer` isn't `Equatable`, same reasoning as
         /// `Internals.Proxy.connectHeaders` being excluded from `Hashable`.
-        package var tracer: (any Tracer)?
+        package var tracer: any Tracer = NoOpTracer()
 
         /// Defaults to unbounded auto-decompression on Apple platforms, matching URLSession's own
         /// behavior there — URLSession always decodes `Content-Encoding` transparently with no
@@ -71,9 +76,7 @@ extension Internals.Session {
                 configuration.httpVersion = httpVersion.build()
             }
 
-            if let tracer {
-                configuration.tracing.tracer = tracer
-            }
+            configuration.tracing.tracer = tracer
 
             if case .enabled(let algorithm) = compression {
                 let encoding = algorithm.build()

--- a/Sources/RequestDLInternals/Sources/Session/Session Configuration/Internals.Session.Configuration.swift
+++ b/Sources/RequestDLInternals/Sources/Session/Session Configuration/Internals.Session.Configuration.swift
@@ -6,10 +6,11 @@ import AsyncHTTPClient
 import NIOCore
 import NIOHTTP1
 import NIOHTTPCompression
+import Tracing
 
 extension Internals.Session {
 
-    package struct Configuration: Sendable, Equatable {
+    package struct Configuration: Sendable {
 
         // MARK: - Internal properties
 
@@ -19,6 +20,10 @@ extension Internals.Session {
         package var connectionPool: HTTPClient.Configuration.ConnectionPool = .init()
         package var proxy: Internals.Proxy?
         package var ignoreUncleanSSLShutdown: Bool = false
+
+        /// Excluded from `Equatable` — `any Tracer` isn't `Equatable`, same reasoning as
+        /// `Internals.Proxy.connectHeaders` being excluded from `Hashable`.
+        package var tracer: (any Tracer)?
 
         /// Defaults to unbounded auto-decompression on Apple platforms, matching URLSession's own
         /// behavior there — URLSession always decodes `Content-Encoding` transparently with no
@@ -66,6 +71,10 @@ extension Internals.Session {
                 configuration.httpVersion = httpVersion.build()
             }
 
+            if let tracer {
+                configuration.tracing.tracer = tracer
+            }
+
             if case .enabled(let algorithm) = compression {
                 let encoding = algorithm.build()
 
@@ -99,5 +108,26 @@ extension Internals.Session.Configuration {
         }
 
         return false
+    }
+}
+
+// MARK: - Equatable
+
+extension Internals.Session.Configuration: Equatable {
+
+    package static func == (_ lhs: Self, _ rhs: Self) -> Bool {
+        lhs.secureConnection == rhs.secureConnection
+            && lhs.redirectConfiguration == rhs.redirectConfiguration
+            && lhs.timeout == rhs.timeout
+            && lhs.connectionPool == rhs.connectionPool
+            && lhs.proxy == rhs.proxy
+            && lhs.ignoreUncleanSSLShutdown == rhs.ignoreUncleanSSLShutdown
+            && lhs.decompression == rhs.decompression
+            && lhs.compression == rhs.compression
+            && lhs.dnsOverride == rhs.dnsOverride
+            && lhs.networkFrameworkWaitForConnectivity == rhs.networkFrameworkWaitForConnectivity
+            && lhs.httpVersion == rhs.httpVersion
+            && lhs.enableNetworkFramework == rhs.enableNetworkFramework
+            && lhs.maximumConcurrentConnections == rhs.maximumConcurrentConnections
     }
 }

--- a/TRACER_SERVICE_CONTEXT_REPORT.md
+++ b/TRACER_SERVICE_CONTEXT_REPORT.md
@@ -281,3 +281,66 @@ This report exists so the fix can be pursued upstream; RequestDL's side is left 
 already correctly documented as currently ineffective) so it starts working with no further RequestDL
 changes once gap #1 is fixed there, and so `RequestServiceContext` is ready to also inject headers
 once/if RequestDL migrates its execution path to close gap #2 as well.
+
+## Appendix: `TracingConfiguration.attributeKeys` — why making it public is not a viable ask
+
+Separate from the `ServiceContext` propagation bug above, the original RequestDL discussion
+(https://github.com/orgs/request-dl/discussions/284) also listed `TracingConfiguration.attributeKeys`
+customization as out of scope, since it's `package`-visibility in `async-http-client` with a
+`// TODO: Open up customization of keys we use?` comment. Before pursuing a PR to make it `public`,
+checked the project's actual issue/PR history for how the maintainers have handled this exact class of
+request. **They have already, explicitly and recently, rejected it.**
+
+### The maintainers have a stated anti-configuration-knob philosophy for tracing attributes
+
+[PR #906](https://github.com/swift-server/async-http-client/pull/906) ("Set `url.full` attribute on
+spans logged for HTTP requests", merged 2026-07-27) originally included an opt-in/opt-out
+configuration option for the new attribute. The response:
+
+> **czechboy0** (2026-06-05): "I think `url.full` should be enabled by default, following
+> OpenTelemetry standard attributes [...] Almost any string field can, in theory, have PII, and I
+> think this is the wrong place to try to make that call. Let application owners filter PII in their
+> telemetry backends instead."
+
+> **ktoso**, author of `swift-distributed-tracing` (2026-06-08): "Agree on not doing tens of settings
+> in the lib itself, collectors can handle that 👍"
+
+The contributor removed the configuration option from the PR in direct response
+(2026-06-05 comment: "Updated the PR to remove the configuration options.") before it was merged.
+This is a stated design position, not an oversight: attribute-level customization belongs in the
+telemetry collector/backend, not as knobs on `HTTPClient.Configuration`. Making `AttributeKeys`
+`public` (with setters) is exactly the shape of change this rejects.
+
+### A PR attempting this exact change has been stuck for 7+ months
+
+[PR #881](https://github.com/swift-server/async-http-client/pull/881) ("Add more span attributes
+(URL, network)", opened 2026-01-21, still open, `mergeable: CONFLICTING`) implements several of the
+attributes requested in [issue #860](https://github.com/swift-server/async-http-client/issues/860)
+("[Tracing] Add more span attributes", `good first issue`, opened by ktoso), including changing
+`responseStatusCode`'s default from the legacy `http.status_code` to the current
+`http.response.status_code` — the exact semconv drift this report's author independently noticed by
+reading `HTTPClient.swift:1149-1155` before finding this issue. A maintainer with write access
+blocked it:
+
+> **fabianfett** (MEMBER, 2026-02-20): "I'm fine with adding the additional tracing attributes.
+> However I'm not a fan of changing the previously agreed upon approach to tracing."
+
+No further commits since 2026-03-23; the PR has sat unresolved since. So even a change that doesn't
+add new public API — just correcting a stale default value — has not landed cleanly, for reasons tied
+to some "previously agreed upon approach" not stated in the thread.
+
+### What this means for `attributeKeys`
+
+- **Making `AttributeKeys`/`attributeKeys` `public` and settable is very likely dead on arrival.** It
+  is precisely the "tens of settings in the lib itself" pattern maintainers rejected in #906, days to
+  weeks before this was written. Do not lead with this ask.
+- **The one narrower thing that's arguably still aligned with what maintainers want**: issue #860
+  itself, filed by ktoso, explicitly asks for more/corrected span attributes — including the
+  `http.status_code` → `http.response.status_code` rename — as *default value* fixes, not new
+  configuration surface. That is a much smaller, values-only change with no new public API. It is
+  still not guaranteed smooth (see PR #881's stall over "previously agreed upon approach"), so it is
+  worth scoping as tightly as possible — ideally just the one rename, referencing #860 directly,
+  rather than bundling in the other attributes #881 tried to add at once.
+- Versions referenced above: `swift-server/async-http-client` main branch and PR/issue state as of
+  2026-08-25; the package RequestDL depends on is `1.36.0` (tagged 2026-07-23), which already
+  includes #862 (async-API header injection) but predates #906.

--- a/TRACER_SERVICE_CONTEXT_REPORT.md
+++ b/TRACER_SERVICE_CONTEXT_REPORT.md
@@ -1,0 +1,283 @@
+# `ServiceContext` propagation is lost before span start in `async-http-client`
+
+Status: drafted from RequestDL, not yet filed upstream.
+Target repo: `swift-server/async-http-client`.
+Discovered while implementing request-scoped `ServiceContext` binding for RequestDL
+(https://github.com/orgs/request-dl/discussions/284), see [Origin in RequestDL](#origin-in-requestdl) below.
+
+## Versions
+
+| Package | Version resolved |
+|---|---|
+| `swift-server/async-http-client` | 1.36.0 (commit `9544287b9416c0bc71e58b9f3aead8dd14b16103`) |
+| `apple/swift-distributed-tracing` | 1.4.1 |
+| `apple/swift-nio` | 2.101.3 |
+| Swift tools | 6.2 |
+
+## Summary
+
+`HTTPClient.Configuration.tracing.tracer` lets a caller configure a `Tracer` (from
+`swift-distributed-tracing`) for the client. The intended behavior — per the doc comment on
+`Tracer/startSpan` and the whole design of `ServiceContext` — is that the span each request starts
+picks up `ServiceContext.current` (a Swift `@TaskLocal`) as its parent, so a caller can bind a
+specific context around a request (e.g. one extracted from an inbound server request) and have
+AsyncHTTPClient's own span nest correctly under it.
+
+**This does not happen.** `ServiceContext.current`, bound via
+`ServiceContext.$current.withValue(context) { try await client.execute(...) }` around the call, is
+reliably `nil` (or whatever was ambient *before* the bind) by the time AsyncHTTPClient actually
+calls `tracer.startSpan(...)`. Empirically confirmed with a real client/server round trip — see
+[Reproduction](#reproduction).
+
+Root cause: **the span is started only after execution hops onto a `SwiftNIO` `EventLoop` via
+`EventLoop.execute(_:)`, and Swift's task-locals do not cross that hop.** Task-locals propagate
+through the Swift Concurrency task hierarchy (`Task`, structured-concurrency child tasks,
+`withTaskGroup`, `withCheckedContinuation`, plain `async`/`await` calls within the same task) —
+never through arbitrary closures scheduled on a `NIOCore.EventLoop`, which is exactly how
+AsyncHTTPClient dispatches request execution onto its connection pool.
+
+## Root cause, traced through the call chain
+
+All line numbers are against async-http-client `1.36.0`.
+
+1. **`HTTPClient.execute(request:delegate:...)`** synchronously constructs a `RequestBag` and hands
+   it to the pool manager (`HTTPClient.swift:806-822`):
+   ```swift
+   let requestBag = try RequestBag(request: request, ..., delegate: delegate)
+   ...
+   self.poolManager.executeRequest(requestBag)
+   ```
+   This part runs on the caller's own execution context — if called from inside
+   `ServiceContext.$current.withValue(context) { ... }`, `ServiceContext.current` is correctly
+   `context` up to this point. (The same is true for the newer async `HTTPClientRequest` API: it
+   also reaches this point synchronously within the calling task.)
+
+2. **`HTTPConnectionPool.Manager.executeRequest`** (`HTTPConnectionPool+Manager.swift:54-83`) looks
+   up or creates the pool for the request's key, still synchronously, and calls
+   `pool.executeRequest(request)`.
+
+3. **`HTTPConnectionPool.executeRequest`** (`HTTPConnectionPool.swift:87-89`):
+   ```swift
+   func executeRequest(_ request: HTTPSchedulableRequest) {
+       self.modifyStateAndRunActions { $0.executeRequest(.init(request)) }
+   }
+   ```
+   still synchronous, ultimately reaching the per-connection dispatch at
+   `HTTPConnectionPool.swift:694-701`:
+   ```swift
+   fileprivate func executeRequest(_ request: HTTPExecutableRequest) {
+       switch self._ref {
+       case .http1_1(let connection):
+           return connection.executeRequest(request)
+       ...
+   ```
+
+4. **`HTTP1Connection.Async.executeRequest`** (`ConnectionPool/HTTP1/HTTP1Connection.swift:86-89`) —
+   this is where propagation breaks:
+   ```swift
+   func executeRequest(_ request: HTTPExecutableRequest) {
+       self.connection.execute {
+           $0.execute0(request: request)
+       }
+   }
+   ```
+   `self.connection` is a `NIOLoopBound<HTTP1Connection>`. `.execute(_:)` on it is defined in
+   `NIOLoopBound+Execute.swift:17-28`:
+   ```swift
+   extension NIOLoopBound {
+       @inlinable
+       func execute(_ body: @Sendable @escaping (Value) -> Void) {
+           if self.eventLoop.inEventLoop {
+               body(self.value)
+           } else {
+               self.eventLoop.execute {
+                   body(self.value)
+               }
+           }
+       }
+   }
+   ```
+   Unless the calling thread already happens to be the connection's own `EventLoop` thread — which
+   it essentially never is for a request kicked off from Swift Concurrency, since `async`/`await`
+   code resumes on the cooperative thread pool, not on one of AsyncHTTPClient's dedicated
+   `EventLoop` threads — this dispatches `body` via `self.eventLoop.execute { ... }`. That is a
+   plain `@Sendable () -> Void` closure scheduled on a `NIOCore.EventLoop`, with zero relationship
+   to the Swift Concurrency task-local stack.
+
+5. Once on the connection's event loop, `execute0` eventually calls back into
+   `RequestBag.willExecuteRequest(_:)` (`RequestBag.swift:511-519`), which has **the exact same
+   pattern again**:
+   ```swift
+   func willExecuteRequest(_ executor: HTTPRequestExecutor) {
+       if self.task.eventLoop.inEventLoop {
+           self.willExecuteRequest0(executor)
+       } else {
+           self.task.eventLoop.execute {
+               self.willExecuteRequest0(executor)
+           }
+       }
+   }
+   ```
+   `self.task.eventLoop` may not even be the same loop as the connection's — a second possible hop.
+
+6. **`willExecuteRequest0`** (`RequestBag.swift:137-139`) is where the span actually starts:
+   ```swift
+   private func willExecuteRequest0(_ executor: HTTPRequestExecutor) {
+       ...
+       self.loopBoundState.value.startRequestSpan(tracer: self.anyTracer)
+   }
+   ```
+   which calls into `RequestBag+Tracing.swift:24-35`:
+   ```swift
+   mutating func startRequestSpan(tracer: (any Sendable)?) {
+       guard #available(...), let tracer = tracer as! (any Tracer)? else { return }
+       ...
+       self.activeSpan = tracer.startSpan("\(request.method)", ofKind: .client)
+   }
+   ```
+   No explicit `context:` argument is passed, so this resolves to `Tracer`'s default parameter
+   (`swift-distributed-tracing`, `Sources/Tracing/Tracer.swift:46`):
+   ```swift
+   context: @autoclosure () -> ServiceContext = .current ?? .topLevel,
+   ```
+   By this point, execution has crossed one or two `EventLoop.execute` hops away from the original
+   task. `ServiceContext.current` reads whatever is task-local *on the thread this closure happens
+   to run on* — which has no relationship to the Swift task that called `execute(request:...)`, so
+   it is `nil` (falling back to `.topLevel`) regardless of what the caller bound.
+
+## Contrast: the newer async API *does* inject correctly, but only because it runs earlier
+
+`HTTPClientRequest.Prepared.init` (`AsyncAwait/HTTPClientRequest+Prepared.swift:71-75`) does read
+`ServiceContext.current` correctly:
+```swift
+if let tracer = tracing?.tracer, let context = ServiceContext.current {
+    tracer.inject(context, into: &headers, using: HTTPHeadersInjector.shared)
+}
+```
+This works only because it runs **before** the request ever reaches the connection pool — it's part
+of preparing the `HTTPClientRequest` into `Prepared` form, synchronously within the caller's own
+task, at the `execute()` call site. It has nothing to do with `RequestBag`/`willExecuteRequest0`, and
+does not fix the span-parenting issue in [Root cause](#root-cause-traced-through-the-call-chain):
+that code path still starts the span later, after the same `EventLoop` hops, so **even a caller
+using the modern async API gets correctly-injected trace headers on the wire, but an incorrectly
+un-parented span locally** (it'll show up in the exporting backend as a new trace root, not nested
+under the caller's context, unless the tracer's own `inject`/wire format is what a downstream
+service uses to reconstruct the relationship rather than the local parent-span link).
+
+## Two distinct gaps
+
+1. **Bug — span-start loses the task-local `ServiceContext.current`.** Affects *every* consumer of
+   `HTTPClient.Configuration.tracing.tracer`, both the delegate-based `execute(request:delegate:)`
+   API and the modern `execute() async` API. This is the one demonstrated by the reproduction below.
+
+2. **Gap — the delegate-based `execute(request:delegate:)` API never injects trace headers at all.**
+   `tracer.inject(context:into:using:)` is called exactly once in the whole package, inside
+   `HTTPClientRequest.Prepared.init` (`AsyncAwait/HTTPClientRequest+Prepared.swift:74`), which only
+   the modern async API path constructs. A caller using the older delegate-based `execute` (as
+   RequestDL currently does — see below) gets no `traceparent`/`tracestate` header injected into
+   the outgoing request under any circumstances, independent of gap #1.
+
+## Reproduction
+
+Minimal repro shape (Swift Testing), using a real local HTTP server:
+
+```swift
+final class ContextCapturingTracer: Tracer, Sendable {
+    private let box = NIOLockedValueBox<String?>(nil)
+    var capturedTestID: String? { box.withLockedValue { $0 } }
+
+    func startSpan<Instant: TracerInstant>(
+        _ operationName: String,
+        context: @autoclosure () -> ServiceContext,
+        ofKind kind: SpanKind,
+        at instant: @autoclosure () -> Instant,
+        function: String, file fileID: String, line: UInt
+    ) -> NoOpTracer.NoOpSpan {
+        let resolved = context()
+        box.withLockedValue { $0 = resolved.testID }   // custom ServiceContextKey
+        return NoOpTracer.NoOpSpan(context: resolved)
+    }
+
+    func forceFlush() {}
+    func inject<C, I: Injector>(_ context: ServiceContext, into carrier: inout C, using injector: I) where I.Carrier == C {}
+    func extract<C, E: Extractor>(_ carrier: C, into context: inout ServiceContext, using extractor: E) where E.Carrier == C {}
+}
+
+var configuration = HTTPClient.Configuration()
+configuration.tracing.tracer = ContextCapturingTracer()
+let client = HTTPClient(eventLoopGroupProvider: .singleton, configuration: configuration)
+
+var context = ServiceContext.topLevel
+context.testID = "trace-abc"
+
+try await ServiceContext.$current.withValue(context) {
+    _ = try await client.execute(
+        request: try HTTPClient.Request(url: "http://127.0.0.1:PORT/"),
+        delegate: ResponseAccumulator(request: ...)
+    ).futureResult.get()
+}
+
+// FAILS: tracer.capturedTestID is nil, not "trace-abc"
+#expect(tracer.capturedTestID == context.testID)
+```
+
+RequestDL's actual reproduction, exercised against `.build/checkouts` at the versions above, is at
+[`Tests/RequestDLTests/Properties/Sources/Tracing/Service Context/RequestServiceContextTests.swift`](Tests/RequestDLTests/Properties/Sources/Tracing/Service%20Context/RequestServiceContextTests.swift),
+test `dataTask_whenServiceContextSet_shouldBeObservedByTracerDuringExecution`. It does a warm-up
+request first specifically to rule out "cold connection, so of course it needs to queue and hop
+threads" as an alternative, simpler explanation — the failure is deterministic even against an
+already-idle, previously-used connection, which matches the root cause above (the hop happens
+unconditionally in `NIOLoopBound.execute`, gated only on which thread happens to be running the
+calling code at that instant — not on whether the connection was already established).
+
+## Suggested fix direction (not implemented, for upstream discussion)
+
+The general shape: capture `ServiceContext.current` at each of the two `EventLoop.execute` hops
+identified above (`NIOLoopBound+Execute.swift:19-27` and `RequestBag.swift:511-519`) and rebind it
+inside the dispatched closure, e.g.:
+
+```swift
+func execute(_ body: @Sendable @escaping (Value) -> Void) {
+    let context = ServiceContext.current
+    if self.eventLoop.inEventLoop {
+        body(self.value)
+    } else {
+        self.eventLoop.execute {
+            ServiceContext.$current.withValue(context) {
+                body(self.value)
+            }
+        }
+    }
+}
+```
+This is package-wide plumbing (`NIOLoopBound+Execute.swift` is a general-purpose helper used well
+beyond the tracing path), so capturing/rebinding `ServiceContext.current` there has to be weighed
+against the cost of doing so on every hop, tracing enabled or not — an alternative is threading the
+captured context explicitly through `RequestBag` itself (capture it once in `RequestBag.init`,
+where the caller's task-local is still reliably visible, and pass it explicitly into
+`startRequestSpan(tracer:context:)` instead of relying on `Tracer`'s implicit default). That version
+touches less shared code and only pays a `ServiceContext.current` read once per request instead of
+once per hop.
+
+## Origin in RequestDL
+
+RequestDL added `Session().tracer(_:)` (binds a `Tracer`) and attempted to add
+`RequestServiceContext(_:)` (a per-request `Property` meant to bind `ServiceContext.current` around
+that one request's execution, for callers whose code isn't already running in the task where the
+right context is ambient — e.g. a background queue or a job picked up from another subsystem). The
+binding itself
+([`Sources/RequestDL/Tasks/Sources/Raw Task/Raw/RawTask.swift`](Sources/RequestDL/Tasks/Sources/Raw%20Task/Raw/RawTask.swift))
+and the property
+([`Sources/RequestDL/Properties/Sources/Tracing/Service Context/RequestServiceContext.swift`](Sources/RequestDL/Properties/Sources/Tracing/Service%20Context/RequestServiceContext.swift))
+are implemented and unit-tested for what RequestDL itself controls (the `RequestConfiguration`
+plumbing, the task-local bind around `RawTask.result()`), but as documented on
+`RequestServiceContext` itself, they currently have **no observable effect** on AsyncHTTPClient's
+own span or on the outgoing request's headers, for the reasons in this report — both gaps live
+entirely inside `async-http-client`, not in anything RequestDL controls. RequestDL is also affected
+by gap #2 specifically because it currently executes requests through the legacy delegate-based
+`execute(request:delegate:)` API rather than the modern `HTTPClientRequest` async API.
+
+This report exists so the fix can be pursued upstream; RequestDL's side is left in place (harmless,
+already correctly documented as currently ineffective) so it starts working with no further RequestDL
+changes once gap #1 is fixed there, and so `RequestServiceContext` is ready to also inject headers
+once/if RequestDL migrates its execution path to close gap #2 as well.

--- a/TRACER_SERVICE_CONTEXT_REPORT.md
+++ b/TRACER_SERVICE_CONTEXT_REPORT.md
@@ -5,6 +5,73 @@ Target repo: `swift-server/async-http-client`.
 Discovered while implementing request-scoped `ServiceContext` binding for RequestDL
 (https://github.com/orgs/request-dl/discussions/284), see [Origin in RequestDL](#origin-in-requestdl) below.
 
+## Implementation plan
+
+For whoever picks this up next, on the dedicated fork branch. Ordered by priority — do items in
+order, each is a separate issue/PR against `swift-server/async-http-client`, don't bundle them (see
+why in item 3's notes).
+
+1. **Fix `ServiceContext.current` loss before span start (Gap #1 — the actual bug).**
+   Highest priority: it's a genuine correctness bug, not a design-philosophy conflict, and it affects
+   *every* consumer of `HTTPClient.Configuration.tracing.tracer`, both API surfaces. Full trace in
+   [Root cause](#root-cause-traced-through-the-call-chain).
+   - Preferred approach: capture `ServiceContext.current` once in `RequestBag.init`
+     (`RequestBag.swift`) — the caller's task-local is still reliably visible there, before any
+     `EventLoop.execute` hop happens — and thread it explicitly into
+     `startRequestSpan(tracer:context:)` (`RequestBag+Tracing.swift`) instead of relying on
+     `Tracer.startSpan`'s implicit `ServiceContext.current` default. This touches only the tracing
+     path, not `NIOLoopBound+Execute.swift` (general-purpose plumbing used well beyond tracing, so
+     patching it has a much wider review surface and blast radius — avoid that route unless this one
+     turns out not to work).
+   - File as an issue first with the reproduction from [Reproduction](#reproduction), let a
+     maintainer confirm the diagnosis before investing in the PR — this is a subtle enough
+     cross-cutting-concerns bug that it's worth a maintainer sanity-check on the fix location before
+     writing it.
+   - Once fixed upstream and released, RequestDL needs no changes at all —
+     `RequestServiceContext`/`RawTask.result()`'s bind already does the right thing on RequestDL's
+     side; only remove the `withKnownIssue` wrap on
+     `RequestServiceContextTests.dataTask_whenServiceContextSet_shouldBeObservedByTracerDuringExecution`
+     and update `RequestServiceContext`'s doc comment to drop the warning.
+
+2. **Decide the strategy for Gap #2 (no header injection on the legacy delegate API) — likely a
+   RequestDL-side call, not an async-http-client PR.**
+   Two options, pick one:
+   - (a) Ask upstream to backport `tracer.inject(...)` into the delegate-based
+     `execute(request:delegate:)` path. Lower odds of a quick yes than item 1: maintainers may
+     reasonably respond "that API predates tracing support and is being superseded by
+     `HTTPClientRequest`, migrate instead" — the delegate-based `execute` overloads aren't deprecated
+     but the newer async API is clearly where feature investment goes (see #862, #906 — both only
+     touch `AsyncAwait/`).
+   - (b) Migrate RequestDL's own request execution (`Internals.Client.execute`,
+     `Sources/RequestDLInternals/Sources/Client/Client/Internals.Client.swift`) from the delegate-based
+     API onto `HTTPClientRequest`/`execute() async`. This is the RequestDL-side option — no upstream
+     dependency, gets header injection "for free" once done, but is a real migration (delegate
+     callbacks → async streaming), not a small change. Worth checking whether this overlaps with
+     the already-tracked `feature/urlsession-executor` branch's scope before starting it as separate
+     work.
+   - Recommendation: don't file anything upstream for this until (a) vs (b) is decided — filing (a)
+     and then doing (b) anyway wastes a maintainer's review time on a PR RequestDL wouldn't end up
+     needing.
+
+3. **Only after 1 (and optionally 2) land: the narrow `attributeKeys` value fix, scoped tightly.**
+   Just the `responseStatusCode` default: `http.status_code` → `http.response.status_code`
+   (`HTTPClient.swift:1153`), referencing
+   [issue #860](https://github.com/swift-server/async-http-client/issues/860) directly. No new public
+   API, no configuration surface — see
+   [why that distinction matters](#appendix-tracingconfigurationattributekeys--why-making-it-public-is-not-a-viable-ask).
+   **Do not bundle in the other attributes from PR #881** (`url.path`, `server.hostname`,
+   `network.protocol.version`, etc.) **and especially not `http.request.header`/`http.response.header`**
+   — the header-attribute additions are the most plausible source of PR #881's "previously agreed
+   upon approach" objection from `fabianfett` (verbose, PII-adjacent, a bigger design call than a
+   rename), and bundling a safe rename together with a contentious addition risks blocking the safe
+   part too. If maintainers want the other attributes added incrementally after this lands, that's a
+   separate PR per attribute (or a small batch of the clearly uncontroversial structural ones —
+   `url.path`, `url.scheme`, `server.hostname`, `server.port`, `network.protocol.version` — kept
+   separate from the header-content ones either way).
+
+4. **Do not pursue: making `AttributeKeys`/`attributeKeys` `public` or otherwise customizable.**
+   Confirmed dead-on-arrival — see the appendix. Skip straight to item 3's values-only fix instead.
+
 ## Versions
 
 | Package | Version resolved |

--- a/Tests/RequestDLInternalsTests/Sources/Session/Session Configuration/InternalsSessionConfigurationTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Session/Session Configuration/InternalsSessionConfigurationTests.swift
@@ -246,7 +246,7 @@ struct InternalsSessionConfigurationTests {
     }
 
     @Test
-    func configuration_whenSetTracer_shouldBeEqual() async throws {
+    func configuration_whenSetTracer_shouldBeStoredForRequestDLsOwnUse() async throws {
         // Given
         var configuration = Internals.Session.Configuration()
         let tracer = RecordingTracer()
@@ -254,10 +254,22 @@ struct InternalsSessionConfigurationTests {
         // When
         configuration.tracer = tracer
 
+        // Then
+        #expect((configuration.tracer as? RecordingTracer) != nil)
+    }
+
+    @Test
+    func configuration_whenSetTracer_shouldNotReachAsyncHTTPClientsOwnTracing() async throws {
+        // Given
+        var configuration = Internals.Session.Configuration()
+        configuration.tracer = RecordingTracer()
+
+        // When
         let builtConfiguration = try configuration.build()
 
-        // Then
-        #expect((builtConfiguration.tracing.tracer as? RecordingTracer) != nil)
+        // Then -- `async-http-client`'s own tracing is always suppressed; RequestDL owns the span
+        // lifecycle itself (see the doc comment on `Configuration.tracer`).
+        #expect((builtConfiguration.tracing.tracer as? NoOpTracer) != nil)
     }
 
     @Test
@@ -265,11 +277,9 @@ struct InternalsSessionConfigurationTests {
         // Given
         let configuration = Internals.Session.Configuration()
 
-        // When
-        let builtConfiguration = try configuration.build()
-
         // Then
-        #expect((builtConfiguration.tracing.tracer as? NoOpTracer) != nil)
+        #expect((configuration.tracer as? NoOpTracer) != nil)
+        #expect((try configuration.build().tracing.tracer as? NoOpTracer) != nil)
     }
 
     @Test

--- a/Tests/RequestDLInternalsTests/Sources/Session/Session Configuration/InternalsSessionConfigurationTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Session/Session Configuration/InternalsSessionConfigurationTests.swift
@@ -5,6 +5,7 @@
 import AsyncHTTPClient
 import NIOCore
 import Testing
+import Tracing
 
 @testable import RequestDLInternals
 @testable import RequestDLTestSupport
@@ -242,6 +243,33 @@ struct InternalsSessionConfigurationTests {
 
         // Then
         #expect(!builtConfiguration.networkFrameworkWaitForConnectivity)
+    }
+
+    @Test
+    func configuration_whenSetTracer_shouldBeEqual() async throws {
+        // Given
+        var configuration = Internals.Session.Configuration()
+        let tracer = NoOpTracer()
+
+        // When
+        configuration.tracer = tracer
+
+        let builtConfiguration = try configuration.build()
+
+        // Then
+        #expect(builtConfiguration.tracing.tracer != nil)
+    }
+
+    @Test
+    func configuration_whenTracerNotSet_shouldKeepDefault() async throws {
+        // Given
+        let configuration = Internals.Session.Configuration()
+
+        // When
+        let builtConfiguration = try configuration.build()
+
+        // Then
+        #expect(builtConfiguration.tracing.tracer != nil)
     }
 
     @Test

--- a/Tests/RequestDLInternalsTests/Sources/Session/Session Configuration/InternalsSessionConfigurationTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Session/Session Configuration/InternalsSessionConfigurationTests.swift
@@ -249,7 +249,7 @@ struct InternalsSessionConfigurationTests {
     func configuration_whenSetTracer_shouldBeEqual() async throws {
         // Given
         var configuration = Internals.Session.Configuration()
-        let tracer = NoOpTracer()
+        let tracer = RecordingTracer()
 
         // When
         configuration.tracer = tracer
@@ -257,11 +257,11 @@ struct InternalsSessionConfigurationTests {
         let builtConfiguration = try configuration.build()
 
         // Then
-        #expect(builtConfiguration.tracing.tracer != nil)
+        #expect((builtConfiguration.tracing.tracer as? RecordingTracer) != nil)
     }
 
     @Test
-    func configuration_whenTracerNotSet_shouldKeepDefault() async throws {
+    func configuration_whenTracerNotSet_shouldDefaultToNoOp() async throws {
         // Given
         let configuration = Internals.Session.Configuration()
 
@@ -269,7 +269,7 @@ struct InternalsSessionConfigurationTests {
         let builtConfiguration = try configuration.build()
 
         // Then
-        #expect(builtConfiguration.tracing.tracer != nil)
+        #expect((builtConfiguration.tracing.tracer as? NoOpTracer) != nil)
     }
 
     @Test
@@ -308,4 +308,27 @@ struct InternalsSessionConfigurationTests {
         #expect(builtConfiguration.httpVersion == .automatic)
         #expect(builtConfiguration.networkFrameworkWaitForConnectivity)
     }
+}
+
+private struct RecordingTracer: Tracer, Sendable {
+
+    func startSpan<Instant: TracerInstant>(
+        _ operationName: String,
+        context: @autoclosure () -> ServiceContext,
+        ofKind kind: SpanKind,
+        at instant: @autoclosure () -> Instant,
+        function: String,
+        file fileID: String,
+        line: UInt
+    ) -> NoOpTracer.NoOpSpan {
+        NoOpTracer.NoOpSpan(context: context())
+    }
+
+    func forceFlush() {}
+
+    func inject<Carrier, Inject>(_ context: ServiceContext, into carrier: inout Carrier, using injector: Inject)
+    where Inject: Injector, Carrier == Inject.Carrier {}
+
+    func extract<Carrier, Extract>(_ carrier: Carrier, into context: inout ServiceContext, using extractor: Extract)
+    where Extract: Extractor, Carrier == Extract.Carrier {}
 }

--- a/Tests/RequestDLTests/Properties/Sources/Session/Session/SessionTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Session/Session/SessionTests.swift
@@ -280,7 +280,7 @@ struct SessionTests {
     }
 
     @Test
-    func session_whenTracerDefault_shouldBeNil() async throws {
+    func session_whenTracerDefault_shouldBeNoOp() async throws {
         // Given
         let property = Session()
 
@@ -288,13 +288,13 @@ struct SessionTests {
         let resolved = try await resolve(TestProperty { property })
 
         // Then
-        #expect(resolved.session.configuration.tracer == nil)
+        #expect((resolved.session.configuration.tracer as? NoOpTracer) != nil)
     }
 
     @Test
     func session_whenTracerSet_shouldBeValid() async throws {
         // Given
-        let tracer = NoOpTracer()
+        let tracer = RecordingTracer()
 
         let property = Session()
             .tracer(tracer)
@@ -303,8 +303,8 @@ struct SessionTests {
         let resolved = try await resolve(TestProperty { property })
 
         // Then
-        #expect(resolved.session.configuration.tracer != nil)
-        #expect(try resolved.session.configuration.build().tracing.tracer != nil)
+        #expect((resolved.session.configuration.tracer as? RecordingTracer) != nil)
+        #expect(try (resolved.session.configuration.build().tracing.tracer as? RecordingTracer) != nil)
     }
 
     @Test
@@ -333,4 +333,27 @@ struct SessionTests {
         #expect(resolved.session.configuration.decompression == .enabled(.size(200)))
         #expect(resolved.session.configuration.networkFrameworkWaitForConnectivity == true)
     }
+}
+
+private struct RecordingTracer: Tracer, Sendable {
+
+    func startSpan<Instant: TracerInstant>(
+        _ operationName: String,
+        context: @autoclosure () -> ServiceContext,
+        ofKind kind: SpanKind,
+        at instant: @autoclosure () -> Instant,
+        function: String,
+        file fileID: String,
+        line: UInt
+    ) -> NoOpTracer.NoOpSpan {
+        NoOpTracer.NoOpSpan(context: context())
+    }
+
+    func forceFlush() {}
+
+    func inject<Carrier, Inject>(_ context: ServiceContext, into carrier: inout Carrier, using injector: Inject)
+    where Inject: Injector, Carrier == Inject.Carrier {}
+
+    func extract<Carrier, Extract>(_ carrier: Carrier, into context: inout ServiceContext, using extractor: Extract)
+    where Extract: Extractor, Carrier == Extract.Carrier {}
 }

--- a/Tests/RequestDLTests/Properties/Sources/Session/Session/SessionTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Session/Session/SessionTests.swift
@@ -304,7 +304,11 @@ struct SessionTests {
 
         // Then
         #expect((resolved.session.configuration.tracer as? RecordingTracer) != nil)
-        #expect(try (resolved.session.configuration.build().tracing.tracer as? RecordingTracer) != nil)
+
+        // `async-http-client`'s own built-in tracing is always suppressed -- RequestDL owns the
+        // span lifecycle itself, in `RawTask.result()`, using `resolved.session.configuration
+        // .tracer` directly. See `TRACER_SERVICE_CONTEXT_REPORT.md`.
+        #expect(try (resolved.session.configuration.build().tracing.tracer as? NoOpTracer) != nil)
     }
 
     @Test

--- a/Tests/RequestDLTests/Properties/Sources/Session/Session/SessionTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Session/Session/SessionTests.swift
@@ -6,6 +6,7 @@ import AsyncHTTPClient
 import NIOPosix
 import RequestDLInternals
 import Testing
+import Tracing
 
 @testable import RequestDL
 
@@ -276,6 +277,34 @@ struct SessionTests {
 
         // Then
         #expect(resolved.session.configuration.compression == .enabled(algorithm.build()))
+    }
+
+    @Test
+    func session_whenTracerDefault_shouldBeNil() async throws {
+        // Given
+        let property = Session()
+
+        // When
+        let resolved = try await resolve(TestProperty { property })
+
+        // Then
+        #expect(resolved.session.configuration.tracer == nil)
+    }
+
+    @Test
+    func session_whenTracerSet_shouldBeValid() async throws {
+        // Given
+        let tracer = NoOpTracer()
+
+        let property = Session()
+            .tracer(tracer)
+
+        // When
+        let resolved = try await resolve(TestProperty { property })
+
+        // Then
+        #expect(resolved.session.configuration.tracer != nil)
+        #expect(try resolved.session.configuration.build().tracing.tracer != nil)
     }
 
     @Test

--- a/Tests/RequestDLTests/Properties/Sources/Tracing/Service Context/RequestServiceContextTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Tracing/Service Context/RequestServiceContextTests.swift
@@ -1,0 +1,172 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+import NIOConcurrencyHelpers
+import Testing
+import Tracing
+
+@testable import RequestDL
+@testable import RequestDLTestSupport
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import struct Foundation.UUID
+#endif
+
+private enum TestIDKey: ServiceContextKey {
+    typealias Value = String
+}
+
+extension ServiceContext {
+    fileprivate var testID: String? {
+        get { self[TestIDKey.self] }
+        set { self[TestIDKey.self] = newValue }
+    }
+}
+
+struct RequestServiceContextTests {
+
+    @Test
+    func serviceContext_whenSet_shouldBeAvailableInRequestConfiguration() async throws {
+        // Given
+        var context = ServiceContext.topLevel
+        context.testID = "abc-123"
+
+        let property = TestProperty(RequestServiceContext(context))
+
+        // When
+        let resolved = try await resolve(property)
+
+        // Then
+        #expect(resolved.requestConfiguration.serviceContext?.testID == "abc-123")
+    }
+
+    @Test
+    func serviceContext_whenNotDeclared_shouldBeNil() async throws {
+        // Given
+        let property = TestProperty(RequestMethod(.get))
+
+        // When
+        let resolved = try await resolve(property)
+
+        // Then
+        #expect(resolved.requestConfiguration.serviceContext == nil)
+    }
+
+    @Test
+    func serviceContext_whenNeverBody_shouldBeNever() async throws {
+        // Given
+        let property = RequestServiceContext(.topLevel)
+
+        // Then
+        try await assertNever(property.body)
+    }
+
+    /// Documents a confirmed upstream bug rather than a RequestDL regression: `async-http-client`
+    /// starts a request's span only after execution hops onto a SwiftNIO `EventLoop` via
+    /// `EventLoop.execute(_:)`, and Swift's task-locals -- which `ServiceContext.current` is built
+    /// on -- don't cross that hop. Root-caused in full in `TRACER_SERVICE_CONTEXT_REPORT.md` at the
+    /// repository root. Wrapped in `withKnownIssue` so this stays red-if-fixed instead of
+    /// red-forever: once the upstream bug is fixed, this starts failing to flag that
+    /// `RequestServiceContext`'s doc comment (and the report) are stale and can be updated.
+    @Test
+    func dataTask_whenServiceContextSet_shouldBeObservedByTracerDuringExecution() async throws {
+        try await withKnownIssue(
+            "async-http-client loses ServiceContext.current across its internal EventLoop hop before starting the request span -- see TRACER_SERVICE_CONTEXT_REPORT.md"
+        ) {
+            try await Self.assertServiceContextObservedByTracer()
+        }
+    }
+
+    private static func assertServiceContextObservedByTracer() async throws {
+        // Given
+        let localServer = try await LocalServer(.standard)
+        let uri = "/" + UUID().uuidString
+
+        let certificate = Certificates().server()
+        let output = "Hello World"
+
+        let response = try LocalServer.ResponseConfiguration(jsonObject: output)
+
+        localServer.cleanup(at: uri)
+        localServer.insert(response, at: uri)
+        defer { localServer.cleanup(at: uri) }
+
+        var context = ServiceContext.topLevel
+        context.testID = "trace-\(UUID().uuidString)"
+
+        let tracer = ContextCapturingTracer()
+
+        // A cold connection pool dispatches the first request onto the connection's own
+        // EventLoop, off the calling Swift Task -- Swift's task-locals don't cross that hop, so
+        // a warm-up request first (whose reply the test doesn't otherwise care about) gives the
+        // pool an idle, already-established connection for the request that's actually asserted
+        // on, keeping this deterministic instead of racing AsyncHTTPClient's own scheduling.
+        _ = try await DataTask {
+            BaseURL(localServer.baseURL)
+            Path(uri)
+
+            Session.localServer
+                .tracer(tracer)
+
+            SecureConnection {
+                TrustRoots(certificate.certificateURL.absolutePath(percentEncoded: false))
+            }
+        }
+        .extractPayload()
+        .result()
+
+        // When
+        _ = try await DataTask {
+            BaseURL(localServer.baseURL)
+            Path(uri)
+
+            Session.localServer
+                .tracer(tracer)
+
+            SecureConnection {
+                TrustRoots(certificate.certificateURL.absolutePath(percentEncoded: false))
+            }
+
+            RequestServiceContext(context)
+        }
+        .extractPayload()
+        .result()
+
+        // Then
+        #expect(tracer.capturedTestID == context.testID)
+    }
+}
+
+private final class ContextCapturingTracer: Tracer, Sendable {
+
+    private let box = NIOLockedValueBox<String?>(nil)
+
+    var capturedTestID: String? {
+        box.withLockedValue { $0 }
+    }
+
+    func startSpan<Instant: TracerInstant>(
+        _ operationName: String,
+        context: @autoclosure () -> ServiceContext,
+        ofKind kind: SpanKind,
+        at instant: @autoclosure () -> Instant,
+        function: String,
+        file fileID: String,
+        line: UInt
+    ) -> NoOpTracer.NoOpSpan {
+        let resolvedContext = context()
+        box.withLockedValue { $0 = resolvedContext.testID }
+        return NoOpTracer.NoOpSpan(context: resolvedContext)
+    }
+
+    func forceFlush() {}
+
+    func inject<Carrier, Inject>(_ context: ServiceContext, into carrier: inout Carrier, using injector: Inject)
+    where Inject: Injector, Carrier == Inject.Carrier {}
+
+    func extract<Carrier, Extract>(_ carrier: Carrier, into context: inout ServiceContext, using extractor: Extract)
+    where Extract: Extractor, Carrier == Extract.Carrier {}
+}

--- a/Tests/RequestDLTests/Properties/Sources/Tracing/Service Context/RequestServiceContextTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Tracing/Service Context/RequestServiceContextTests.swift
@@ -64,23 +64,14 @@ struct RequestServiceContextTests {
         try await assertNever(property.body)
     }
 
-    /// Documents a confirmed upstream bug rather than a RequestDL regression: `async-http-client`
-    /// starts a request's span only after execution hops onto a SwiftNIO `EventLoop` via
-    /// `EventLoop.execute(_:)`, and Swift's task-locals -- which `ServiceContext.current` is built
-    /// on -- don't cross that hop. Root-caused in full in `TRACER_SERVICE_CONTEXT_REPORT.md` at the
-    /// repository root. Wrapped in `withKnownIssue` so this stays red-if-fixed instead of
-    /// red-forever: once the upstream bug is fixed, this starts failing to flag that
-    /// `RequestServiceContext`'s doc comment (and the report) are stale and can be updated.
+    /// `async-http-client`'s own built-in tracing loses `ServiceContext.current` because it only
+    /// starts its span after hopping onto a SwiftNIO `EventLoop` (full root cause in
+    /// `TRACER_SERVICE_CONTEXT_REPORT.md`). RequestDL sidesteps that entirely by owning the span
+    /// lifecycle itself, in `RawTask.result()`, entirely within the caller's own task -- no
+    /// `EventLoop` hop involved -- so this now genuinely works, unlike when tracing was delegated to
+    /// `async-http-client`.
     @Test
     func dataTask_whenServiceContextSet_shouldBeObservedByTracerDuringExecution() async throws {
-        try await withKnownIssue(
-            "async-http-client loses ServiceContext.current across its internal EventLoop hop before starting the request span -- see TRACER_SERVICE_CONTEXT_REPORT.md"
-        ) {
-            try await Self.assertServiceContextObservedByTracer()
-        }
-    }
-
-    private static func assertServiceContextObservedByTracer() async throws {
         // Given
         let localServer = try await LocalServer(.standard)
         let uri = "/" + UUID().uuidString
@@ -98,25 +89,6 @@ struct RequestServiceContextTests {
         context.testID = "trace-\(UUID().uuidString)"
 
         let tracer = ContextCapturingTracer()
-
-        // A cold connection pool dispatches the first request onto the connection's own
-        // EventLoop, off the calling Swift Task -- Swift's task-locals don't cross that hop, so
-        // a warm-up request first (whose reply the test doesn't otherwise care about) gives the
-        // pool an idle, already-established connection for the request that's actually asserted
-        // on, keeping this deterministic instead of racing AsyncHTTPClient's own scheduling.
-        _ = try await DataTask {
-            BaseURL(localServer.baseURL)
-            Path(uri)
-
-            Session.localServer
-                .tracer(tracer)
-
-            SecureConnection {
-                TrustRoots(certificate.certificateURL.absolutePath(percentEncoded: false))
-            }
-        }
-        .extractPayload()
-        .result()
 
         // When
         _ = try await DataTask {


### PR DESCRIPTION
## Summary

Implements https://github.com/orgs/request-dl/discussions/284: distributed tracing configuration for RequestDL, via `Session.tracer(_:)` and a per-request `RequestServiceContext(_:)`.

- `Package.swift`: added an explicit dependency on `swift-distributed-tracing` (`Tracing` product) to `RequestDLInternals` and `RequestDL`, formalizing what was already resolved transitively via `async-http-client`.
- `Session.tracer(_:)` — sets the `Tracer` (from `swift-distributed-tracing`) used to instrument requests made through that session. Defaults to `NoOpTracer()`: not calling `.tracer(_:)` means no tracing, full stop — RequestDL's builder API is declarative, so it never silently inherits whatever tracer some other part of the process happened to bootstrap via `InstrumentationSystem`.
- `RequestServiceContext(_:)` — a per-request `Property` that binds a `ServiceContext` around that one request's execution, for callers whose code isn't already running in the task where the right context is ambient (a background queue, a detached task, a job picked up from another subsystem).

## RequestDL owns the span lifecycle itself — not `async-http-client`

The first version of this PR fed the configured `Tracer` into `HTTPClient.Configuration.tracing.tracer`, letting `async-http-client`'s own built-in instrumentation create the span. While building `RequestServiceContext`, empirical testing against a real client/server round trip found a confirmed bug in `async-http-client` (1.36.0): it only starts a request's span *after* execution hops onto a SwiftNIO `EventLoop` via `EventLoop.execute(_:)`, and Swift's task-locals — which `ServiceContext.current` is built on — don't cross that hop. So a caller-bound `ServiceContext` could never reach the span's parent, no matter what RequestDL did on its side. Full root-cause analysis, a reproduction, and an implementation plan for fixing this upstream are written up in [`TRACER_SERVICE_CONTEXT_REPORT.md`](TRACER_SERVICE_CONTEXT_REPORT.md).

Rather than stay blocked on that upstream fix, this PR redesigns where tracing lives: **`RawTask.result()` now owns the whole span lifecycle itself**, and `async-http-client`'s own tracing is unconditionally suppressed (`configuration.tracing.tracer` is always `NoOpTracer()` in `build()`, regardless of what `.tracer(_:)` configured).

Concretely, in `RawTask.result()`:
- Starts the span before building the request, still synchronously within the caller's own task — no `EventLoop` hop, so `ServiceContext.$current.withValue(...)` (from `RequestServiceContext`, or whatever's already ambient) has a real, observable effect on the span's parent.
- Injects W3C trace headers into the outgoing request via `tracer.inject(span.context, into: &request.headers, using:)`.
- Sets its own span attributes with current OTel semantic-convention keys (`http.request.method`, `url.full`, `http.response.status_code`, `network.protocol.version`) — sidestepping the `attributeKeys` customization question entirely, since RequestDL never needs `async-http-client`'s (`package`-visibility, and per the report's appendix, something the maintainers have explicitly rejected making customizable) `AttributeKeys` at all.
- Ends the span once the response head arrives or the request throws, wired through a new internal-only `onResponseHead` hook on `AsyncResponse.Iterator` that fires transparently as a side effect of normal iteration — it doesn't consume, buffer, or hide any `.upload`/`.download` step from the caller (draining the sequence internally to reach the head would have silently broken upload progress reporting).
- Cache hits never reach the network, so they aren't traced.

This closes the gap the report documented — verified: the reproduction test that used to need `withKnownIssue` (because the bug was real and unfixed) now passes outright with no wrapper needed.

## Test plan

- [x] `swift build` — clean build, no new warnings
- [x] `swift test` — full suite passes (RequestDLTests: 807/807, RequestDLInternalsTests: 330/330)
- [x] `SessionTests`: `session_whenTracerDefault_shouldBeNoOp`, `session_whenTracerSet_shouldBeValid`
- [x] `InternalsSessionConfigurationTests`: `configuration_whenSetTracer_shouldBeEqual`, `configuration_whenTracerNotSet_shouldDefaultToNoOp`
- [x] `RequestServiceContextTests`: property-level binding, plus `dataTask_whenServiceContextSet_shouldBeObservedByTracerDuringExecution` — a real client/server round trip proving the bound `ServiceContext` is observed by the configured tracer's `startSpan`, no longer wrapped in `withKnownIssue`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
