### PR TITLE
Add network-capability parity with URLSessionConfiguration

### DIFF
--- a/Sources/RequestDL/Properties/Sources/Session/Session/Models/NetworkAvailabilityError.swift
+++ b/Sources/RequestDL/Properties/Sources/Session/Session/Models/NetworkAvailabilityError.swift
@@ -88,10 +88,12 @@ extension NetworkAvailabilityError: CustomStringConvertible {
         case .expensiveNotAllowed:
             reasonDescription = "the current network path is expensive, and allowsExpensiveNetworkAccess(false) was set"
         case .constrainedNotAllowed:
-            reasonDescription = "the current network path is constrained, and allowsConstrainedNetworkAccess(false) was set"
+            reasonDescription =
+                "the current network path is constrained, and allowsConstrainedNetworkAccess(false) was set"
         }
 
-        let waitNote = waitedForConnectivity
+        let waitNote =
+            waitedForConnectivity
             ? "RequestDL waited for a satisfying path, but the request was cancelled before one arrived."
             : "RequestDL did not wait for connectivity — pass waitsForConnectivity(true) to Session to wait instead of failing immediately."
 

--- a/Sources/RequestDL/Properties/Sources/Session/Session/Models/NetworkAvailabilityError.swift
+++ b/Sources/RequestDL/Properties/Sources/Session/Session/Models/NetworkAvailabilityError.swift
@@ -1,0 +1,100 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+import RequestDLInternals
+
+/// An error thrown when a request cannot proceed under the network-availability constraints
+/// configured on ``Session`` — ``Session/allowsCellularAccess(_:)``,
+/// ``Session/allowsExpensiveNetworkAccess(_:)``, ``Session/allowsConstrainedNetworkAccess(_:)``,
+/// and ``Session/waitsForConnectivity(_:)``.
+///
+/// AsyncHTTPClient has no hook to configure these at the `NWParameters` level the way
+/// `URLSessionConfiguration` does — see swift-server/async-http-client#915 and #918, both closed
+/// without a path forward — so RequestDL enforces them itself with a pre-flight check against the
+/// current network path, before the request is ever handed to AsyncHTTPClient.
+///
+/// That check runs exactly once, right before the request starts. It is not a mid-flight
+/// watchdog: like `URLSession`, which only waits for connectivity during a task's initial
+/// connection phase, RequestDL never re-evaluates the network path once a transfer is under way —
+/// a network change part way through a request surfaces as an ordinary transport error instead of
+/// this one.
+///
+/// Under normal use this is only ever thrown on Apple platforms, where `Network.framework` is
+/// available to check the current path; the four modifiers above have no effect anywhere else.
+public struct NetworkAvailabilityError: Error, Sendable {
+
+    /// Why the current network path did not satisfy the session's configured constraints.
+    public enum Reason: Sendable, Hashable {
+        /// The device currently has no usable network path at all.
+        case noConnection
+        /// The current path is cellular, and ``Session/allowsCellularAccess(_:)`` is `false`.
+        case cellularNotAllowed
+        /// The current path is expensive (for example, a personal hotspot or metered
+        /// connection), and ``Session/allowsExpensiveNetworkAccess(_:)`` is `false`.
+        case expensiveNotAllowed
+        /// The current path is constrained (for example, Low Data Mode), and
+        /// ``Session/allowsConstrainedNetworkAccess(_:)`` is `false`.
+        case constrainedNotAllowed
+
+        init(_ reason: Internals.NetworkPathUnsatisfiedError.Reason) {
+            switch reason {
+            case .noConnection:
+                self = .noConnection
+            case .cellularNotAllowed:
+                self = .cellularNotAllowed
+            case .expensiveNotAllowed:
+                self = .expensiveNotAllowed
+            case .constrainedNotAllowed:
+                self = .constrainedNotAllowed
+            }
+        }
+    }
+
+    // MARK: - Public properties
+
+    /// The specific reason the request could not proceed. When more than one constraint is
+    /// violated at once, this reports whichever is checked first, in this order:
+    /// ``Reason/noConnection``, ``Reason/cellularNotAllowed``, ``Reason/expensiveNotAllowed``,
+    /// ``Reason/constrainedNotAllowed``.
+    public let reason: Reason
+
+    /// Whether ``Session/waitsForConnectivity(_:)`` was set to `true`. When `true`, RequestDL
+    /// waited for a satisfying network path and the request was cancelled before one arrived;
+    /// when `false` (`URLSessionConfiguration`'s own default), RequestDL failed immediately,
+    /// without waiting at all.
+    public let waitedForConnectivity: Bool
+
+    // MARK: - Inits
+
+    init(_ error: Internals.NetworkPathUnsatisfiedError) {
+        self.reason = Reason(error.reason)
+        self.waitedForConnectivity = error.waitedForConnectivity
+    }
+}
+
+// MARK: - CustomStringConvertible
+
+extension NetworkAvailabilityError: CustomStringConvertible {
+
+    public var description: String {
+        let reasonDescription: String
+
+        switch reason {
+        case .noConnection:
+            reasonDescription = "the device currently has no usable network path"
+        case .cellularNotAllowed:
+            reasonDescription = "the current network path is cellular, and allowsCellularAccess(false) was set"
+        case .expensiveNotAllowed:
+            reasonDescription = "the current network path is expensive, and allowsExpensiveNetworkAccess(false) was set"
+        case .constrainedNotAllowed:
+            reasonDescription = "the current network path is constrained, and allowsConstrainedNetworkAccess(false) was set"
+        }
+
+        let waitNote = waitedForConnectivity
+            ? "RequestDL waited for a satisfying path, but the request was cancelled before one arrived."
+            : "RequestDL did not wait for connectivity — pass waitsForConnectivity(true) to Session to wait instead of failing immediately."
+
+        return "RequestDL could not send this request: \(reasonDescription). \(waitNote)"
+    }
+}

--- a/Sources/RequestDL/Properties/Sources/Session/Session/Models/Session.MultipathServiceType.swift
+++ b/Sources/RequestDL/Properties/Sources/Session/Session/Models/Session.MultipathServiceType.swift
@@ -1,0 +1,37 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+import RequestDLInternals
+
+extension Session {
+
+    /// Mirrors `URLSessionConfiguration.MultipathServiceType`. AsyncHTTPClient only exposes a
+    /// plain on/off `enableMultipath` flag, with no equivalent to `URLSession`'s handover/
+    /// interactive/aggregate distinction, so every case other than ``none`` collapses to the same
+    /// "multipath enabled" behavior underneath. Kept as a 4-case enum anyway, rather than a
+    /// `Bool`, so a caller migrating from `URLSessionConfiguration` doesn't have to translate
+    /// their intent by hand, and so a future AsyncHTTPClient release that adds real granularity
+    /// has somewhere to grow into without a source break here.
+    public enum MultipathServiceType: Sendable, Hashable {
+        case none
+        case handover
+        case interactive
+        case aggregate
+
+        // MARK: - Internal methods
+
+        func build() -> Internals.MultipathServiceType {
+            switch self {
+            case .none:
+                return .none
+            case .handover:
+                return .handover
+            case .interactive:
+                return .interactive
+            case .aggregate:
+                return .aggregate
+            }
+        }
+    }
+}

--- a/Sources/RequestDL/Properties/Sources/Session/Session/Session.swift
+++ b/Sources/RequestDL/Properties/Sources/Session/Session/Session.swift
@@ -92,11 +92,68 @@ public struct Session: Property {
     ///
     /// Set whether the session should wait for connectivity before making a request.
     ///
+    /// Checked once, right before the request is dispatched, against the device's current
+    /// network path — the same way `URLSession`'s own `waitsForConnectivity` only covers a
+    /// task's initial connection phase, never a network change mid-transfer. Effective across
+    /// every executor (previously this only had any effect when Network framework backed the
+    /// connection).
+    ///
     /// - Parameter flag: `true` to wait for connectivity or `false` to not wait for it.
     /// - Returns: The modified `Session` instance with the waiting for connectivity flag configured.
     ///
     public func waitsForConnectivity(_ flag: Bool) -> Self {
-        edit { $0.networkFrameworkWaitForConnectivity = flag }
+        edit { $0.waitsForConnectivity = flag }
+    }
+
+    ///
+    /// Set whether the session may send requests over a cellular network path.
+    ///
+    /// Enforced with a pre-flight check against the device's current network path, mirroring
+    /// `URLSessionConfiguration.allowsCellularAccess` — see ``NetworkAvailabilityError``.
+    ///
+    /// - Parameter flag: `true` to allow cellular access, `false` to require a non-cellular path.
+    /// - Returns: The modified `Session` instance with the cellular-access flag configured.
+    ///
+    public func allowsCellularAccess(_ flag: Bool) -> Self {
+        edit { $0.allowsCellularAccess = flag }
+    }
+
+    ///
+    /// Set whether the session may send requests over an expensive network path (for example, a
+    /// personal hotspot or a metered connection).
+    ///
+    /// Enforced with a pre-flight check against the device's current network path, mirroring
+    /// `URLSessionConfiguration.allowsExpensiveNetworkAccess` — see ``NetworkAvailabilityError``.
+    ///
+    /// - Parameter flag: `true` to allow expensive access, `false` to require a non-expensive path.
+    /// - Returns: The modified `Session` instance with the expensive-access flag configured.
+    ///
+    public func allowsExpensiveNetworkAccess(_ flag: Bool) -> Self {
+        edit { $0.allowsExpensiveNetworkAccess = flag }
+    }
+
+    ///
+    /// Set whether the session may send requests over a constrained network path (for example,
+    /// when the user has enabled Low Data Mode).
+    ///
+    /// Enforced with a pre-flight check against the device's current network path, mirroring
+    /// `URLSessionConfiguration.allowsConstrainedNetworkAccess` — see ``NetworkAvailabilityError``.
+    ///
+    /// - Parameter flag: `true` to allow constrained access, `false` to require an unconstrained path.
+    /// - Returns: The modified `Session` instance with the constrained-access flag configured.
+    ///
+    public func allowsConstrainedNetworkAccess(_ flag: Bool) -> Self {
+        edit { $0.allowsConstrainedNetworkAccess = flag }
+    }
+
+    ///
+    /// Configures multipath TCP for the session, mirroring `URLSessionConfiguration.multipathServiceType`.
+    ///
+    /// - Parameter type: The multipath service type to use.
+    /// - Returns: The modified `Session` instance with multipath configured.
+    ///
+    public func multipathServiceType(_ type: MultipathServiceType) -> Self {
+        edit { $0.multipathServiceType = type.build() }
     }
 
     ///

--- a/Sources/RequestDL/Tasks/Sources/Raw Task/Raw/RawTask.swift
+++ b/Sources/RequestDL/Tasks/Sources/Raw Task/Raw/RawTask.swift
@@ -18,6 +18,14 @@ struct RawTask<Content: Property>: RequestTask {
             environment: environment
         ).build()
 
+        if let constraints = resolved.session.configuration.networkPathConstraints {
+            do {
+                try await Internals.NetworkPathGate.wait(for: constraints)
+            } catch let error as Internals.NetworkPathUnsatisfiedError {
+                throw NetworkAvailabilityError(error)
+            }
+        }
+
         let logger = Internals.TaskLogger(
             baseURL: resolved.requestConfiguration.baseURL,
             pathComponents: resolved.requestConfiguration.pathComponents,

--- a/Sources/RequestDLInternals/Sources/Session/Network Path Monitor/Internals.NetworkPathMonitor.swift
+++ b/Sources/RequestDLInternals/Sources/Session/Network Path Monitor/Internals.NetworkPathMonitor.swift
@@ -31,7 +31,7 @@ extension Internals {
 
         /// Guarded by `lock`. Keyed by subscription identity so each `updates()` call can
         /// deregister only its own continuation on termination.
-        private var _subscribers: [ObjectIdentifier: Swift.AsyncStream<NetworkPath>.Continuation] = [:]
+        private var _subscribers: [ObjectIdentifier: _Concurrency.AsyncStream<NetworkPath>.Continuation] = [:]
 
         package var currentPath: NetworkPath {
             lock.withLock { _currentPath }
@@ -49,11 +49,11 @@ extension Internals {
 
         // MARK: - Internal methods
 
-        package func updates() -> Swift.AsyncStream<NetworkPath> {
+        package func updates() -> _Concurrency.AsyncStream<NetworkPath> {
             let token = SubscriberToken()
             let id = ObjectIdentifier(token)
 
-            return Swift.AsyncStream(bufferingPolicy: .bufferingNewest(1)) { continuation in
+            return _Concurrency.AsyncStream(bufferingPolicy: .bufferingNewest(1)) { continuation in
                 let initialPath = lock.withLock { () -> NetworkPath in
                     _subscribers[id] = continuation
                     return _currentPath
@@ -77,7 +77,7 @@ extension Internals {
         // MARK: - Private methods
 
         private func updatePath(_ path: NetworkPath) {
-            let subscribers = lock.withLock { () -> [Swift.AsyncStream<NetworkPath>.Continuation] in
+            let subscribers = lock.withLock { () -> [_Concurrency.AsyncStream<NetworkPath>.Continuation] in
                 _currentPath = path
                 return Array(_subscribers.values)
             }

--- a/Sources/RequestDLInternals/Sources/Session/Network Path Monitor/Internals.NetworkPathMonitor.swift
+++ b/Sources/RequestDLInternals/Sources/Session/Network Path Monitor/Internals.NetworkPathMonitor.swift
@@ -1,0 +1,107 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+#if canImport(Darwin)
+import Network
+import SwiftAsyncStream
+
+extension Internals {
+
+    /// A shared, process-lifetime wrapper around a single `NWPathMonitor`, fanning its updates
+    /// out to any number of concurrent ``updates()`` subscribers.
+    ///
+    /// One `NWPathMonitor` for the whole process, not one per request/gate call -- starting a
+    /// fresh monitor has real overhead. Lazily created via `.shared`'s own thread-safe lazy
+    /// static initialization, so a process that never sets `allowsCellularAccess`/
+    /// `allowsExpensiveNetworkAccess`/`allowsConstrainedNetworkAccess`/`waitsForConnectivity`
+    /// never starts an `NWPathMonitor` at all -- `Internals.NetworkPathGate.wait(for:)` is only
+    /// ever called when at least one of those four is set, and `.shared` is only referenced from
+    /// inside that call's default `observer` argument.
+    package final class NetworkPathMonitor: NetworkPathObserving, @unchecked Sendable {
+
+        package static let shared = NetworkPathMonitor()
+
+        private let monitor = NWPathMonitor()
+        private let queue = DispatchQueue(label: "RequestDL.NetworkPathMonitor")
+        private let lock = Lock()
+
+        /// Guarded by `lock`.
+        private var _currentPath: NetworkPath
+
+        /// Guarded by `lock`. Keyed by subscription identity so each `updates()` call can
+        /// deregister only its own continuation on termination.
+        private var _subscribers: [ObjectIdentifier: Swift.AsyncStream<NetworkPath>.Continuation] = [:]
+
+        package var currentPath: NetworkPath {
+            lock.withLock { _currentPath }
+        }
+
+        // MARK: - Inits
+
+        private init() {
+            _currentPath = monitor.currentPath.toNetworkPath
+            monitor.pathUpdateHandler = { [weak self] path in
+                self?.updatePath(path.toNetworkPath)
+            }
+            monitor.start(queue: queue)
+        }
+
+        // MARK: - Internal methods
+
+        package func updates() -> Swift.AsyncStream<NetworkPath> {
+            let token = SubscriberToken()
+            let id = ObjectIdentifier(token)
+
+            return Swift.AsyncStream(bufferingPolicy: .bufferingNewest(1)) { continuation in
+                let initialPath = lock.withLock { () -> NetworkPath in
+                    _subscribers[id] = continuation
+                    return _currentPath
+                }
+
+                // A path that already satisfies by the time a caller subscribes must not wait
+                // for the *next* change to be observed.
+                continuation.yield(initialPath)
+
+                // Fires when this stream's consuming task is cancelled. This is the
+                // cancellation-safety hook `Internals.NetworkPathGate.wait(for:)` relies on: it
+                // removes the dead subscriber so `updatePath` stops retaining/yielding to it,
+                // with no separate cancellation plumbing needed in the gate itself.
+                continuation.onTermination = { [weak self, token] _ in
+                    _ = token
+                    self?.lock.withLock { self?._subscribers[id] = nil }
+                }
+            }
+        }
+
+        // MARK: - Private methods
+
+        private func updatePath(_ path: NetworkPath) {
+            let subscribers = lock.withLock { () -> [Swift.AsyncStream<NetworkPath>.Continuation] in
+                _currentPath = path
+                return Array(_subscribers.values)
+            }
+
+            for continuation in subscribers {
+                continuation.yield(path)
+            }
+        }
+
+        /// Identity anchor for a single `updates()` subscription -- kept alive by its own
+        /// `onTermination` closure until termination fires, then released.
+        private final class SubscriberToken: Sendable {}
+    }
+}
+
+extension NWPath {
+
+    fileprivate var toNetworkPath: Internals.NetworkPath {
+        .init(
+            isSatisfied: status == .satisfied,
+            usesCellular: usesInterfaceType(.cellular),
+            isExpensive: isExpensive,
+            isConstrained: isConstrained
+        )
+    }
+}
+#endif

--- a/Sources/RequestDLInternals/Sources/Session/Session Configuration/Internals.Session.Configuration.swift
+++ b/Sources/RequestDLInternals/Sources/Session/Session Configuration/Internals.Session.Configuration.swift
@@ -167,7 +167,11 @@ extension Internals.Session.Configuration: Equatable {
             && lhs.decompression == rhs.decompression
             && lhs.compression == rhs.compression
             && lhs.dnsOverride == rhs.dnsOverride
-            && lhs.networkFrameworkWaitForConnectivity == rhs.networkFrameworkWaitForConnectivity
+            && lhs.waitsForConnectivity == rhs.waitsForConnectivity
+            && lhs.allowsCellularAccess == rhs.allowsCellularAccess
+            && lhs.allowsExpensiveNetworkAccess == rhs.allowsExpensiveNetworkAccess
+            && lhs.allowsConstrainedNetworkAccess == rhs.allowsConstrainedNetworkAccess
+            && lhs.multipathServiceType == rhs.multipathServiceType
             && lhs.httpVersion == rhs.httpVersion
             && lhs.enableNetworkFramework == rhs.enableNetworkFramework
             && lhs.maximumConcurrentConnections == rhs.maximumConcurrentConnections

--- a/Sources/RequestDLInternals/Sources/Session/Session Configuration/Internals.Session.Configuration.swift
+++ b/Sources/RequestDLInternals/Sources/Session/Session Configuration/Internals.Session.Configuration.swift
@@ -112,10 +112,11 @@ extension Internals.Session.Configuration {
     /// can skip `Internals.NetworkPathGate` -- and therefore skip ever starting
     /// `Internals.NetworkPathMonitor` -- entirely for sessions that never use this API.
     package var networkPathConstraints: Internals.NetworkPathGate.Constraints? {
-        guard allowsCellularAccess != nil
-            || allowsExpensiveNetworkAccess != nil
-            || allowsConstrainedNetworkAccess != nil
-            || waitsForConnectivity != nil
+        guard
+            allowsCellularAccess != nil
+                || allowsExpensiveNetworkAccess != nil
+                || allowsConstrainedNetworkAccess != nil
+                || waitsForConnectivity != nil
         else {
             return nil
         }

--- a/Sources/RequestDLInternals/Sources/Session/Session Configuration/Internals.Session.Configuration.swift
+++ b/Sources/RequestDLInternals/Sources/Session/Session Configuration/Internals.Session.Configuration.swift
@@ -34,7 +34,17 @@ extension Internals.Session {
 
         package var compression: Internals.Compression = .disabled
         package var dnsOverride: [String: String] = [:]
-        package var networkFrameworkWaitForConnectivity: Bool?
+
+        /// Renamed from the old `networkFrameworkWaitForConnectivity` -- no longer a straight
+        /// forward to AsyncHTTPClient's own field of that name (which only took effect on
+        /// NIOTransportServices). Consumed by `Internals.NetworkPathGate` instead, via
+        /// `networkPathConstraints`, uniformly across every executor. See `build()`.
+        package var waitsForConnectivity: Bool?
+        package var allowsCellularAccess: Bool?
+        package var allowsExpensiveNetworkAccess: Bool?
+        package var allowsConstrainedNetworkAccess: Bool?
+        package var multipathServiceType: Internals.MultipathServiceType = .none
+
         package var httpVersion: Internals.HTTPVersion?
         package var enableNetworkFramework: Bool = false
         package var maximumConcurrentConnections: Int?
@@ -57,10 +67,7 @@ extension Internals.Session {
             )
 
             configuration.dnsOverride = dnsOverride
-
-            if let flag = networkFrameworkWaitForConnectivity {
-                configuration.networkFrameworkWaitForConnectivity = flag
-            }
+            configuration.enableMultipath = (multipathServiceType != .none)
 
             if let httpVersion {
                 configuration.httpVersion = httpVersion.build()
@@ -99,5 +106,25 @@ extension Internals.Session.Configuration {
         }
 
         return false
+    }
+
+    /// `nil` when none of the four network-availability knobs were touched, so `RawTask.result()`
+    /// can skip `Internals.NetworkPathGate` -- and therefore skip ever starting
+    /// `Internals.NetworkPathMonitor` -- entirely for sessions that never use this API.
+    package var networkPathConstraints: Internals.NetworkPathGate.Constraints? {
+        guard allowsCellularAccess != nil
+            || allowsExpensiveNetworkAccess != nil
+            || allowsConstrainedNetworkAccess != nil
+            || waitsForConnectivity != nil
+        else {
+            return nil
+        }
+
+        return .init(
+            allowsCellularAccess: allowsCellularAccess,
+            allowsExpensiveNetworkAccess: allowsExpensiveNetworkAccess,
+            allowsConstrainedNetworkAccess: allowsConstrainedNetworkAccess,
+            waitsForConnectivity: waitsForConnectivity
+        )
     }
 }

--- a/Sources/RequestDLInternals/Sources/Session/Session Configuration/Models/Internals.MultipathServiceType.swift
+++ b/Sources/RequestDLInternals/Sources/Session/Session Configuration/Models/Internals.MultipathServiceType.swift
@@ -1,0 +1,20 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+extension Internals {
+
+    /// Mirrors `URLSessionConfiguration.MultipathServiceType`'s cases. AsyncHTTPClient only
+    /// exposes a plain on/off `enableMultipath` flag on `HTTPClient.Configuration`, with no
+    /// equivalent to the handover/interactive/aggregate distinction, so the collapse to `Bool`
+    /// happens inline as `self != .none` at the one call site that needs it
+    /// (`Internals.Session.Configuration.build()`) rather than through a `build()` method here --
+    /// that mapping is lossy (4 cases to 1), not a 1:1 translation like the other `Internals`
+    /// enums in this file's sibling models.
+    package enum MultipathServiceType: Sendable, Hashable {
+        case none
+        case handover
+        case interactive
+        case aggregate
+    }
+}

--- a/Sources/RequestDLInternals/Sources/Session/Session Configuration/Models/Internals.NetworkPath.swift
+++ b/Sources/RequestDLInternals/Sources/Session/Session Configuration/Models/Internals.NetworkPath.swift
@@ -1,0 +1,36 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+extension Internals {
+
+    /// A platform-agnostic snapshot of a network path's availability characteristics.
+    ///
+    /// Exists because `Network.framework`'s own `NWPath` has no public initializer, so nothing
+    /// built directly on it could be exercised by a fake in a unit test --
+    /// ``Internals/NetworkPathGate`` and ``Internals/NetworkPathObserving`` are written against
+    /// this type instead, never against `NWPath` directly.
+    package struct NetworkPath: Sendable, Equatable {
+
+        // MARK: - Internal properties
+
+        package var isSatisfied: Bool
+        package var usesCellular: Bool
+        package var isExpensive: Bool
+        package var isConstrained: Bool
+
+        // MARK: - Inits
+
+        package init(
+            isSatisfied: Bool,
+            usesCellular: Bool,
+            isExpensive: Bool,
+            isConstrained: Bool
+        ) {
+            self.isSatisfied = isSatisfied
+            self.usesCellular = usesCellular
+            self.isExpensive = isExpensive
+            self.isConstrained = isConstrained
+        }
+    }
+}

--- a/Sources/RequestDLInternals/Sources/Session/Session Configuration/Models/Internals.NetworkPathGate.swift
+++ b/Sources/RequestDLInternals/Sources/Session/Session Configuration/Models/Internals.NetworkPathGate.swift
@@ -118,8 +118,8 @@ extension Internals {
                 .init(isSatisfied: true, usesCellular: false, isExpensive: false, isConstrained: false)
             }
 
-            func updates() -> Swift.AsyncStream<NetworkPath> {
-                Swift.AsyncStream { $0.finish() }
+            func updates() -> _Concurrency.AsyncStream<NetworkPath> {
+                _Concurrency.AsyncStream { $0.finish() }
             }
         }
         #endif

--- a/Sources/RequestDLInternals/Sources/Session/Session Configuration/Models/Internals.NetworkPathGate.swift
+++ b/Sources/RequestDLInternals/Sources/Session/Session Configuration/Models/Internals.NetworkPathGate.swift
@@ -1,0 +1,127 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+extension Internals {
+
+    /// Enforces ``Session``'s `allowsCellularAccess`/`allowsExpensiveNetworkAccess`/
+    /// `allowsConstrainedNetworkAccess`/`waitsForConnectivity` constraints in front of a request,
+    /// since AsyncHTTPClient has no hook to configure the equivalent `NWParameters` itself (see
+    /// swift-server/async-http-client#915 and #918, both closed with no path forward).
+    ///
+    /// Pre-flight only, checked once before the request is dispatched -- never re-evaluated once
+    /// a transfer is under way. This matches `URLSession` itself: `waitsForConnectivity`/
+    /// `taskIsWaitingForConnectivity` only ever cover the initial connection phase, and a network
+    /// change mid-transfer surfaces there as an ordinary task error, not a retry. So this is
+    /// parity with `URLSession`'s actual behavior, not a weaker stand-in for it.
+    package enum NetworkPathGate {
+
+        /// The subset of `Internals.Session.Configuration` this gate acts on.
+        package struct Constraints: Sendable, Equatable {
+
+            package var allowsCellularAccess: Bool?
+            package var allowsExpensiveNetworkAccess: Bool?
+            package var allowsConstrainedNetworkAccess: Bool?
+            package var waitsForConnectivity: Bool?
+
+            package init(
+                allowsCellularAccess: Bool?,
+                allowsExpensiveNetworkAccess: Bool?,
+                allowsConstrainedNetworkAccess: Bool?,
+                waitsForConnectivity: Bool?
+            ) {
+                self.allowsCellularAccess = allowsCellularAccess
+                self.allowsExpensiveNetworkAccess = allowsExpensiveNetworkAccess
+                self.allowsConstrainedNetworkAccess = allowsConstrainedNetworkAccess
+                self.waitsForConnectivity = waitsForConnectivity
+            }
+        }
+
+        // MARK: - Internal static methods
+
+        /// Returns once `observer.currentPath` satisfies `constraints`, throwing instead when it
+        /// doesn't and either `constraints.waitsForConnectivity` isn't `true`, or the wait is
+        /// cancelled before a satisfying path arrives.
+        ///
+        /// - Parameter observer: Defaults to the real, Darwin-only `NWPathMonitor`-backed
+        /// singleton; falls back to an always-satisfied observer everywhere else, making this
+        /// call an immediate no-op off Darwin. Overridable for tests.
+        package static func wait(
+            for constraints: Constraints,
+            observer: any NetworkPathObserving = defaultObserver
+        ) async throws {
+            try Task.checkCancellation()
+
+            if reason(for: observer.currentPath, constraints) == nil {
+                return
+            }
+
+            guard constraints.waitsForConnectivity == true else {
+                throw NetworkPathUnsatisfiedError(
+                    reason: reason(for: observer.currentPath, constraints) ?? .noConnection,
+                    waitedForConnectivity: false
+                )
+            }
+
+            for await path in observer.updates() {
+                if reason(for: path, constraints) == nil {
+                    return
+                }
+            }
+
+            // `observer.updates()` only ends when its consuming task is cancelled (see
+            // `Internals.NetworkPathMonitor.updates()`'s `onTermination`), so reaching this point
+            // means the wait was cancelled rather than that no satisfying path ever existed.
+            try Task.checkCancellation()
+
+            throw NetworkPathUnsatisfiedError(
+                reason: reason(for: observer.currentPath, constraints) ?? .noConnection,
+                waitedForConnectivity: true
+            )
+        }
+
+        // MARK: - Private static methods
+
+        /// The single source of truth for whether `path` satisfies `constraints`: `nil` means it
+        /// does, any other value names the first constraint it violates, checked in this order --
+        /// connectivity, then cellular, then expensive, then constrained.
+        private static func reason(
+            for path: NetworkPath,
+            _ constraints: Constraints
+        ) -> NetworkPathUnsatisfiedError.Reason? {
+            guard path.isSatisfied else {
+                return .noConnection
+            }
+            if constraints.allowsCellularAccess == false, path.usesCellular {
+                return .cellularNotAllowed
+            }
+            if constraints.allowsExpensiveNetworkAccess == false, path.isExpensive {
+                return .expensiveNotAllowed
+            }
+            if constraints.allowsConstrainedNetworkAccess == false, path.isConstrained {
+                return .constrainedNotAllowed
+            }
+            return nil
+        }
+
+        #if canImport(Darwin)
+        private static var defaultObserver: any NetworkPathObserving {
+            NetworkPathMonitor.shared
+        }
+        #else
+        private static var defaultObserver: any NetworkPathObserving {
+            AlwaysSatisfiedObserver()
+        }
+
+        private struct AlwaysSatisfiedObserver: NetworkPathObserving {
+            var currentPath: NetworkPath {
+                .init(isSatisfied: true, usesCellular: false, isExpensive: false, isConstrained: false)
+            }
+
+            func updates() -> Swift.AsyncStream<NetworkPath> {
+                Swift.AsyncStream { $0.finish() }
+            }
+        }
+        #endif
+    }
+}

--- a/Sources/RequestDLInternals/Sources/Session/Session Configuration/Models/Internals.NetworkPathObserving.swift
+++ b/Sources/RequestDLInternals/Sources/Session/Session Configuration/Models/Internals.NetworkPathObserving.swift
@@ -17,10 +17,10 @@ extension Internals {
         /// the new subscriber and then yielding every subsequent change. Ends when the
         /// subscribing task is cancelled.
         ///
-        /// - Note: `Swift.AsyncStream`, explicitly qualified -- an unqualified reference here
+        /// - Note: `_Concurrency.AsyncStream`, explicitly qualified -- an unqualified reference here
         /// would resolve to `Internals.AsyncStream` instead, a throwing, replay-everything type
         /// meant for one-shot response bodies, a poor fit for a long-lived, ever-changing path
         /// signal.
-        func updates() -> Swift.AsyncStream<NetworkPath>
+        func updates() -> _Concurrency.AsyncStream<NetworkPath>
     }
 }

--- a/Sources/RequestDLInternals/Sources/Session/Session Configuration/Models/Internals.NetworkPathObserving.swift
+++ b/Sources/RequestDLInternals/Sources/Session/Session Configuration/Models/Internals.NetworkPathObserving.swift
@@ -1,0 +1,26 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+extension Internals {
+
+    /// What ``Internals/NetworkPathGate`` needs from a network path source, independent of
+    /// `Network.framework` -- implemented by `Internals.NetworkPathMonitor` on Darwin, and by
+    /// fakes in tests, so the gate's wait/fail logic can be exercised without ever touching a
+    /// real `NWPathMonitor`.
+    package protocol NetworkPathObserving: Sendable {
+
+        /// The most recently observed path.
+        var currentPath: NetworkPath { get }
+
+        /// A fresh, independent subscription per call, immediately replaying `currentPath` to
+        /// the new subscriber and then yielding every subsequent change. Ends when the
+        /// subscribing task is cancelled.
+        ///
+        /// - Note: `Swift.AsyncStream`, explicitly qualified -- an unqualified reference here
+        /// would resolve to `Internals.AsyncStream` instead, a throwing, replay-everything type
+        /// meant for one-shot response bodies, a poor fit for a long-lived, ever-changing path
+        /// signal.
+        func updates() -> Swift.AsyncStream<NetworkPath>
+    }
+}

--- a/Sources/RequestDLInternals/Sources/Session/Session Configuration/Models/Internals.NetworkPathUnsatisfiedError.swift
+++ b/Sources/RequestDLInternals/Sources/Session/Session Configuration/Models/Internals.NetworkPathUnsatisfiedError.swift
@@ -1,0 +1,35 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+extension Internals {
+
+    /// Thrown by ``Internals/NetworkPathGate`` when the current network path does not satisfy
+    /// the caller's constraints and either waiting is disabled, or the wait was cancelled before
+    /// a satisfying path arrived.
+    ///
+    /// Rewrapped into the public, documented `NetworkAvailabilityError` at the one call site in
+    /// `RequestDL` that can throw it (`RawTask.swift`), the same way `Internals.SecureFileLoadError`
+    /// becomes `SecureFileError`.
+    package struct NetworkPathUnsatisfiedError: Error, Sendable {
+
+        package enum Reason: Sendable, Hashable {
+            case noConnection
+            case cellularNotAllowed
+            case expensiveNotAllowed
+            case constrainedNotAllowed
+        }
+
+        // MARK: - Internal properties
+
+        package let reason: Reason
+        package let waitedForConnectivity: Bool
+
+        // MARK: - Inits
+
+        package init(reason: Reason, waitedForConnectivity: Bool) {
+            self.reason = reason
+            self.waitedForConnectivity = waitedForConnectivity
+        }
+    }
+}

--- a/Tests/RequestDLInternalsTests/Sources/Session/Network Path Monitor/InternalsNetworkPathGateTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Session/Network Path Monitor/InternalsNetworkPathGateTests.swift
@@ -11,9 +11,9 @@ private struct FakeNetworkPathObserver: Internals.NetworkPathObserving {
     let currentPath: Internals.NetworkPath
     let updateSequence: [Internals.NetworkPath]
 
-    func updates() -> Swift.AsyncStream<Internals.NetworkPath> {
+    func updates() -> _Concurrency.AsyncStream<Internals.NetworkPath> {
         let sequence = updateSequence
-        return Swift.AsyncStream { continuation in
+        return _Concurrency.AsyncStream { continuation in
             for path in sequence {
                 continuation.yield(path)
             }
@@ -28,8 +28,8 @@ private struct HangingNetworkPathObserver: Internals.NetworkPathObserving {
 
     let currentPath: Internals.NetworkPath
 
-    func updates() -> Swift.AsyncStream<Internals.NetworkPath> {
-        Swift.AsyncStream { _ in }
+    func updates() -> _Concurrency.AsyncStream<Internals.NetworkPath> {
+        _Concurrency.AsyncStream { _ in }
     }
 }
 

--- a/Tests/RequestDLInternalsTests/Sources/Session/Network Path Monitor/InternalsNetworkPathGateTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Session/Network Path Monitor/InternalsNetworkPathGateTests.swift
@@ -1,0 +1,232 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+import Testing
+
+@testable import RequestDLInternals
+
+private struct FakeNetworkPathObserver: Internals.NetworkPathObserving {
+
+    let currentPath: Internals.NetworkPath
+    let updateSequence: [Internals.NetworkPath]
+
+    func updates() -> Swift.AsyncStream<Internals.NetworkPath> {
+        let sequence = updateSequence
+        return Swift.AsyncStream { continuation in
+            for path in sequence {
+                continuation.yield(path)
+            }
+            continuation.finish()
+        }
+    }
+}
+
+/// An observer whose `updates()` stream never yields and never finishes on its own -- used to
+/// exercise real `Task` cancellation while `NetworkPathGate.wait(for:)` is awaiting it.
+private struct HangingNetworkPathObserver: Internals.NetworkPathObserving {
+
+    let currentPath: Internals.NetworkPath
+
+    func updates() -> Swift.AsyncStream<Internals.NetworkPath> {
+        Swift.AsyncStream { _ in }
+    }
+}
+
+private let satisfiedPath = Internals.NetworkPath(
+    isSatisfied: true,
+    usesCellular: false,
+    isExpensive: false,
+    isConstrained: false
+)
+
+private let cellularPath = Internals.NetworkPath(
+    isSatisfied: true,
+    usesCellular: true,
+    isExpensive: false,
+    isConstrained: false
+)
+
+private let expensivePath = Internals.NetworkPath(
+    isSatisfied: true,
+    usesCellular: false,
+    isExpensive: true,
+    isConstrained: false
+)
+
+private let constrainedPath = Internals.NetworkPath(
+    isSatisfied: true,
+    usesCellular: false,
+    isExpensive: false,
+    isConstrained: true
+)
+
+private let disconnectedPath = Internals.NetworkPath(
+    isSatisfied: false,
+    usesCellular: false,
+    isExpensive: false,
+    isConstrained: false
+)
+
+struct InternalsNetworkPathGateTests {
+
+    @Test
+    func gate_whenPathAlreadySatisfies_shouldReturnImmediately() async throws {
+        // Given
+        let observer = FakeNetworkPathObserver(currentPath: satisfiedPath, updateSequence: [])
+        let constraints = Internals.NetworkPathGate.Constraints(
+            allowsCellularAccess: false,
+            allowsExpensiveNetworkAccess: nil,
+            allowsConstrainedNetworkAccess: nil,
+            waitsForConnectivity: nil
+        )
+
+        // When / Then
+        try await Internals.NetworkPathGate.wait(for: constraints, observer: observer)
+    }
+
+    @Test
+    func gate_whenCellularViolatedAndNotWaiting_shouldThrowImmediately() async throws {
+        // Given
+        let observer = FakeNetworkPathObserver(currentPath: cellularPath, updateSequence: [])
+        let constraints = Internals.NetworkPathGate.Constraints(
+            allowsCellularAccess: false,
+            allowsExpensiveNetworkAccess: nil,
+            allowsConstrainedNetworkAccess: nil,
+            waitsForConnectivity: nil
+        )
+
+        // When / Then
+        await #expect {
+            try await Internals.NetworkPathGate.wait(for: constraints, observer: observer)
+        } throws: { error in
+            guard let error = error as? Internals.NetworkPathUnsatisfiedError else { return false }
+            return error.reason == .cellularNotAllowed && !error.waitedForConnectivity
+        }
+    }
+
+    @Test
+    func gate_whenExpensiveViolatedAndNotWaiting_shouldThrowImmediately() async throws {
+        // Given
+        let observer = FakeNetworkPathObserver(currentPath: expensivePath, updateSequence: [])
+        let constraints = Internals.NetworkPathGate.Constraints(
+            allowsCellularAccess: nil,
+            allowsExpensiveNetworkAccess: false,
+            allowsConstrainedNetworkAccess: nil,
+            waitsForConnectivity: nil
+        )
+
+        // When / Then
+        await #expect {
+            try await Internals.NetworkPathGate.wait(for: constraints, observer: observer)
+        } throws: { error in
+            (error as? Internals.NetworkPathUnsatisfiedError)?.reason == .expensiveNotAllowed
+        }
+    }
+
+    @Test
+    func gate_whenConstrainedViolatedAndNotWaiting_shouldThrowImmediately() async throws {
+        // Given
+        let observer = FakeNetworkPathObserver(currentPath: constrainedPath, updateSequence: [])
+        let constraints = Internals.NetworkPathGate.Constraints(
+            allowsCellularAccess: nil,
+            allowsExpensiveNetworkAccess: nil,
+            allowsConstrainedNetworkAccess: false,
+            waitsForConnectivity: nil
+        )
+
+        // When / Then
+        await #expect {
+            try await Internals.NetworkPathGate.wait(for: constraints, observer: observer)
+        } throws: { error in
+            (error as? Internals.NetworkPathUnsatisfiedError)?.reason == .constrainedNotAllowed
+        }
+    }
+
+    @Test
+    func gate_whenNoConnection_shouldReportNoConnectionReasonRegardlessOfOtherFlags() async throws {
+        // Given
+        let observer = FakeNetworkPathObserver(currentPath: disconnectedPath, updateSequence: [])
+        let constraints = Internals.NetworkPathGate.Constraints(
+            allowsCellularAccess: false,
+            allowsExpensiveNetworkAccess: false,
+            allowsConstrainedNetworkAccess: false,
+            waitsForConnectivity: nil
+        )
+
+        // When / Then
+        await #expect {
+            try await Internals.NetworkPathGate.wait(for: constraints, observer: observer)
+        } throws: { error in
+            (error as? Internals.NetworkPathUnsatisfiedError)?.reason == .noConnection
+        }
+    }
+
+    @Test
+    func gate_whenPathUnsatisfiedButWaits_shouldAwaitUpdateThatSatisfies() async throws {
+        // Given
+        let observer = FakeNetworkPathObserver(
+            currentPath: cellularPath,
+            updateSequence: [cellularPath, satisfiedPath]
+        )
+        let constraints = Internals.NetworkPathGate.Constraints(
+            allowsCellularAccess: false,
+            allowsExpensiveNetworkAccess: nil,
+            allowsConstrainedNetworkAccess: nil,
+            waitsForConnectivity: true
+        )
+
+        // When / Then
+        try await Internals.NetworkPathGate.wait(for: constraints, observer: observer)
+    }
+
+    @Test
+    func gate_whenObserverFinishesWithoutSatisfying_shouldThrowUnsatisfiedError() async throws {
+        // Given
+        let observer = FakeNetworkPathObserver(
+            currentPath: cellularPath,
+            updateSequence: [cellularPath]
+        )
+        let constraints = Internals.NetworkPathGate.Constraints(
+            allowsCellularAccess: false,
+            allowsExpensiveNetworkAccess: nil,
+            allowsConstrainedNetworkAccess: nil,
+            waitsForConnectivity: true
+        )
+
+        // When / Then
+        await #expect {
+            try await Internals.NetworkPathGate.wait(for: constraints, observer: observer)
+        } throws: { error in
+            guard let error = error as? Internals.NetworkPathUnsatisfiedError else { return false }
+            return error.reason == .cellularNotAllowed && error.waitedForConnectivity
+        }
+    }
+
+    @Test
+    func gate_whenCallerTaskCancelledWhileWaiting_shouldThrowCancellationError() async throws {
+        // Given
+        let observer = HangingNetworkPathObserver(currentPath: cellularPath)
+        let constraints = Internals.NetworkPathGate.Constraints(
+            allowsCellularAccess: false,
+            allowsExpensiveNetworkAccess: nil,
+            allowsConstrainedNetworkAccess: nil,
+            waitsForConnectivity: true
+        )
+
+        let task = Task {
+            try await Internals.NetworkPathGate.wait(for: constraints, observer: observer)
+        }
+
+        // When
+        task.cancel()
+
+        // Then
+        await #expect {
+            try await task.value
+        } throws: { error in
+            error is CancellationError
+        }
+    }
+
+}

--- a/Tests/RequestDLInternalsTests/Sources/Session/Network Path Monitor/InternalsNetworkPathMonitorTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Session/Network Path Monitor/InternalsNetworkPathMonitorTests.swift
@@ -1,0 +1,52 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+#if canImport(Darwin)
+import Testing
+
+@testable import RequestDLInternals
+
+struct InternalsNetworkPathMonitorTests {
+
+    @Test
+    func monitor_whenSharedAccessedTwice_shouldReturnSameInstance() async throws {
+        // Given
+        let first = Internals.NetworkPathMonitor.shared
+        let second = Internals.NetworkPathMonitor.shared
+
+        // Then
+        #expect(first === second)
+    }
+
+    @Test
+    func monitor_updates_shouldYieldCurrentSnapshotImmediatelyOnSubscribe() async throws {
+        // Given
+        let monitor = Internals.NetworkPathMonitor.shared
+        let expectedPath = monitor.currentPath
+
+        // When
+        var iterator = monitor.updates().makeAsyncIterator()
+        let firstUpdate = await iterator.next()
+
+        // Then
+        #expect(firstUpdate == expectedPath)
+    }
+
+    @Test
+    func monitor_updates_multipleConcurrentSubscribers_shouldEachReceiveTheirOwnFirstSnapshot() async throws {
+        // Given
+        let monitor = Internals.NetworkPathMonitor.shared
+
+        // When
+        async let first = monitor.updates().first { _ in true }
+        async let second = monitor.updates().first { _ in true }
+
+        let (firstResult, secondResult) = try await (first, second)
+
+        // Then
+        #expect(firstResult != nil)
+        #expect(secondResult != nil)
+    }
+}
+#endif

--- a/Tests/RequestDLInternalsTests/Sources/Session/Session Configuration/InternalsSessionConfigurationTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Session/Session Configuration/InternalsSessionConfigurationTests.swift
@@ -229,19 +229,96 @@ struct InternalsSessionConfigurationTests {
         #expect(builtConfiguration.httpVersion == version.build())
     }
 
-    @Test
-    func configuration_whenWaitForConnectivity_shouldBeEqual() async throws {
+    @Test(arguments: [
+        Internals.MultipathServiceType.handover,
+        .interactive,
+        .aggregate,
+    ])
+    func configuration_whenSetMultipathServiceType_shouldForwardEnableMultipath(
+        _ multipathServiceType: Internals.MultipathServiceType
+    ) async throws {
         // Given
         var configuration = Internals.Session.Configuration()
-        let waitForConnectivity = false
 
         // When
-        configuration.networkFrameworkWaitForConnectivity = waitForConnectivity
+        configuration.multipathServiceType = multipathServiceType
 
         let builtConfiguration = try configuration.build()
 
         // Then
-        #expect(!builtConfiguration.networkFrameworkWaitForConnectivity)
+        #expect(builtConfiguration.enableMultipath)
+    }
+
+    @Test
+    func configuration_whenMultipathServiceTypeNone_shouldNotEnableMultipath() async throws {
+        // Given
+        let configuration = Internals.Session.Configuration()
+
+        // When
+        let builtConfiguration = try configuration.build()
+
+        // Then
+        #expect(!builtConfiguration.enableMultipath)
+    }
+
+    @Test
+    func configuration_whenNetworkPathConstraintsAllNil_shouldBeNil() async throws {
+        // Given
+        let configuration = Internals.Session.Configuration()
+
+        // Then
+        #expect(configuration.networkPathConstraints == nil)
+    }
+
+    @Test
+    func configuration_whenAllowsCellularAccessSet_shouldPopulateNetworkPathConstraints() async throws {
+        // Given
+        var configuration = Internals.Session.Configuration()
+
+        // When
+        configuration.allowsCellularAccess = false
+
+        // Then
+        #expect(configuration.networkPathConstraints?.allowsCellularAccess == false)
+        #expect(configuration.networkPathConstraints?.allowsExpensiveNetworkAccess == nil)
+        #expect(configuration.networkPathConstraints?.allowsConstrainedNetworkAccess == nil)
+        #expect(configuration.networkPathConstraints?.waitsForConnectivity == nil)
+    }
+
+    @Test
+    func configuration_whenAllowsExpensiveNetworkAccessSet_shouldPopulateNetworkPathConstraints() async throws {
+        // Given
+        var configuration = Internals.Session.Configuration()
+
+        // When
+        configuration.allowsExpensiveNetworkAccess = false
+
+        // Then
+        #expect(configuration.networkPathConstraints?.allowsExpensiveNetworkAccess == false)
+    }
+
+    @Test
+    func configuration_whenAllowsConstrainedNetworkAccessSet_shouldPopulateNetworkPathConstraints() async throws {
+        // Given
+        var configuration = Internals.Session.Configuration()
+
+        // When
+        configuration.allowsConstrainedNetworkAccess = false
+
+        // Then
+        #expect(configuration.networkPathConstraints?.allowsConstrainedNetworkAccess == false)
+    }
+
+    @Test
+    func configuration_whenWaitsForConnectivitySet_shouldPopulateNetworkPathConstraints() async throws {
+        // Given
+        var configuration = Internals.Session.Configuration()
+
+        // When
+        configuration.waitsForConnectivity = true
+
+        // Then
+        #expect(configuration.networkPathConstraints?.waitsForConnectivity == true)
     }
 
     @Test
@@ -278,6 +355,6 @@ struct InternalsSessionConfigurationTests {
                 )
         )
         #expect(builtConfiguration.httpVersion == .automatic)
-        #expect(builtConfiguration.networkFrameworkWaitForConnectivity)
+        #expect(!builtConfiguration.enableMultipath)
     }
 }

--- a/Tests/RequestDLTests/Properties/Sources/Session/Session/Models/NetworkAvailabilityErrorTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Session/Session/Models/NetworkAvailabilityErrorTests.swift
@@ -1,0 +1,49 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+import RequestDLInternals
+import Testing
+
+@testable import RequestDL
+
+struct NetworkAvailabilityErrorTests {
+
+    @Test(arguments: [
+        (Internals.NetworkPathUnsatisfiedError.Reason.noConnection, NetworkAvailabilityError.Reason.noConnection),
+        (.cellularNotAllowed, .cellularNotAllowed),
+        (.expensiveNotAllowed, .expensiveNotAllowed),
+        (.constrainedNotAllowed, .constrainedNotAllowed),
+    ])
+    func error_whenInitFromInternalError_shouldMapReason(
+        _ pair: (Internals.NetworkPathUnsatisfiedError.Reason, NetworkAvailabilityError.Reason)
+    ) async throws {
+        // Given
+        let internalError = Internals.NetworkPathUnsatisfiedError(
+            reason: pair.0,
+            waitedForConnectivity: true
+        )
+
+        // When
+        let sut = NetworkAvailabilityError(internalError)
+
+        // Then
+        #expect(sut.reason == pair.1)
+        #expect(sut.waitedForConnectivity)
+    }
+
+    @Test
+    func error_whenNotWaitedForConnectivity_shouldPropagateFlag() async throws {
+        // Given
+        let internalError = Internals.NetworkPathUnsatisfiedError(
+            reason: .cellularNotAllowed,
+            waitedForConnectivity: false
+        )
+
+        // When
+        let sut = NetworkAvailabilityError(internalError)
+
+        // Then
+        #expect(!sut.waitedForConnectivity)
+    }
+}

--- a/Tests/RequestDLTests/Properties/Sources/Session/Session/SessionTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Session/Session/SessionTests.swift
@@ -32,6 +32,12 @@ struct SessionTests {
             String(describing: sut.decompression) == String(describing: configuration.decompression)
         )
         #expect(sut.connectionPool == configuration.connectionPool)
+        #expect(sut.allowsCellularAccess == nil)
+        #expect(sut.allowsExpensiveNetworkAccess == nil)
+        #expect(sut.allowsConstrainedNetworkAccess == nil)
+        #expect(sut.waitsForConnectivity == nil)
+        #expect(sut.multipathServiceType == .none)
+        #expect(sut.networkPathConstraints == nil)
     }
 
     @Test
@@ -83,9 +89,67 @@ struct SessionTests {
         let resolved = try await resolve(TestProperty { property })
 
         // Then
-        #expect(
-            try resolved.session.configuration.build().networkFrameworkWaitForConnectivity == waitsForConnectivity
-        )
+        #expect(resolved.session.configuration.waitsForConnectivity == waitsForConnectivity)
+    }
+
+    @Test
+    func session_whenAllowsCellularAccess_shouldBeValid() async throws {
+        // Given
+        let allowsCellularAccess = false
+
+        let property = Session()
+            .allowsCellularAccess(allowsCellularAccess)
+
+        // When
+        let resolved = try await resolve(TestProperty { property })
+
+        // Then
+        #expect(resolved.session.configuration.allowsCellularAccess == allowsCellularAccess)
+    }
+
+    @Test
+    func session_whenAllowsExpensiveNetworkAccess_shouldBeValid() async throws {
+        // Given
+        let allowsExpensiveNetworkAccess = false
+
+        let property = Session()
+            .allowsExpensiveNetworkAccess(allowsExpensiveNetworkAccess)
+
+        // When
+        let resolved = try await resolve(TestProperty { property })
+
+        // Then
+        #expect(resolved.session.configuration.allowsExpensiveNetworkAccess == allowsExpensiveNetworkAccess)
+    }
+
+    @Test
+    func session_whenAllowsConstrainedNetworkAccess_shouldBeValid() async throws {
+        // Given
+        let allowsConstrainedNetworkAccess = false
+
+        let property = Session()
+            .allowsConstrainedNetworkAccess(allowsConstrainedNetworkAccess)
+
+        // When
+        let resolved = try await resolve(TestProperty { property })
+
+        // Then
+        #expect(resolved.session.configuration.allowsConstrainedNetworkAccess == allowsConstrainedNetworkAccess)
+    }
+
+    @Test
+    func session_whenMultipathServiceType_shouldBeValid() async throws {
+        // Given
+        let multipathServiceType = Session.MultipathServiceType.handover
+
+        let property = Session()
+            .multipathServiceType(multipathServiceType)
+
+        // When
+        let resolved = try await resolve(TestProperty { property })
+
+        // Then
+        #expect(resolved.session.configuration.multipathServiceType == multipathServiceType.build())
     }
 
     @Test
@@ -302,6 +366,6 @@ struct SessionTests {
 
         // Then
         #expect(resolved.session.configuration.decompression == .enabled(.size(200)))
-        #expect(resolved.session.configuration.networkFrameworkWaitForConnectivity == true)
+        #expect(resolved.session.configuration.waitsForConnectivity == true)
     }
 }


### PR DESCRIPTION
## Summary

- Adds `Session.allowsCellularAccess(_:)`, `.allowsExpensiveNetworkAccess(_:)`, `.allowsConstrainedNetworkAccess(_:)`, and `.multipathServiceType(_:)`, mirroring `URLSessionConfiguration`'s equivalents and closing the remaining scope of [discussion #191](https://github.com/orgs/request-dl/discussions/191).
- AsyncHTTPClient has no hook to configure the underlying `NWParameters` for the first three — two upstream PRs proposing it ([swift-server/async-http-client#915](https://github.com/swift-server/async-http-client/pull/915), [#918](https://github.com/swift-server/async-http-client/pull/918)) were both closed with no path forward — so RequestDL now enforces them itself with a pre-flight `NWPathMonitor` check run once, immediately before a request is dispatched (`Internals.NetworkPathGate`, Darwin-only, no-op elsewhere). This is genuine parity with `URLSession`, not an approximation: `waitsForConnectivity`/`taskIsWaitingForConnectivity` only ever cover a task's *initial* connection phase — a network change mid-transfer surfaces as an ordinary error there too, never a retry.
- `waitsForConnectivity(_:)` is internalized onto this same gate. Previously it was a straight forward to AsyncHTTPClient's own `networkFrameworkWaitForConnectivity` field, which only took effect on NIOTransportServices; it now works uniformly across every executor. This is a behavior change for existing callers of this pre-existing API, not just an addition.
- `multipathServiceType` is simpler: AsyncHTTPClient already exposes a plain `enableMultipath: Bool`, so it's a direct forward (`enableMultipath = type != .none`), no gate involved. Lossy versus `URLSessionConfiguration`'s handover/interactive/aggregate distinction — accepted, matches the project's existing "coarser but functional" pattern where AsyncHTTPClient can't carry full fidelity.
- Defaults match `URLSessionConfiguration`'s own defaults (all three access flags permissive/`true`, `multipathServiceType = .none`, `waitsForConnectivity = false`), and the gate costs nothing (no `NWPathMonitor` started) for sessions that never touch this API.

## Test plan

- [x] `swift build` — full package, all targets
- [x] `swift test` — full suite: 807 + 344 tests, 0 failures
- [x] New unit tests for `Internals.NetworkPathGate` (satisfied/violated/waiting/cancellation, via an injectable `NetworkPathObserving` fake — no real network changes needed)
- [x] New Darwin-only tests for `Internals.NetworkPathMonitor` (singleton identity, immediate snapshot replay, concurrent subscribers)
- [x] New tests for `Session`'s four modifiers, `Internals.Session.Configuration`'s `enableMultipath` forward and `networkPathConstraints` short-circuit, and the `NetworkAvailabilityError` reason mapping
- [ ] Manual smoke test (not automatable — real network path changes can't be simulated in CI): toggle Wi-Fi with `Session().allowsCellularAccess(false)` / `.waitsForConnectivity(true)` against a real endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)