### PR TITLE
Enable release builds and static SDK in CI

### DIFF
--- a/.github/workflows/swift-ci.yaml
+++ b/.github/workflows/swift-ci.yaml
@@ -31,7 +31,7 @@ concurrency:
 jobs:
   ci:
     name: "Swift CI"
-    uses: request-dl/.github/.github/workflows/swift-ci.yaml@main
+    uses: request-dl/.github/.github/workflows/swift-ci.yaml@claude/proposal-release-builds-static-sdk-d53aed
     with:
       name: request-dl
       product-name: RequestDL

--- a/.github/workflows/swift-ci.yaml
+++ b/.github/workflows/swift-ci.yaml
@@ -31,7 +31,7 @@ concurrency:
 jobs:
   ci:
     name: "Swift CI"
-    uses: request-dl/.github/.github/workflows/swift-ci.yaml@claude/proposal-release-builds-static-sdk-d53aed
+    uses: request-dl/.github/.github/workflows/swift-ci.yaml@main
     with:
       name: request-dl
       product-name: RequestDL

--- a/.github/workflows/swift-ci.yaml
+++ b/.github/workflows/swift-ci.yaml
@@ -64,6 +64,10 @@ jobs:
       # Step 3 – Android Build
       enable-android-build: true
 
+      # Step 3 – Release Builds / Static SDK
+      enable-release-builds: true
+      enable-static-sdk: true
+
       # Step 4
       enable-coverage-upload: true
     secrets: inherit

--- a/Package.swift
+++ b/Package.swift
@@ -102,7 +102,7 @@ let package = Package(
             swiftSettings: [.defaultIsolation(nil)],
         ),
 
-        .target(
+        .testTarget(
             name: "RequestDLTestSupport",
             dependencies: [
                 "RequestDLInternals",

--- a/Package.swift
+++ b/Package.swift
@@ -102,7 +102,7 @@ let package = Package(
             swiftSettings: [.defaultIsolation(nil)],
         ),
 
-        .testTarget(
+        .target(
             name: "RequestDLTestSupport",
             dependencies: [
                 "RequestDLInternals",


### PR DESCRIPTION
## Summary
- Turns on `enable-release-builds` and `enable-static-sdk` inputs for the reusable Swift CI workflow.

## Test plan
- [ ] Confirm CI run picks up the new flags without errors.