### PR TITLE
Add BackgroundDownloadTask for URLSession background transfers

### DIFF
--- a/Sources/RequestDL/Documentation.docc/Advanced/Downloading-in-the-Background.md
+++ b/Sources/RequestDL/Documentation.docc/Advanced/Downloading-in-the-Background.md
@@ -59,10 +59,17 @@ func application(
 
 This is required, not optional — without it, a download that finishes while your app is suspended or not running has no way to reconnect and report back through ``BackgroundDownloads/onEvent``.
 
+## Cancelling a download
+
+```swift
+let wasRunning = await BackgroundDownloads.cancel(id: "episode-42")
+```
+
+There's no separate "cancelled" case in ``BackgroundDownloads/Event`` — a cancelled download is reported through ``BackgroundDownloads/onEvent`` as an ordinary `.failed` event, with `NSURLErrorCancelled` as its underlying error, the same way any other failure is. ``BackgroundDownloads/cancel(id:)`` returns `false` when there's nothing to cancel — the download already finished, failed, or never existed under that `id`.
+
 ## What's not supported yet
 
 - **``SecureConnection``.** A request configured with one throws ``BackgroundDownloadUnsupportedConfigurationError`` before it's ever scheduled. A background download's delegate can be asked to answer a TLS challenge long after the process that built the original request is gone, with no `Property` tree left to rebuild a client identity or custom trust roots from — that gap isn't closed yet, so it's rejected up front rather than left to fail unpredictably after a relaunch.
-- **Cancellation.** There's no `BackgroundDownloadTask.cancel(id:)` yet.
 - **Modifiers and interceptors.** ``BackgroundDownloadTask`` does not conform to ``RequestTask`` — its result doesn't arrive in-process the way every modifier/interceptor assumes.
 
 ## Topics
@@ -71,7 +78,7 @@ This is required, not optional — without it, a download that finishes while yo
 
 - ``BackgroundDownloadTask``
 
-### Observing events
+### Observing and managing downloads
 
 - ``BackgroundDownloads``
 - ``BackgroundDownloads/Event``

--- a/Sources/RequestDL/Documentation.docc/Advanced/Downloading-in-the-Background.md
+++ b/Sources/RequestDL/Documentation.docc/Advanced/Downloading-in-the-Background.md
@@ -67,9 +67,30 @@ let wasRunning = await BackgroundDownloads.cancel(id: "episode-42")
 
 There's no separate "cancelled" case in ``BackgroundDownloads/Event`` — a cancelled download is reported through ``BackgroundDownloads/onEvent`` as an ordinary `.failed` event, with `NSURLErrorCancelled` as its underlying error, the same way any other failure is. ``BackgroundDownloads/cancel(id:)`` returns `false` when there's nothing to cancel — the download already finished, failed, or never existed under that `id`.
 
+## Trusting a specific server certificate
+
+``TrustRoots``, ``AdditionalTrustRoots``, and ``SecureConnection/verification(_:)`` all work exactly as they do with ``DownloadTask``:
+
+```swift
+try await BackgroundDownloadTask(
+    id: "episode-42",
+    destination: episodesDirectory.appendingPathComponent("episode-42.mp3")
+) {
+    BaseURL("api.example.com")
+    Path("episodes/42/audio")
+
+    SecureConnection {
+        TrustRoots(certificateURL)
+    }
+}
+.result()
+```
+
+None of these need a Keychain round-trip to survive a relaunch — only the certificate bytes themselves, which travel alongside `id`/`destination` in the scheduled task's own state, the same way. A **client certificate** (mTLS) is different: see ``BackgroundDownloadUnsupportedConfigurationError`` for why that's still rejected.
+
 ## What's not supported yet
 
-- **``SecureConnection``.** A request configured with one throws ``BackgroundDownloadUnsupportedConfigurationError`` before it's ever scheduled. A background download's delegate can be asked to answer a TLS challenge long after the process that built the original request is gone, with no `Property` tree left to rebuild a client identity or custom trust roots from — that gap isn't closed yet, so it's rejected up front rather than left to fail unpredictably after a relaunch.
+- **A client certificate (mTLS).** A request configured with `Certificates`/`PrivateKey` throws ``BackgroundDownloadUnsupportedConfigurationError`` before it's ever scheduled — presenting one needs a `SecIdentity` built via a Keychain round-trip, which would have to be redone from scratch after a relaunch, and isn't implemented yet.
 - **Modifiers and interceptors.** ``BackgroundDownloadTask`` does not conform to ``RequestTask`` — its result doesn't arrive in-process the way every modifier/interceptor assumes.
 
 ## Topics

--- a/Sources/RequestDL/Documentation.docc/Advanced/Downloading-in-the-Background.md
+++ b/Sources/RequestDL/Documentation.docc/Advanced/Downloading-in-the-Background.md
@@ -86,11 +86,32 @@ try await BackgroundDownloadTask(
 .result()
 ```
 
-None of these need a Keychain round-trip to survive a relaunch — only the certificate bytes themselves, which travel alongside `id`/`destination` in the scheduled task's own state, the same way. A **client certificate** (mTLS) is different: see ``BackgroundDownloadUnsupportedConfigurationError`` for why that's still rejected.
+None of these need a Keychain round-trip to survive a relaunch — only the certificate bytes themselves, which travel alongside `id`/`destination` in the scheduled task's own state, the same way.
+
+## Presenting a client certificate (mTLS)
+
+Works too, as long as both ``Certificate`` and ``PrivateKey`` come from a **file path**, not in-memory bytes:
+
+```swift
+try await BackgroundDownloadTask(
+    id: "episode-42",
+    destination: episodesDirectory.appendingPathComponent("episode-42.mp3")
+) {
+    BaseURL("api.example.com")
+    Path("episodes/42/audio")
+
+    SecureConnection {
+        Certificates(certificateFileURL.absolutePath(percentEncoded: false))
+        PrivateKey(privateKeyFileURL.absolutePath(percentEncoded: false))
+    }
+}
+.result()
+```
+
+Only the file path is persisted alongside `id`/`destination` — never the key material itself. The identity is rebuilt from that file via a fresh Keychain round-trip on every challenge, live or after a relaunch alike, the same way it would be for a foreground request. This is exactly why the path has to be stable: a certificate/key backed by in-memory bytes has nothing left to rebuild from once the process that held them is gone. See ``BackgroundDownloadUnsupportedConfigurationError`` for the specific cases that still aren't supported (in-memory bytes, a pre-built certificate, or a password-protected private key).
 
 ## What's not supported yet
 
-- **A client certificate (mTLS).** A request configured with `Certificates`/`PrivateKey` throws ``BackgroundDownloadUnsupportedConfigurationError`` before it's ever scheduled — presenting one needs a `SecIdentity` built via a Keychain round-trip, which would have to be redone from scratch after a relaunch, and isn't implemented yet.
 - **Modifiers and interceptors.** ``BackgroundDownloadTask`` does not conform to ``RequestTask`` — its result doesn't arrive in-process the way every modifier/interceptor assumes.
 
 ## Topics

--- a/Sources/RequestDL/Documentation.docc/Advanced/Downloading-in-the-Background.md
+++ b/Sources/RequestDL/Documentation.docc/Advanced/Downloading-in-the-Background.md
@@ -1,0 +1,81 @@
+# Downloading in the background
+
+Schedule a download that keeps running even if your app is suspended or terminated, using `URLSession`'s background transfer support.
+
+## Overview
+
+``DownloadTask`` waits for a response and hands it back in the same call. ``BackgroundDownloadTask`` can't work that way: the whole point of a background transfer is that it can outlive the process that started it, possibly finishing in a completely different launch of your app. ``BackgroundDownloadTask/result()`` only confirms the download was scheduled — it returns as soon as that happens, not when the file is actually there.
+
+```swift
+try await BackgroundDownloadTask(
+    id: "episode-42",
+    destination: episodesDirectory.appendingPathComponent("episode-42.mp3")
+) {
+    BaseURL("api.example.com")
+    Path("episodes/42/audio")
+}
+.result()
+```
+
+`id` is yours to choose — it's how you tell this download apart from every other one in ``BackgroundDownloads/Event``, described below. `destination` is where the file ends up; anything already there is overwritten once the download finishes.
+
+## Observing progress and completion
+
+Because the call site that scheduled a download might not exist anymore by the time it finishes, there's no per-call completion handler or `async` sequence to await. Instead, register one handler for every background download in the app:
+
+```swift
+BackgroundDownloads.onEvent = { event in
+    switch event {
+    case .progress(let id, _, let bytesWritten, let totalBytesExpected):
+        print("\(id): \(bytesWritten)/\(totalBytesExpected)")
+    case .completed(let id, let destination):
+        print("\(id) finished at \(destination)")
+    case .failed(let id, _, let error):
+        print("\(id) failed: \(error)")
+    }
+}
+```
+
+Set this once, as early as possible — ideally before your app finishes launching, and unconditionally on every launch, including one the system triggered only to deliver background events, where there's no user-visible UI yet for those events to update.
+
+> Note: ``BackgroundDownloads`` is deliberately not part of ``BackgroundDownloadTask`` itself. A generic type's static members are per-specialization in Swift, and every `BackgroundDownloadTask<Content>` call site has its own concrete `Content` — a handler stored there would only ever see downloads created with that exact `Content` type.
+
+## Reconnecting after a relaunch
+
+For the system to be able to reconnect a background session to a suspended or relaunched app, forward `application(_:handleEventsForBackgroundURLSession:completionHandler:)` from your `UIApplicationDelegate`:
+
+```swift
+func application(
+    _ application: UIApplication,
+    handleEventsForBackgroundURLSession identifier: String,
+    completionHandler: @escaping () -> Void
+) {
+    BackgroundDownloads.handleEvents(
+        forBackgroundURLSession: identifier,
+        completionHandler: completionHandler
+    )
+}
+```
+
+This is required, not optional — without it, a download that finishes while your app is suspended or not running has no way to reconnect and report back through ``BackgroundDownloads/onEvent``.
+
+## What's not supported yet
+
+- **``SecureConnection``.** A request configured with one throws ``BackgroundDownloadUnsupportedConfigurationError`` before it's ever scheduled. A background download's delegate can be asked to answer a TLS challenge long after the process that built the original request is gone, with no `Property` tree left to rebuild a client identity or custom trust roots from — that gap isn't closed yet, so it's rejected up front rather than left to fail unpredictably after a relaunch.
+- **Cancellation.** There's no `BackgroundDownloadTask.cancel(id:)` yet.
+- **Modifiers and interceptors.** ``BackgroundDownloadTask`` does not conform to ``RequestTask`` — its result doesn't arrive in-process the way every modifier/interceptor assumes.
+
+## Topics
+
+### Scheduling a download
+
+- ``BackgroundDownloadTask``
+
+### Observing events
+
+- ``BackgroundDownloads``
+- ``BackgroundDownloads/Event``
+
+### Errors
+
+- ``BackgroundDownloadUnsupportedConfigurationError``

--- a/Sources/RequestDL/Documentation.docc/Essentials/Executing the Request/For Everybody/Exploring-task.md
+++ b/Sources/RequestDL/Documentation.docc/Essentials/Executing the Request/For Everybody/Exploring-task.md
@@ -150,6 +150,10 @@ struct OfflineError: Error {}
 let task = MockedTask(throwing: OfflineError(), delay: .seconds(1))
 ```
 
+### BackgroundDownloadTask
+
+Every task above runs and reports back in the same process. ``RequestDL/BackgroundDownloadTask`` is different on purpose: it schedules a download that keeps running even if your app is suspended or terminated, using `URLSession`'s background transfer support, and does not conform to ``RequestDL/RequestTask``. See <doc:Downloading-in-the-Background> for how to schedule one and observe when it finishes.
+
 ## Topics
 
 ### The basics
@@ -194,3 +198,7 @@ let task = MockedTask(throwing: OfflineError(), delay: .seconds(1))
 ### Testing and debugging
 
 - ``RequestDL/MockedTask``
+
+### Downloading in the background
+
+- <doc:Downloading-in-the-Background>

--- a/Sources/RequestDL/Documentation.docc/RequestDL.md
+++ b/Sources/RequestDL/Documentation.docc/RequestDL.md
@@ -78,6 +78,7 @@ try await DataTask {
 - [x] [Swift Concurrency](<doc:Swift-concurrency>);
 - [x] [Combine support](<doc:Exploring-combine>) (Apple platforms only);
 - [x] [Image loading for SwiftUI, UIKit, AppKit and watchOS](<doc:Loading-images>) (Apple platforms only);
+- [x] [Downloading in the background](<doc:Downloading-in-the-Background>) (Apple platforms only);
 
 We are excited to expand this list with many other features. Start by making your contribution in [Discussions](https://github.com/orgs/request-dl/discussions) or by opening a PR (Pull Request).
 
@@ -97,3 +98,4 @@ We are excited to expand this list with many other features. Start by making you
 
 - <doc:Request-Customization>
 - <doc:Using-a-Client-Certificate-with-URLSession>
+- <doc:Downloading-in-the-Background>

--- a/Sources/RequestDL/Tasks/Sources/Background Download/BackgroundDownloadTask.swift
+++ b/Sources/RequestDL/Tasks/Sources/Background Download/BackgroundDownloadTask.swift
@@ -1,0 +1,93 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+#if canImport(Darwin)
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import struct Foundation.URL
+#endif
+
+/// Schedules a download that keeps running even if the app is suspended or terminated, via
+/// `URLSession`'s background transfer support.
+///
+/// Unlike ``DownloadTask``, ``result()`` does not wait for the download to finish -- it can't:
+/// the transfer may complete long after this call returns, in a different process launch
+/// entirely. Register ``BackgroundDownloads/onEvent`` to be told when it actually completes,
+/// fails, or makes progress, and forward
+/// `application(_:handleEventsForBackgroundURLSession:completionHandler:)` to
+/// ``BackgroundDownloads/handleEvents(forBackgroundURLSession:completionHandler:)`` for the
+/// system to be able to reconnect to it after a relaunch.
+///
+/// ```swift
+/// try await BackgroundDownloadTask(
+///     id: "episode-42",
+///     destination: episodesDirectory.appendingPathComponent("episode-42.mp3")
+/// ) {
+///     BaseURL("api.example.com")
+///     Path("episodes/42/audio")
+/// }
+/// .result()
+/// ```
+///
+/// `content` cannot configure a ``SecureConnection`` -- see
+/// ``BackgroundDownloadUnsupportedConfigurationError`` for why.
+public struct BackgroundDownloadTask<Content: Property> {
+
+    // MARK: - Private properties
+
+    private let id: String
+    private let destination: URL
+    private let content: Content
+
+    // MARK: - Inits
+
+    /// - Parameters:
+    ///   - id: Identifies this download in every ``BackgroundDownloads/Event`` it produces.
+    ///     Not the `URLSession` background session identifier, which RequestDL manages
+    ///     internally -- this is only ever your own correlation key.
+    ///   - destination: Where the downloaded file ends up. Overwrites anything already there
+    ///     once the download completes.
+    ///   - content: The request to make, exactly as with any other task.
+    public init(
+        id: String,
+        destination: URL,
+        @PropertyBuilder content: () -> Content
+    ) {
+        self.id = id
+        self.destination = destination
+        self.content = content()
+    }
+
+    // MARK: - Public methods
+
+    /// Resolves `content` and schedules the download. Returns as soon as it's scheduled --
+    /// use ``BackgroundDownloads/onEvent`` to observe how it turns out.
+    ///
+    /// - Throws: ``BackgroundDownloadUnsupportedConfigurationError`` if `content` configures a
+    ///   ``SecureConnection``, or any error `content` itself throws while being resolved into a
+    ///   request (an invalid URL, a certificate file that can't be read for an otherwise-unrelated
+    ///   property, etc.) -- the same errors any other task can throw at this stage.
+    public func result() async throws {
+        let resolved = try await Resolve(
+            root: content,
+            environment: RequestEnvironmentValues.current
+        ).build()
+
+        guard resolved.session.configuration.secureConnection == nil else {
+            throw BackgroundDownloadUnsupportedConfigurationError()
+        }
+
+        let request = try resolved.requestConfiguration.buildURLRequestWithoutBody()
+
+        BackgroundDownloads.Session.shared.schedule(
+            request: request,
+            id: id,
+            destination: destination
+        )
+    }
+}
+
+#endif

--- a/Sources/RequestDL/Tasks/Sources/Background Download/BackgroundDownloadTask.swift
+++ b/Sources/RequestDL/Tasks/Sources/Background Download/BackgroundDownloadTask.swift
@@ -35,10 +35,11 @@ import struct Foundation.URL
 /// ```
 ///
 /// `content` can configure ``TrustRoots``/``AdditionalTrustRoots``/``SecureConnection/verification(_:)``
-/// -- none of them need a Keychain round-trip to survive a relaunch, only the certificate bytes
-/// themselves, which travel alongside `id`/`destination` in the scheduled task's own state. A
-/// client certificate (mTLS) is different: see ``BackgroundDownloadUnsupportedConfigurationError``
-/// for why that's still rejected.
+/// freely -- none of them need a Keychain round-trip to survive a relaunch, only the certificate
+/// bytes themselves, which travel alongside `id`/`destination` in the scheduled task's own state.
+/// A client certificate (mTLS) works too, as long as both ``Certificate`` and ``PrivateKey`` come
+/// from a **file path**, not in-memory bytes -- see ``BackgroundDownloadUnsupportedConfigurationError``
+/// for the specific cases that still aren't supported.
 public struct BackgroundDownloadTask<Content: Property> {
 
     // MARK: - Private properties
@@ -72,9 +73,10 @@ public struct BackgroundDownloadTask<Content: Property> {
     /// use ``BackgroundDownloads/onEvent`` to observe how it turns out.
     ///
     /// - Throws: ``BackgroundDownloadUnsupportedConfigurationError`` if `content` configures a
-    ///   client certificate (mTLS), or any error `content` itself throws while being resolved
-    ///   into a request (an invalid URL, a certificate file that can't be read, etc.) -- the same
-    ///   errors any other task can throw at this stage.
+    ///   client certificate this executor can't rebuild after a relaunch (see its own
+    ///   documentation for the specific cases), or any error `content` itself throws while being
+    ///   resolved into a request (an invalid URL, a certificate file that can't be read, etc.) --
+    ///   the same errors any other task can throw at this stage.
     public func result() async throws {
         let resolved = try await Resolve(
             root: content,
@@ -82,12 +84,16 @@ public struct BackgroundDownloadTask<Content: Property> {
         ).build()
 
         let serverTrust = try resolved.session.configuration.secureConnection.map {
-            (secureConnection: Internals.SecureConnection) -> Internals.ServerTrustPolicy.Descriptor in
-            guard secureConnection.certificateChain == nil, secureConnection.privateKey == nil else {
-                throw BackgroundDownloadUnsupportedConfigurationError()
-            }
+            try Internals.ServerTrustPolicy.resolve(from: $0).descriptor
+        }
 
-            return try Internals.ServerTrustPolicy.resolve(from: secureConnection).descriptor
+        let clientIdentity: Internals.ClientIdentityDescriptor?
+        do {
+            clientIdentity = try resolved.session.configuration.secureConnection.flatMap {
+                try Internals.ClientIdentityDescriptor.resolve(from: $0)
+            }
+        } catch let error as Internals.ClientIdentityDescriptor.ResolutionError {
+            throw BackgroundDownloadUnsupportedConfigurationError(error)
         }
 
         let request = try resolved.requestConfiguration.buildURLRequestWithoutBody()
@@ -96,7 +102,8 @@ public struct BackgroundDownloadTask<Content: Property> {
             request: request,
             id: id,
             destination: destination,
-            serverTrust: serverTrust
+            serverTrust: serverTrust,
+            clientIdentity: clientIdentity
         )
     }
 }

--- a/Sources/RequestDL/Tasks/Sources/Background Download/BackgroundDownloadTask.swift
+++ b/Sources/RequestDL/Tasks/Sources/Background Download/BackgroundDownloadTask.swift
@@ -4,6 +4,8 @@
 
 #if canImport(Darwin)
 
+import RequestDLInternals
+
 #if canImport(FoundationEssentials)
 import FoundationEssentials
 #else
@@ -32,8 +34,11 @@ import struct Foundation.URL
 /// .result()
 /// ```
 ///
-/// `content` cannot configure a ``SecureConnection`` -- see
-/// ``BackgroundDownloadUnsupportedConfigurationError`` for why.
+/// `content` can configure ``TrustRoots``/``AdditionalTrustRoots``/``SecureConnection/verification(_:)``
+/// -- none of them need a Keychain round-trip to survive a relaunch, only the certificate bytes
+/// themselves, which travel alongside `id`/`destination` in the scheduled task's own state. A
+/// client certificate (mTLS) is different: see ``BackgroundDownloadUnsupportedConfigurationError``
+/// for why that's still rejected.
 public struct BackgroundDownloadTask<Content: Property> {
 
     // MARK: - Private properties
@@ -67,17 +72,22 @@ public struct BackgroundDownloadTask<Content: Property> {
     /// use ``BackgroundDownloads/onEvent`` to observe how it turns out.
     ///
     /// - Throws: ``BackgroundDownloadUnsupportedConfigurationError`` if `content` configures a
-    ///   ``SecureConnection``, or any error `content` itself throws while being resolved into a
-    ///   request (an invalid URL, a certificate file that can't be read for an otherwise-unrelated
-    ///   property, etc.) -- the same errors any other task can throw at this stage.
+    ///   client certificate (mTLS), or any error `content` itself throws while being resolved
+    ///   into a request (an invalid URL, a certificate file that can't be read, etc.) -- the same
+    ///   errors any other task can throw at this stage.
     public func result() async throws {
         let resolved = try await Resolve(
             root: content,
             environment: RequestEnvironmentValues.current
         ).build()
 
-        guard resolved.session.configuration.secureConnection == nil else {
-            throw BackgroundDownloadUnsupportedConfigurationError()
+        let serverTrust = try resolved.session.configuration.secureConnection.map {
+            (secureConnection: Internals.SecureConnection) -> Internals.ServerTrustPolicy.Descriptor in
+            guard secureConnection.certificateChain == nil, secureConnection.privateKey == nil else {
+                throw BackgroundDownloadUnsupportedConfigurationError()
+            }
+
+            return try Internals.ServerTrustPolicy.resolve(from: secureConnection).descriptor
         }
 
         let request = try resolved.requestConfiguration.buildURLRequestWithoutBody()
@@ -85,7 +95,8 @@ public struct BackgroundDownloadTask<Content: Property> {
         BackgroundDownloads.Session.shared.schedule(
             request: request,
             id: id,
-            destination: destination
+            destination: destination,
+            serverTrust: serverTrust
         )
     }
 }

--- a/Sources/RequestDL/Tasks/Sources/Background Download/BackgroundDownloads.swift
+++ b/Sources/RequestDL/Tasks/Sources/Background Download/BackgroundDownloads.swift
@@ -74,6 +74,19 @@ public enum BackgroundDownloads {
     ) {
         Session.shared.handleEvents(forIdentifier: identifier, completionHandler: completionHandler)
     }
+
+    /// Cancels the ``BackgroundDownloadTask`` scheduled with this `id`, if it's still running.
+    ///
+    /// A cancelled download is reported through ``onEvent`` as an ordinary `.failed` event (the
+    /// underlying error is `NSURLErrorCancelled`), the same way any other failure is -- there is
+    /// no separate "was cancelled" event of its own.
+    ///
+    /// - Returns: `true` if a matching, still-running download was found and cancelled; `false`
+    ///   if none was -- it may have already finished, failed, or never existed.
+    @discardableResult
+    public static func cancel(id: String) async -> Bool {
+        await Session.shared.cancel(id: id)
+    }
 }
 
 #endif

--- a/Sources/RequestDL/Tasks/Sources/Background Download/BackgroundDownloads.swift
+++ b/Sources/RequestDL/Tasks/Sources/Background Download/BackgroundDownloads.swift
@@ -1,0 +1,79 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+#if canImport(Darwin)
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+
+/// Observes and integrates with every ``BackgroundDownloadTask`` in the process.
+///
+/// Deliberately not a member of ``BackgroundDownloadTask`` itself: a generic type's static
+/// storage is per-specialization in Swift, and every `BackgroundDownloadTask<Content>` call site
+/// has its own concrete `Content` -- a handler stored there would only ever see the downloads
+/// created with that exact `Content` type, not every download in the app. `BackgroundDownloads`
+/// is a plain, non-generic namespace specifically so there is exactly one of everything below,
+/// regardless of how many different `BackgroundDownloadTask<Content>` specializations exist.
+public enum BackgroundDownloads {
+
+    /// One thing that happened to a ``BackgroundDownloadTask``, identified by the `id` it was
+    /// created with.
+    public enum Event: Sendable {
+        /// `bytesWritten`/`totalBytesExpected` are the running totals for the whole download, not
+        /// the size of this particular callback -- matching
+        /// `URLSessionDownloadDelegate.urlSession(_:downloadTask:didWriteData:totalBytesWritten:totalBytesExpectedToWrite:)`.
+        case progress(id: String, destination: URL, bytesWritten: Int64, totalBytesExpected: Int64)
+
+        /// The file is already at `destination` by the time this fires -- moved there from
+        /// `URLSession`'s own temporary location before this event is ever produced.
+        case completed(id: String, destination: URL)
+
+        case failed(id: String, destination: URL, error: any Error)
+    }
+
+    /// Called for every event from every ``BackgroundDownloadTask`` in the process, on an
+    /// unspecified queue.
+    ///
+    /// Set this once, early -- ideally before any ``BackgroundDownloadTask`` is ever created,
+    /// and unconditionally on every launch, including a launch the system triggered only to
+    /// deliver background events (there is no user-visible UI at that point, but the events still
+    /// need somewhere to go).
+    public static var onEvent: (@Sendable (Event) -> Void)? {
+        get { Session.shared.onEvent }
+        set { Session.shared.onEvent = newValue }
+    }
+
+    /// Forwards `application(_:handleEventsForBackgroundURLSession:completionHandler:)` from the
+    /// app's own `UIApplicationDelegate`.
+    ///
+    /// Required for background downloads to work at all: this is how the system hands back the
+    /// identifier of the session it wants reconnected, and the completion handler that has to be
+    /// called once every queued event has actually been delivered to ``onEvent`` -- calling it
+    /// any earlier risks the system snapshotting the app before its state reflects what actually
+    /// finished.
+    ///
+    /// ```swift
+    /// func application(
+    ///     _ application: UIApplication,
+    ///     handleEventsForBackgroundURLSession identifier: String,
+    ///     completionHandler: @escaping () -> Void
+    /// ) {
+    ///     BackgroundDownloads.handleEvents(
+    ///         forBackgroundURLSession: identifier,
+    ///         completionHandler: completionHandler
+    ///     )
+    /// }
+    /// ```
+    public static func handleEvents(
+        forBackgroundURLSession identifier: String,
+        completionHandler: @escaping @Sendable () -> Void
+    ) {
+        Session.shared.handleEvents(forIdentifier: identifier, completionHandler: completionHandler)
+    }
+}
+
+#endif

--- a/Sources/RequestDL/Tasks/Sources/Background Download/Models/BackgroundDownloadUnsupportedConfigurationError.swift
+++ b/Sources/RequestDL/Tasks/Sources/Background Download/Models/BackgroundDownloadUnsupportedConfigurationError.swift
@@ -4,6 +4,8 @@
 
 #if canImport(Darwin)
 
+import RequestDLInternals
+
 #if canImport(FoundationEssentials)
 import FoundationEssentials
 #else
@@ -11,20 +13,61 @@ import protocol Foundation.LocalizedError
 #endif
 
 /// An error thrown when a ``BackgroundDownloadTask``'s content configures a client certificate
-/// (mTLS) -- ``SecureConnection``'s `certificateChain`/`privateKey`.
+/// (mTLS) -- ``SecureConnection``'s `certificateChain`/`privateKey` -- in a shape that can't
+/// survive a relaunch.
 ///
-/// A background download can outlive the process that started it -- the delegate answering a TLS
-/// challenge after the app relaunches has no access to the `Property` tree the request was
-/// originally built from, only to whatever survives on the `URLSessionTask` itself.
-/// `TrustRoots`/`AdditionalTrustRoots`/``SecureConnection/verification(_:)`` all survive that fine
-/// -- their certificate bytes travel with the scheduled task itself, the same way `id`/
-/// `destination` do. A client identity does not: presenting one needs a `SecIdentity` built via a
-/// Keychain round-trip, which would have to be redone from scratch after a relaunch, and isn't
-/// implemented yet -- so a request that needs one is rejected up front, rather than allowed to
-/// silently misbehave after the first relaunch.
+/// A background download can outlive the process that started it -- the delegate answering a
+/// client-certificate challenge after the app relaunches has no `Property` tree left to resolve
+/// `certificateChain`/`privateKey` from, only whatever was persisted alongside `id`/`destination`
+/// on the scheduled task itself. `Certificate`/`PrivateKey` backed by a **file path** work fine:
+/// the path is what's persisted, and the identity is rebuilt from that file via the same Keychain
+/// round-trip on every challenge, live or after a relaunch alike. What doesn't survive is
+/// anything that isn't a stable path on disk -- see ``Reason`` for the specific cases.
+///
+/// `TrustRoots`/`AdditionalTrustRoots`/``SecureConnection/verification(_:)`` are unaffected by any
+/// of this: their certificate bytes are public, so they're persisted directly rather than by
+/// path, and work regardless of how they were originally configured.
 public struct BackgroundDownloadUnsupportedConfigurationError: Error, Sendable {
 
-    init() {}
+    /// The specific reason a client certificate configuration can't be used in a background
+    /// download.
+    public enum Reason: Sendable {
+        /// Only one of `certificateChain`/`privateKey` was configured -- mTLS needs both.
+        case incompleteClientIdentity
+
+        /// `certificateChain` or `privateKey` came from in-memory bytes or a pre-built
+        /// certificate, not a file path. Only a file path is guaranteed to still be there to
+        /// re-read after a relaunch -- in-memory bytes are gone with the process that held them.
+        case nonFileBackedSource
+
+        /// The private key is password-protected. Decrypting it once and persisting the
+        /// decrypted bytes would defeat the point of the password; persisting the password
+        /// itself would mean storing a secret in the task's own state. Neither is done.
+        case passwordProtectedPrivateKey
+
+        // MARK: - Inits
+
+        init(_ reason: Internals.ClientIdentityDescriptor.ResolutionError) {
+            switch reason {
+            case .incompleteClientIdentity:
+                self = .incompleteClientIdentity
+            case .nonFileBackedSource:
+                self = .nonFileBackedSource
+            case .passwordProtectedPrivateKey:
+                self = .passwordProtectedPrivateKey
+            }
+        }
+    }
+
+    // MARK: - Public properties
+
+    public let reason: Reason
+
+    // MARK: - Inits
+
+    init(_ reason: Internals.ClientIdentityDescriptor.ResolutionError) {
+        self.reason = Reason(reason)
+    }
 }
 
 // MARK: - LocalizedError
@@ -41,13 +84,34 @@ extension BackgroundDownloadUnsupportedConfigurationError: LocalizedError {
 extension BackgroundDownloadUnsupportedConfigurationError: CustomStringConvertible {
 
     public var description: String {
-        """
-        BackgroundDownloadTask does not support a client certificate (mTLS) -- a background \
-        download can outlive the process that started it, and there is no way yet to rebuild a \
-        client identity via a Keychain round-trip after a relaunch. TrustRoots/AdditionalTrustRoots \
-        are supported; remove the client certificate/private key from this request, or use \
-        DownloadTask instead if it needs to run in the foreground.
-        """
+        "BackgroundDownloadTask can't use this client certificate configuration: \(reason.description)"
+    }
+}
+
+// MARK: - Reason.CustomStringConvertible
+
+extension BackgroundDownloadUnsupportedConfigurationError.Reason: CustomStringConvertible {
+
+    public var description: String {
+        switch self {
+        case .incompleteClientIdentity:
+            return "mTLS needs both a certificateChain and a privateKey configured on SecureConnection; only one was."
+        case .nonFileBackedSource:
+            return
+                """
+                certificateChain and privateKey must both come from a file path -- use \
+                Certificate(_:format:)/PrivateKey(_:format:) with a path, not in-memory bytes or a \
+                pre-built certificate. Only a path is guaranteed to still exist to rebuild the \
+                identity from after a relaunch.
+                """
+        case .passwordProtectedPrivateKey:
+            return
+                """
+                a password-protected private key can't be used here -- rebuilding the identity \
+                after a relaunch would need the password again, and neither the decrypted key nor \
+                the password itself is persisted. Use an unencrypted private key file instead.
+                """
+        }
     }
 }
 

--- a/Sources/RequestDL/Tasks/Sources/Background Download/Models/BackgroundDownloadUnsupportedConfigurationError.swift
+++ b/Sources/RequestDL/Tasks/Sources/Background Download/Models/BackgroundDownloadUnsupportedConfigurationError.swift
@@ -10,15 +10,18 @@ import FoundationEssentials
 import protocol Foundation.LocalizedError
 #endif
 
-/// An error thrown when a ``BackgroundDownloadTask``'s content configures a ``SecureConnection``.
+/// An error thrown when a ``BackgroundDownloadTask``'s content configures a client certificate
+/// (mTLS) -- ``SecureConnection``'s `certificateChain`/`privateKey`.
 ///
 /// A background download can outlive the process that started it -- the delegate answering a TLS
 /// challenge after the app relaunches has no access to the `Property` tree the request was
-/// originally built from, only to whatever survives on the `URLSessionTask` itself. Rebuilding a
-/// client identity (mTLS) would need a Keychain round-trip redone from scratch at relaunch time,
-/// and rebuilding custom trust roots would need their source files re-resolved independently of
-/// any in-memory state -- neither is implemented yet, so a request that needs either is rejected
-/// up front rather than allowed to silently misbehave after the first relaunch.
+/// originally built from, only to whatever survives on the `URLSessionTask` itself.
+/// `TrustRoots`/`AdditionalTrustRoots`/``SecureConnection/verification(_:)`` all survive that fine
+/// -- their certificate bytes travel with the scheduled task itself, the same way `id`/
+/// `destination` do. A client identity does not: presenting one needs a `SecIdentity` built via a
+/// Keychain round-trip, which would have to be redone from scratch after a relaunch, and isn't
+/// implemented yet -- so a request that needs one is rejected up front, rather than allowed to
+/// silently misbehave after the first relaunch.
 public struct BackgroundDownloadUnsupportedConfigurationError: Error, Sendable {
 
     init() {}
@@ -39,10 +42,11 @@ extension BackgroundDownloadUnsupportedConfigurationError: CustomStringConvertib
 
     public var description: String {
         """
-        BackgroundDownloadTask does not support SecureConnection -- a background download can \
-        outlive the process that started it, and there is no way yet to rebuild a client \
-        identity or custom trust roots after a relaunch. Remove SecureConnection from this \
-        request, or use DownloadTask instead if it needs to run in the foreground.
+        BackgroundDownloadTask does not support a client certificate (mTLS) -- a background \
+        download can outlive the process that started it, and there is no way yet to rebuild a \
+        client identity via a Keychain round-trip after a relaunch. TrustRoots/AdditionalTrustRoots \
+        are supported; remove the client certificate/private key from this request, or use \
+        DownloadTask instead if it needs to run in the foreground.
         """
     }
 }

--- a/Sources/RequestDL/Tasks/Sources/Background Download/Models/BackgroundDownloadUnsupportedConfigurationError.swift
+++ b/Sources/RequestDL/Tasks/Sources/Background Download/Models/BackgroundDownloadUnsupportedConfigurationError.swift
@@ -1,0 +1,50 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+#if canImport(Darwin)
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import protocol Foundation.LocalizedError
+#endif
+
+/// An error thrown when a ``BackgroundDownloadTask``'s content configures a ``SecureConnection``.
+///
+/// A background download can outlive the process that started it -- the delegate answering a TLS
+/// challenge after the app relaunches has no access to the `Property` tree the request was
+/// originally built from, only to whatever survives on the `URLSessionTask` itself. Rebuilding a
+/// client identity (mTLS) would need a Keychain round-trip redone from scratch at relaunch time,
+/// and rebuilding custom trust roots would need their source files re-resolved independently of
+/// any in-memory state -- neither is implemented yet, so a request that needs either is rejected
+/// up front rather than allowed to silently misbehave after the first relaunch.
+public struct BackgroundDownloadUnsupportedConfigurationError: Error, Sendable {
+
+    init() {}
+}
+
+// MARK: - LocalizedError
+
+extension BackgroundDownloadUnsupportedConfigurationError: LocalizedError {
+
+    public var errorDescription: String? {
+        description
+    }
+}
+
+// MARK: - CustomStringConvertible
+
+extension BackgroundDownloadUnsupportedConfigurationError: CustomStringConvertible {
+
+    public var description: String {
+        """
+        BackgroundDownloadTask does not support SecureConnection -- a background download can \
+        outlive the process that started it, and there is no way yet to rebuild a client \
+        identity or custom trust roots after a relaunch. Remove SecureConnection from this \
+        request, or use DownloadTask instead if it needs to run in the foreground.
+        """
+    }
+}
+
+#endif

--- a/Sources/RequestDL/Tasks/Sources/Background Download/Models/BackgroundDownloads.Session.swift
+++ b/Sources/RequestDL/Tasks/Sources/Background Download/Models/BackgroundDownloads.Session.swift
@@ -31,8 +31,6 @@ extension BackgroundDownloads {
 
         static let shared = Session()
 
-        // MARK: - Internal static properties
-
         /// Stable across launches (same bundle, same string every time) -- required for the
         /// system to reconnect this session to tasks that outlived a previous process. Not
         /// `private` -- `handleEvents(forIdentifier:completionHandler:)`'s identifier-matching
@@ -81,6 +79,37 @@ extension BackgroundDownloads {
             // identifier is what makes the system replay queued delegate callbacks -- there is no
             // separate "reconnect" call.
             _ = urlSession()
+        }
+
+        /// Cancels the download with this `id`, if one is currently running.
+        ///
+        /// No index of `id` -> `URLSessionTask` is kept around -- there is nowhere safe to keep
+        /// one that would still be valid after a relaunch anyway, since a fresh process starts
+        /// with nothing in memory. `allTasks` is the system's own live answer instead, always
+        /// asked fresh: cheap enough for something that only runs when a caller explicitly asks
+        /// to cancel something, not on any hot path.
+        ///
+        /// Cancelling a `URLSessionTask` this way makes it fail with `NSURLErrorCancelled`
+        /// shortly after, through the ordinary `didCompleteWithError` callback below -- so a
+        /// cancellation is reported through ``BackgroundDownloads/onEvent`` as an ordinary
+        /// `.failed` event, not a distinct case of its own.
+        ///
+        /// - Returns: `true` if a matching, still-running download was found and cancelled;
+        /// `false` if none was (already finished, never existed, or no download has ever been
+        /// scheduled in this process at all -- checked without creating a session just to find
+        /// out, since there would be nothing in it to cancel either way).
+        @discardableResult
+        func cancel(id: String) async -> Bool {
+            guard let urlSession = lock.withLock({ _urlSession }) else {
+                return false
+            }
+
+            guard let match = Self.firstTask(matching: id, in: await urlSession.allTasks) else {
+                return false
+            }
+
+            match.cancel()
+            return true
         }
 
         // MARK: - Private methods
@@ -197,6 +226,16 @@ extension BackgroundDownloads {
             }
 
             return (descriptor.id, descriptor.destination)
+        }
+
+        // MARK: - Task matching
+
+        /// The pure part of ``cancel(id:)`` -- picking the right task out of a list -- pulled out
+        /// on its own specifically so it's testable without a real background `URLSession` to ask
+        /// `allTasks` of. A task with no `taskDescription`, or one this type didn't encode, simply
+        /// never matches, the same way `decode(_:)`'s callers already treat it elsewhere.
+        static func firstTask(matching id: String, in tasks: [URLSessionTask]) -> URLSessionTask? {
+            tasks.first { decode($0.taskDescription)?.id == id }
         }
     }
 }

--- a/Sources/RequestDL/Tasks/Sources/Background Download/Models/BackgroundDownloads.Session.swift
+++ b/Sources/RequestDL/Tasks/Sources/Background Download/Models/BackgroundDownloads.Session.swift
@@ -4,6 +4,7 @@
 
 #if canImport(Darwin)
 
+import RequestDLInternals
 import SwiftAsyncStream
 
 #if canImport(FoundationEssentials)
@@ -56,9 +57,14 @@ extension BackgroundDownloads {
 
         // MARK: - Internal methods
 
-        func schedule(request: URLRequest, id: String, destination: URL) {
+        func schedule(
+            request: URLRequest,
+            id: String,
+            destination: URL,
+            serverTrust: Internals.ServerTrustPolicy.Descriptor? = nil
+        ) {
             let task = urlSession().downloadTask(with: request)
-            task.taskDescription = Self.encode(id: id, destination: destination)
+            task.taskDescription = Self.encode(id: id, destination: destination, serverTrust: serverTrust)
             task.resume()
         }
 
@@ -125,6 +131,28 @@ extension BackgroundDownloads {
                 _urlSession = urlSession
                 return urlSession
             }
+        }
+
+        // MARK: - URLSessionTaskDelegate
+
+        /// Not part of `URLSessionDownloadDelegate` itself -- `URLSessionTaskDelegate`, which
+        /// `URLSessionDownloadDelegate` already inherits from, so no extra protocol conformance
+        /// is needed to implement it. A task with no persisted `serverTrust` (the common case:
+        /// plain HTTPS, system trust) defers to the system's own default handling, exactly the
+        /// behavior this method not existing at all already had before this existed.
+        func urlSession(
+            _ session: URLSession,
+            task: URLSessionTask,
+            didReceive challenge: URLAuthenticationChallenge,
+            completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+        ) {
+            guard let descriptor = Self.decodeServerTrust(task.taskDescription) else {
+                completionHandler(.performDefaultHandling, nil)
+                return
+            }
+
+            Internals.ServerTrustPolicy(descriptor: descriptor)
+                .handle(challenge: challenge, completionHandler: completionHandler)
         }
 
         // MARK: - URLSessionDownloadDelegate
@@ -203,13 +231,22 @@ extension BackgroundDownloads {
         private struct Descriptor: Codable {
             let id: String
             let destination: URL
+            let serverTrust: Internals.ServerTrustPolicy.Descriptor?
         }
 
         // Not `private` -- unit-tested directly (`@testable import`) independent of any real
         // `URLSessionTask`, the same way `InternalsURLSessionUploadFileTests` covers its bridge
         // without a network round trip.
-        static func encode(id: String, destination: URL) -> String? {
-            guard let data = try? JSONEncoder().encode(Descriptor(id: id, destination: destination)) else {
+        static func encode(
+            id: String,
+            destination: URL,
+            serverTrust: Internals.ServerTrustPolicy.Descriptor? = nil
+        ) -> String? {
+            guard
+                let data = try? JSONEncoder().encode(
+                    Descriptor(id: id, destination: destination, serverTrust: serverTrust)
+                )
+            else {
                 return nil
             }
 
@@ -217,6 +254,21 @@ extension BackgroundDownloads {
         }
 
         static func decode(_ taskDescription: String?) -> (id: String, destination: URL)? {
+            guard let descriptor = Self.decodeDescriptor(taskDescription) else {
+                return nil
+            }
+
+            return (descriptor.id, descriptor.destination)
+        }
+
+        /// `nil` both when `taskDescription` isn't one this type encoded at all, and when it is
+        /// but carries no `serverTrust` (the common, plain-HTTPS case) -- either way, the caller's
+        /// only correct response is the same: defer to the system's default handling.
+        static func decodeServerTrust(_ taskDescription: String?) -> Internals.ServerTrustPolicy.Descriptor? {
+            Self.decodeDescriptor(taskDescription)?.serverTrust
+        }
+
+        private static func decodeDescriptor(_ taskDescription: String?) -> Descriptor? {
             guard
                 let taskDescription,
                 let data = taskDescription.data(using: .utf8),
@@ -225,7 +277,7 @@ extension BackgroundDownloads {
                 return nil
             }
 
-            return (descriptor.id, descriptor.destination)
+            return descriptor
         }
 
         // MARK: - Task matching

--- a/Sources/RequestDL/Tasks/Sources/Background Download/Models/BackgroundDownloads.Session.swift
+++ b/Sources/RequestDL/Tasks/Sources/Background Download/Models/BackgroundDownloads.Session.swift
@@ -61,10 +61,16 @@ extension BackgroundDownloads {
             request: URLRequest,
             id: String,
             destination: URL,
-            serverTrust: Internals.ServerTrustPolicy.Descriptor? = nil
+            serverTrust: Internals.ServerTrustPolicy.Descriptor? = nil,
+            clientIdentity: Internals.ClientIdentityDescriptor? = nil
         ) {
             let task = urlSession().downloadTask(with: request)
-            task.taskDescription = Self.encode(id: id, destination: destination, serverTrust: serverTrust)
+            task.taskDescription = Self.encode(
+                id: id,
+                destination: destination,
+                serverTrust: serverTrust,
+                clientIdentity: clientIdentity
+            )
             task.resume()
         }
 
@@ -146,6 +152,11 @@ extension BackgroundDownloads {
             didReceive challenge: URLAuthenticationChallenge,
             completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
         ) {
+            if challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodClientCertificate {
+                handleClientCertificateChallenge(task: task, completionHandler: completionHandler)
+                return
+            }
+
             guard let descriptor = Self.decodeServerTrust(task.taskDescription) else {
                 completionHandler(.performDefaultHandling, nil)
                 return
@@ -153,6 +164,41 @@ extension BackgroundDownloads {
 
             Internals.ServerTrustPolicy(descriptor: descriptor)
                 .handle(challenge: challenge, completionHandler: completionHandler)
+        }
+
+        /// Rebuilds the identity fresh from disk for this one challenge and removes it again
+        /// right after handing the credential over -- no identity is cached across calls, so
+        /// there's nothing to invalidate if the same task is challenged again later (a redirect
+        /// to a new host, for instance): it's simply rebuilt again, from the same file, the same
+        /// way. Safe to remove immediately: once `SecItemCopyMatching` has handed back a
+        /// `SecIdentity`, the in-memory object doesn't stop working just because the Keychain
+        /// entry backing it is deleted afterward, the same assumption
+        /// `Internals.URLSessionIdentityPolicy.deinit` already relies on, just at a smaller grain
+        /// here.
+        private func handleClientCertificateChallenge(
+            task: URLSessionTask,
+            completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+        ) {
+            guard let descriptor = Self.decodeClientIdentity(task.taskDescription) else {
+                completionHandler(.performDefaultHandling, nil)
+                return
+            }
+
+            guard let (handle, intermediates) = try? descriptor.makeIdentity() else {
+                completionHandler(.performDefaultHandling, nil)
+                return
+            }
+
+            completionHandler(
+                .useCredential,
+                URLCredential(
+                    identity: handle.identity,
+                    certificates: intermediates.isEmpty ? nil : intermediates,
+                    persistence: .forSession
+                )
+            )
+
+            Internals.RawBytesIdentityBuilder.remove(handle)
         }
 
         // MARK: - URLSessionDownloadDelegate
@@ -232,6 +278,7 @@ extension BackgroundDownloads {
             let id: String
             let destination: URL
             let serverTrust: Internals.ServerTrustPolicy.Descriptor?
+            let clientIdentity: Internals.ClientIdentityDescriptor?
         }
 
         // Not `private` -- unit-tested directly (`@testable import`) independent of any real
@@ -240,11 +287,17 @@ extension BackgroundDownloads {
         static func encode(
             id: String,
             destination: URL,
-            serverTrust: Internals.ServerTrustPolicy.Descriptor? = nil
+            serverTrust: Internals.ServerTrustPolicy.Descriptor? = nil,
+            clientIdentity: Internals.ClientIdentityDescriptor? = nil
         ) -> String? {
             guard
                 let data = try? JSONEncoder().encode(
-                    Descriptor(id: id, destination: destination, serverTrust: serverTrust)
+                    Descriptor(
+                        id: id,
+                        destination: destination,
+                        serverTrust: serverTrust,
+                        clientIdentity: clientIdentity
+                    )
                 )
             else {
                 return nil
@@ -266,6 +319,13 @@ extension BackgroundDownloads {
         /// only correct response is the same: defer to the system's default handling.
         static func decodeServerTrust(_ taskDescription: String?) -> Internals.ServerTrustPolicy.Descriptor? {
             Self.decodeDescriptor(taskDescription)?.serverTrust
+        }
+
+        /// `nil` both when `taskDescription` isn't one this type encoded at all, and when it is
+        /// but carries no `clientIdentity` (no mTLS configured) -- either way, the caller's only
+        /// correct response is the same: defer to the system's default handling.
+        static func decodeClientIdentity(_ taskDescription: String?) -> Internals.ClientIdentityDescriptor? {
+            Self.decodeDescriptor(taskDescription)?.clientIdentity
         }
 
         private static func decodeDescriptor(_ taskDescription: String?) -> Descriptor? {

--- a/Sources/RequestDL/Tasks/Sources/Background Download/Models/BackgroundDownloads.Session.swift
+++ b/Sources/RequestDL/Tasks/Sources/Background Download/Models/BackgroundDownloads.Session.swift
@@ -1,0 +1,202 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+#if canImport(Darwin)
+
+import SwiftAsyncStream
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+
+extension BackgroundDownloads {
+
+    /// The single `URLSession` backing every ``BackgroundDownloadTask``, plus the delegate
+    /// callbacks that turn its events into ``BackgroundDownloads/Event``.
+    ///
+    /// One fixed identifier for the whole process, not one per download -- a background session
+    /// happily runs many concurrent tasks, and splitting them across sessions would only add
+    /// surface to keep in sync on reconnection for no real benefit. Individual downloads are told
+    /// apart by `URLSessionTask.taskDescription`, not by which session they run on.
+    ///
+    /// Not an `actor`: `urlSession(_:downloadTask:didFinishDownloadingTo:)` has to move the
+    /// downloaded file synchronously, before returning, since the system deletes the temporary
+    /// file right after that call returns -- an `await` hop there would race the cleanup.
+    final class Session: NSObject, URLSessionDownloadDelegate, @unchecked Sendable {
+
+        // MARK: - Internal static properties
+
+        static let shared = Session()
+
+        // MARK: - Private static properties
+
+        /// Stable across launches (same bundle, same string every time) -- required for the
+        /// system to reconnect this session to tasks that outlived a previous process.
+        private static let identifier = "\(Bundle.main.bundleIdentifier ?? "RequestDL").BackgroundDownloadTask"
+
+        // MARK: - Private properties
+
+        private let lock = Lock()
+
+        // MARK: - Unsafe properties
+
+        private var _urlSession: URLSession?
+        private var _pendingCompletionHandler: (@Sendable () -> Void)?
+        private var _onEvent: (@Sendable (BackgroundDownloads.Event) -> Void)?
+
+        // MARK: - Internal properties
+
+        var onEvent: (@Sendable (BackgroundDownloads.Event) -> Void)? {
+            get { lock.withLock { _onEvent } }
+            set { lock.withLock { _onEvent = newValue } }
+        }
+
+        // MARK: - Internal methods
+
+        func schedule(request: URLRequest, id: String, destination: URL) {
+            let task = urlSession().downloadTask(with: request)
+            task.taskDescription = Self.encode(id: id, destination: destination)
+            task.resume()
+        }
+
+        /// Forwarded from `application(_:handleEventsForBackgroundURLSession:completionHandler:)`.
+        /// Ignores any identifier other than this type's own, in case the app also manages its
+        /// own, unrelated background sessions.
+        func handleEvents(
+            forIdentifier identifier: String,
+            completionHandler: @escaping @Sendable () -> Void
+        ) {
+            guard identifier == Self.identifier else {
+                return
+            }
+
+            lock.withLock { _pendingCompletionHandler = completionHandler }
+
+            // Recreating the session (or confirming it already exists) with the matching
+            // identifier is what makes the system replay queued delegate callbacks -- there is no
+            // separate "reconnect" call.
+            _ = urlSession()
+        }
+
+        // MARK: - Private methods
+
+        private func urlSession() -> URLSession {
+            lock.withLock {
+                if let _urlSession {
+                    return _urlSession
+                }
+
+                let configuration = URLSessionConfiguration.background(withIdentifier: Self.identifier)
+                let urlSession = URLSession(configuration: configuration, delegate: self, delegateQueue: nil)
+                _urlSession = urlSession
+                return urlSession
+            }
+        }
+
+        // MARK: - URLSessionDownloadDelegate
+
+        func urlSession(
+            _ session: URLSession,
+            downloadTask: URLSessionDownloadTask,
+            didFinishDownloadingTo location: URL
+        ) {
+            guard let (id, destination) = Self.decode(downloadTask.taskDescription) else {
+                return
+            }
+
+            do {
+                // Best-effort -- a destination that doesn't already exist is the common case, and
+                // `moveItem` below is what actually needs to succeed.
+                try? FileManager.default.removeItem(at: destination)
+                try FileManager.default.moveItem(at: location, to: destination)
+                onEvent?(.completed(id: id, destination: destination))
+            } catch {
+                onEvent?(.failed(id: id, destination: destination, error: error))
+            }
+        }
+
+        func urlSession(
+            _ session: URLSession,
+            downloadTask: URLSessionDownloadTask,
+            didWriteData bytesWritten: Int64,
+            totalBytesWritten: Int64,
+            totalBytesExpectedToWrite: Int64
+        ) {
+            guard let (id, destination) = Self.decode(downloadTask.taskDescription) else {
+                return
+            }
+
+            onEvent?(
+                .progress(
+                    id: id,
+                    destination: destination,
+                    bytesWritten: totalBytesWritten,
+                    totalBytesExpected: totalBytesExpectedToWrite
+                )
+            )
+        }
+
+        /// Also fires with `error == nil` on success -- ignored here, since a successful download
+        /// is already reported from `didFinishDownloadingTo` above, once the file has actually
+        /// been moved to `destination`.
+        func urlSession(
+            _ session: URLSession,
+            task: URLSessionTask,
+            didCompleteWithError error: (any Error)?
+        ) {
+            guard let error, let (id, destination) = Self.decode(task.taskDescription) else {
+                return
+            }
+
+            onEvent?(.failed(id: id, destination: destination, error: error))
+        }
+
+        func urlSessionDidFinishEvents(forBackgroundURLSession session: URLSession) {
+            let handler = lock.withLock {
+                defer { _pendingCompletionHandler = nil }
+                return _pendingCompletionHandler
+            }
+
+            handler?()
+        }
+
+        // MARK: - taskDescription encoding
+
+        /// Everything a delegate callback needs to know about one download, carried on the
+        /// `URLSessionTask` itself (`taskDescription`) rather than in a store RequestDL would
+        /// otherwise have to keep in sync with the system's own task bookkeeping -- the system
+        /// already persists this string across a relaunch for free.
+        private struct Descriptor: Codable {
+            let id: String
+            let destination: URL
+        }
+
+        // Not `private` -- unit-tested directly (`@testable import`) independent of any real
+        // `URLSessionTask`, the same way `InternalsURLSessionUploadFileTests` covers its bridge
+        // without a network round trip.
+        static func encode(id: String, destination: URL) -> String? {
+            guard let data = try? JSONEncoder().encode(Descriptor(id: id, destination: destination)) else {
+                return nil
+            }
+
+            return String(data: data, encoding: .utf8)
+        }
+
+        static func decode(_ taskDescription: String?) -> (id: String, destination: URL)? {
+            guard
+                let taskDescription,
+                let data = taskDescription.data(using: .utf8),
+                let descriptor = try? JSONDecoder().decode(Descriptor.self, from: data)
+            else {
+                return nil
+            }
+
+            return (descriptor.id, descriptor.destination)
+        }
+    }
+}
+
+#endif

--- a/Sources/RequestDL/Tasks/Sources/Background Download/Models/BackgroundDownloads.Session.swift
+++ b/Sources/RequestDL/Tasks/Sources/Background Download/Models/BackgroundDownloads.Session.swift
@@ -31,11 +31,13 @@ extension BackgroundDownloads {
 
         static let shared = Session()
 
-        // MARK: - Private static properties
+        // MARK: - Internal static properties
 
         /// Stable across launches (same bundle, same string every time) -- required for the
-        /// system to reconnect this session to tasks that outlived a previous process.
-        private static let identifier = "\(Bundle.main.bundleIdentifier ?? "RequestDL").BackgroundDownloadTask"
+        /// system to reconnect this session to tasks that outlived a previous process. Not
+        /// `private` -- `handleEvents(forIdentifier:completionHandler:)`'s identifier-matching
+        /// guard is unit-tested directly against this exact value, rather than duplicating it.
+        static let identifier = "\(Bundle.main.bundleIdentifier ?? "RequestDL").BackgroundDownloadTask"
 
         // MARK: - Private properties
 

--- a/Sources/RequestDLInternals/Sources/Client/URLSession Client/Identity/Internals.ClientIdentityDescriptor.swift
+++ b/Sources/RequestDLInternals/Sources/Client/URLSession Client/Identity/Internals.ClientIdentityDescriptor.swift
@@ -1,0 +1,149 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+// What a `BackgroundDownloadTask` persists on `URLSessionTask.taskDescription` for a client
+// certificate (mTLS) -- deliberately never the private key's own bytes, only the file path it
+// lives at. Unlike `Internals.ServerTrustPolicy.Descriptor` (public certificate bytes, fine to
+// carry verbatim), embedding key material in a task's plain-text description would be a real
+// regression from the Keychain-only handling this package otherwise holds itself to. This is why
+// a client identity sourced from `.bytes` (in-memory only, no path to persist) can't be supported
+// here at all, and why an identity is rebuilt fresh from disk on every challenge rather than
+// cached: the file, not any in-memory state, is the only thing guaranteed to still exist after a
+// relaunch.
+
+#if canImport(Darwin)
+
+import Security
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+
+extension Internals {
+
+    package struct ClientIdentityDescriptor: Codable, Equatable, Sendable {
+
+        package enum ResolutionError: Swift.Error, CustomStringConvertible, Equatable, Sendable {
+            case incompleteClientIdentity
+            case nonFileBackedSource
+            case passwordProtectedPrivateKey
+
+            package var description: String {
+                switch self {
+                case .incompleteClientIdentity:
+                    return "mTLS needs both a certificateChain and a privateKey; only one was configured."
+                case .nonFileBackedSource:
+                    return
+                        "the certificateChain/privateKey must both come from a file path, not in-memory bytes or pre-built certificates."
+                case .passwordProtectedPrivateKey:
+                    return "a password-protected private key can't be rebuilt from disk without the password."
+                }
+            }
+        }
+
+        // MARK: - Internal properties
+
+        package let certificateChainFilePath: String
+        package let privateKeyFilePath: String
+        package let privateKeyFormat: Internals.Certificate.Format
+
+        // MARK: - Inits
+
+        package init(
+            certificateChainFilePath: String,
+            privateKeyFilePath: String,
+            privateKeyFormat: Internals.Certificate.Format
+        ) {
+            self.certificateChainFilePath = certificateChainFilePath
+            self.privateKeyFilePath = privateKeyFilePath
+            self.privateKeyFormat = privateKeyFormat
+        }
+
+        // MARK: - Internal methods
+
+        /// `nil` when `secureConnection` configures no client identity at all -- the common case,
+        /// and not an error.
+        package static func resolve(from secureConnection: Internals.SecureConnection) throws -> Self? {
+            switch (secureConnection.certificateChain, secureConnection.privateKey) {
+            case (nil, nil):
+                return nil
+
+            case (.some(let certificateChain), .some(.privateKey(let privateKey))):
+                guard case .file(let certificateChainFilePath) = certificateChain else {
+                    throw ResolutionError.nonFileBackedSource
+                }
+
+                guard case .file(let privateKeyFilePath) = privateKey.source else {
+                    throw ResolutionError.nonFileBackedSource
+                }
+
+                guard privateKey.password == nil else {
+                    throw ResolutionError.passwordProtectedPrivateKey
+                }
+
+                return Self(
+                    certificateChainFilePath: certificateChainFilePath,
+                    privateKeyFilePath: privateKeyFilePath,
+                    privateKeyFormat: privateKey.format
+                )
+
+            case (.some, nil), (nil, .some):
+                throw ResolutionError.incompleteClientIdentity
+            }
+        }
+
+        /// Rebuilds a `SecIdentity` from disk, via the same Keychain round-trip
+        /// `Internals.URLSessionIdentityPolicy` uses -- safe to call repeatedly (the Keychain
+        /// label is content-derived, so re-adding the same identity is a no-op success, not a
+        /// duplicate), and expected to be: this runs fresh on every client-certificate challenge,
+        /// live or after a relaunch alike, with the caller removing the handle again once it's
+        /// done answering.
+        package func makeIdentity() throws -> (
+            handle: Internals.RawBytesIdentityBuilder.Handle, intermediates: [SecCertificate]
+        ) {
+            let derCertificates = try Internals.CertificateChain.file(certificateChainFilePath).build().map {
+                source -> Data in
+                guard case .certificate(let certificate) = source else {
+                    preconditionFailure(
+                        "Internals.CertificateChain.build() unexpectedly produced a non-certificate source"
+                    )
+                }
+                return Data(try certificate.toDERBytes())
+            }
+
+            guard let leaf = derCertificates.first else {
+                throw ResolutionError.incompleteClientIdentity
+            }
+
+            let rawKeyBytes: Data
+            do {
+                rawKeyBytes = try Data(contentsOf: URL(fileURLWithPath: privateKeyFilePath))
+            } catch {
+                throw SecureFileLoadError(resource: .privateKey, path: privateKeyFilePath, underlying: error)
+            }
+
+            let privateKeyDER: Data
+            switch privateKeyFormat {
+            case .der:
+                privateKeyDER = rawKeyBytes
+            case .pem:
+                privateKeyDER = try Internals.RawBytesIdentityBuilder.privateKeyDER(fromPEM: rawKeyBytes)
+            }
+
+            let handle = try Internals.RawBytesIdentityBuilder.makeIdentity(
+                certificateDER: leaf,
+                privateKeyDER: privateKeyDER
+            )
+            let intermediates = try derCertificates.dropFirst().map {
+                try Internals.RawBytesIdentityBuilder.certificate(fromDER: $0)
+            }
+
+            return (handle, intermediates)
+        }
+    }
+}
+
+#endif

--- a/Sources/RequestDLInternals/Sources/Client/URLSession Client/Identity/Internals.ServerTrustPolicy.swift
+++ b/Sources/RequestDLInternals/Sources/Client/URLSession Client/Identity/Internals.ServerTrustPolicy.swift
@@ -1,0 +1,207 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+// The server-trust half of `Internals.URLSessionIdentityPolicy`, pulled out on its own: unlike
+// the client-identity half, it needs no Keychain round-trip, so it can be rebuilt from nothing
+// but raw certificate bytes -- which is exactly what a `BackgroundDownloadTask` needs to do after
+// a relaunch, with no `Internals.SecureConnection` left in memory to resolve from.
+
+#if canImport(Darwin)
+
+import NIOSSL
+import Security
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+
+extension Internals {
+
+    package final class ServerTrustPolicy: @unchecked Sendable {
+
+        /// A `Codable`, `NIOSSL`-free snapshot of one `ServerTrustPolicy` -- what actually
+        /// survives a relaunch. Certificates are carried as raw DER bytes rather than file paths,
+        /// since the original source (`.bytes` or `.file`) has already been resolved once by the
+        /// time this is built, and a persisted path could stop pointing at the same content (or
+        /// anything at all) between one launch and the next.
+        package struct Descriptor: Codable, Equatable, Sendable {
+            package let trustedRootCertificatesDER: [Data]
+            package let verification: Verification
+
+            package enum Verification: String, Codable, Equatable, Sendable {
+                case none
+                case fullVerification
+                case noHostnameVerification
+
+                package init(_ verification: NIOSSL.CertificateVerification) {
+                    switch verification {
+                    case .none:
+                        self = .none
+                    case .noHostnameVerification:
+                        self = .noHostnameVerification
+                    case .fullVerification:
+                        self = .fullVerification
+                    @unknown default:
+                        self = .fullVerification
+                    }
+                }
+
+                package var nioSSLValue: NIOSSL.CertificateVerification {
+                    switch self {
+                    case .none: return .none
+                    case .fullVerification: return .fullVerification
+                    case .noHostnameVerification: return .noHostnameVerification
+                    }
+                }
+            }
+
+            package init(trustedRootCertificatesDER: [Data], verification: Verification) {
+                self.trustedRootCertificatesDER = trustedRootCertificatesDER
+                self.verification = verification
+            }
+        }
+
+        // MARK: - Private properties
+
+        private let trustedRootCertificates: [SecCertificate]
+        private let certificateVerification: NIOSSL.CertificateVerification
+
+        // MARK: - Inits
+
+        package init(
+            trustedRootCertificates: [SecCertificate],
+            certificateVerification: NIOSSL.CertificateVerification
+        ) {
+            self.trustedRootCertificates = trustedRootCertificates
+            self.certificateVerification = certificateVerification
+        }
+
+        /// Rebuilds a policy from a previously captured ``descriptor``. A certificate that fails
+        /// to parse back out of its own DER bytes is dropped silently rather than thrown -- it
+        /// was already valid DER when captured (`SecCertificateCopyData` never produces anything
+        /// else), so this is not expected to happen in practice, and failing the whole challenge
+        /// over one bad anchor would be a worse outcome than trusting one fewer root than
+        /// intended.
+        package convenience init(descriptor: Descriptor) {
+            self.init(
+                trustedRootCertificates: descriptor.trustedRootCertificatesDER.compactMap {
+                    SecCertificateCreateWithData(nil, $0 as CFData)
+                },
+                certificateVerification: descriptor.verification.nioSSLValue
+            )
+        }
+
+        // MARK: - Internal properties
+
+        /// The `Codable` snapshot of this exact policy -- everything ``init(descriptor:)`` needs
+        /// to rebuild an equivalent one later, with no `Internals.SecureConnection` in hand.
+        package var descriptor: Descriptor {
+            Descriptor(
+                trustedRootCertificatesDER: trustedRootCertificates.map { SecCertificateCopyData($0) as Data },
+                verification: Descriptor.Verification(certificateVerification)
+            )
+        }
+
+        // MARK: - Internal methods
+
+        /// Resolves trust roots straight from a `SecureConnection` -- the same
+        /// `Internals.TrustRoots`/`Internals.AdditionalTrustRoots` parsing
+        /// `Internals.URLSessionIdentityPolicy` uses for its own server-trust half, shared rather
+        /// than duplicated between the two.
+        package static func resolve(from secureConnection: Internals.SecureConnection) throws -> ServerTrustPolicy {
+            var trustedRootCertificates: [SecCertificate] = []
+
+            if let trustRoots = secureConnection.trustRoots {
+                trustedRootCertificates += try certificates(from: trustRoots).map {
+                    try RawBytesIdentityBuilder.certificate(fromDER: Data($0.toDERBytes()))
+                }
+            }
+
+            if let additionalTrustRoots = secureConnection.additionalTrustRoots {
+                for additionalTrustRoot in additionalTrustRoots {
+                    trustedRootCertificates += try certificates(from: additionalTrustRoot).map {
+                        try RawBytesIdentityBuilder.certificate(fromDER: Data($0.toDERBytes()))
+                    }
+                }
+            }
+
+            return ServerTrustPolicy(
+                trustedRootCertificates: trustedRootCertificates,
+                certificateVerification: secureConnection.certificateVerification ?? .fullVerification
+            )
+        }
+
+        /// Answers a server-trust challenge. Anything else (client-certificate, or any other
+        /// authentication method) defers to the system's default handling -- this type only ever
+        /// speaks to the server side of a handshake.
+        package func handle(
+            challenge: URLAuthenticationChallenge,
+            completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+        ) {
+            guard
+                challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodServerTrust,
+                let serverTrust = challenge.protectionSpace.serverTrust
+            else {
+                completionHandler(.performDefaultHandling, nil)
+                return
+            }
+
+            if case .none = certificateVerification {
+                // Mirrors NIOSSL's `CertificateVerification.none` -- deliberately unsafe,
+                // opt-in only.
+                completionHandler(.useCredential, URLCredential(trust: serverTrust))
+                return
+            }
+
+            if certificateVerification == .noHostnameVerification {
+                let policy = SecPolicyCreateSSL(true, nil)
+                _ = SecTrustSetPolicies(serverTrust, policy as CFTypeRef)
+            }
+
+            if !trustedRootCertificates.isEmpty {
+                _ = SecTrustSetAnchorCertificates(serverTrust, trustedRootCertificates as CFArray)
+                _ = SecTrustSetAnchorCertificatesOnly(serverTrust, true)
+            }
+
+            var evaluationError: CFError?
+            let isTrusted = SecTrustEvaluateWithError(serverTrust, &evaluationError)
+
+            if isTrusted {
+                completionHandler(.useCredential, URLCredential(trust: serverTrust))
+            } else {
+                completionHandler(.cancelAuthenticationChallenge, nil)
+            }
+        }
+
+        // MARK: - Private methods
+
+        private static func certificates(from trustRoots: Internals.TrustRoots) throws -> [NIOSSLCertificate] {
+            switch trustRoots {
+            case .file(let file):
+                return try Internals.Certificate(file, format: .pem).build()
+            case .bytes(let bytes):
+                return try Internals.Certificate(bytes, format: .pem).build()
+            case .certificates(let certificates):
+                return try certificates.flatMap { try $0.build() }
+            }
+        }
+
+        private static func certificates(
+            from additionalTrustRoots: Internals.AdditionalTrustRoots
+        ) throws -> [NIOSSLCertificate] {
+            switch additionalTrustRoots {
+            case .file(let file):
+                return try Internals.Certificate(file, format: .pem).build()
+            case .bytes(let bytes):
+                return try Internals.Certificate(bytes, format: .pem).build()
+            case .certificates(let certificates):
+                return try certificates.flatMap { try $0.build() }
+            }
+        }
+    }
+}
+
+#endif

--- a/Sources/RequestDLInternals/Sources/Client/URLSession Client/Identity/Internals.URLSessionIdentityPolicy.swift
+++ b/Sources/RequestDLInternals/Sources/Client/URLSession Client/Identity/Internals.URLSessionIdentityPolicy.swift
@@ -20,8 +20,10 @@ import Foundation
 extension Internals {
 
     /// The resolved, `URLSession`-ready form of one `Internals.SecureConnection`: a client
-    /// identity (if `certificateChain`/`privateKey` were configured) plus the trust roots and
-    /// verification mode to apply to the server side of the handshake.
+    /// identity (if `certificateChain`/`privateKey` were configured), composed with an
+    /// `Internals.ServerTrustPolicy` for the trust roots/verification mode half -- the one part
+    /// of this that needs no Keychain round-trip, and so is reusable on its own wherever only
+    /// that half is needed.
     ///
     /// Built once per `SecureConnection` and held for as long as the owning
     /// `Internals.URLSessionClient` is alive -- mirrors NIOSSL's own per-connection
@@ -48,8 +50,7 @@ extension Internals {
 
         private let identityHandle: Internals.RawBytesIdentityBuilder.Handle?
         private let intermediateCertificates: [SecCertificate]
-        private let trustedRootCertificates: [SecCertificate]
-        private let certificateVerification: NIOSSL.CertificateVerification
+        private let serverTrustPolicy: Internals.ServerTrustPolicy
 
         // MARK: - Inits
 
@@ -80,24 +81,7 @@ extension Internals {
                 throw ConfigurationError.incompleteClientIdentity
             }
 
-            var trustedRootCertificates: [SecCertificate] = []
-
-            if let trustRoots = secureConnection.trustRoots {
-                trustedRootCertificates += try Self.certificates(from: trustRoots).map {
-                    try RawBytesIdentityBuilder.certificate(fromDER: Data($0.toDERBytes()))
-                }
-            }
-
-            if let additionalTrustRoots = secureConnection.additionalTrustRoots {
-                for additionalTrustRoot in additionalTrustRoots {
-                    trustedRootCertificates += try Self.certificates(from: additionalTrustRoot).map {
-                        try RawBytesIdentityBuilder.certificate(fromDER: Data($0.toDERBytes()))
-                    }
-                }
-            }
-
-            self.trustedRootCertificates = trustedRootCertificates
-            self.certificateVerification = secureConnection.certificateVerification ?? .fullVerification
+            self.serverTrustPolicy = try Internals.ServerTrustPolicy.resolve(from: secureConnection)
         }
 
         deinit {
@@ -115,57 +99,24 @@ extension Internals {
             challenge: URLAuthenticationChallenge,
             completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
         ) {
-            switch challenge.protectionSpace.authenticationMethod {
-            case NSURLAuthenticationMethodClientCertificate:
-                guard let identityHandle else {
-                    completionHandler(.performDefaultHandling, nil)
-                    return
-                }
-
-                completionHandler(
-                    .useCredential,
-                    URLCredential(
-                        identity: identityHandle.identity,
-                        certificates: intermediateCertificates.isEmpty ? nil : intermediateCertificates,
-                        persistence: .forSession
-                    )
-                )
-
-            case NSURLAuthenticationMethodServerTrust:
-                guard let serverTrust = challenge.protectionSpace.serverTrust else {
-                    completionHandler(.performDefaultHandling, nil)
-                    return
-                }
-
-                if case .none = certificateVerification {
-                    // Mirrors NIOSSL's `CertificateVerification.none` -- deliberately unsafe,
-                    // opt-in only.
-                    completionHandler(.useCredential, URLCredential(trust: serverTrust))
-                    return
-                }
-
-                if certificateVerification == .noHostnameVerification {
-                    let policy = SecPolicyCreateSSL(true, nil)
-                    _ = SecTrustSetPolicies(serverTrust, policy as CFTypeRef)
-                }
-
-                if !trustedRootCertificates.isEmpty {
-                    _ = SecTrustSetAnchorCertificates(serverTrust, trustedRootCertificates as CFArray)
-                    _ = SecTrustSetAnchorCertificatesOnly(serverTrust, true)
-                }
-
-                var evaluationError: CFError?
-                let isTrusted = SecTrustEvaluateWithError(serverTrust, &evaluationError)
-
-                if isTrusted {
-                    completionHandler(.useCredential, URLCredential(trust: serverTrust))
-                } else {
-                    completionHandler(.cancelAuthenticationChallenge, nil)
-                }
-
-            default:
-                completionHandler(.performDefaultHandling, nil)
+            guard challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodClientCertificate else {
+                serverTrustPolicy.handle(challenge: challenge, completionHandler: completionHandler)
+                return
             }
+
+            guard let identityHandle else {
+                completionHandler(.performDefaultHandling, nil)
+                return
+            }
+
+            completionHandler(
+                .useCredential,
+                URLCredential(
+                    identity: identityHandle.identity,
+                    certificates: intermediateCertificates.isEmpty ? nil : intermediateCertificates,
+                    persistence: .forSession
+                )
+            )
         }
 
         // MARK: - Private methods
@@ -185,30 +136,6 @@ extension Internals {
                     )
                 }
                 return Data(try certificate.toDERBytes())
-            }
-        }
-
-        private static func certificates(from trustRoots: Internals.TrustRoots) throws -> [NIOSSLCertificate] {
-            switch trustRoots {
-            case .file(let file):
-                return try Internals.Certificate(file, format: .pem).build()
-            case .bytes(let bytes):
-                return try Internals.Certificate(bytes, format: .pem).build()
-            case .certificates(let certificates):
-                return try certificates.flatMap { try $0.build() }
-            }
-        }
-
-        private static func certificates(
-            from additionalTrustRoots: Internals.AdditionalTrustRoots
-        ) throws -> [NIOSSLCertificate] {
-            switch additionalTrustRoots {
-            case .file(let file):
-                return try Internals.Certificate(file, format: .pem).build()
-            case .bytes(let bytes):
-                return try Internals.Certificate(bytes, format: .pem).build()
-            case .certificates(let certificates):
-                return try certificates.flatMap { try $0.build() }
             }
         }
 

--- a/Sources/RequestDLInternals/Sources/Secure Connection/Certificate/Models/Internals.Certificate.Format.swift
+++ b/Sources/RequestDLInternals/Sources/Secure Connection/Certificate/Models/Internals.Certificate.Format.swift
@@ -6,7 +6,7 @@ import NIOSSL
 
 extension Internals.Certificate {
 
-    package enum Format: Sendable, Hashable {
+    package enum Format: Sendable, Hashable, Codable {
 
         case der
         case pem

--- a/Tests/RequestDLTests/Request/InternalsClientIdentityDescriptorTests.swift
+++ b/Tests/RequestDLTests/Request/InternalsClientIdentityDescriptorTests.swift
@@ -1,0 +1,278 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+import NIOSSL
+import RequestDLInternals
+import Testing
+
+@testable import RequestDL
+@testable import RequestDLTestSupport
+
+#if canImport(Darwin)
+
+import Foundation
+import Security
+
+/// Covers `Internals.ClientIdentityDescriptor` -- what `BackgroundDownloadTask` persists for a
+/// client certificate (mTLS), and rebuilds fresh from disk on every challenge, live or after a
+/// relaunch alike.
+struct InternalsClientIdentityDescriptorTests {
+
+    // MARK: - resolve(from:)
+
+    @Test
+    func resolve_whenNoClientIdentityConfigured_returnsNil() async throws {
+        // Given
+        let secureConnection = Internals.SecureConnection()
+
+        // When / Then
+        #expect(try Internals.ClientIdentityDescriptor.resolve(from: secureConnection) == nil)
+    }
+
+    @Test
+    func resolve_whenFileBackedCertificateAndKeyConfigured_capturesPaths() async throws {
+        // Given
+        let client = Certificates().client()
+        let certificatePath = client.certificateURL.absolutePath(percentEncoded: false)
+        let privateKeyPath = client.privateKeyURL.absolutePath(percentEncoded: false)
+
+        var secureConnection = Internals.SecureConnection()
+        secureConnection.certificateChain = .file(certificatePath)
+        secureConnection.privateKey = .privateKey(.init(privateKeyPath, format: .pem))
+
+        // When
+        let descriptor = try #require(try Internals.ClientIdentityDescriptor.resolve(from: secureConnection))
+
+        // Then
+        #expect(descriptor.certificateChainFilePath == certificatePath)
+        #expect(descriptor.privateKeyFilePath == privateKeyPath)
+        #expect(descriptor.privateKeyFormat == .pem)
+    }
+
+    @Test
+    func resolve_whenCertificateChainIsBytesBacked_throwsNonFileBackedSource() async throws {
+        // Given
+        let client = Certificates().client()
+        let certificateBytes = try [UInt8](Data(contentsOf: client.certificateURL))
+
+        var secureConnection = Internals.SecureConnection()
+        secureConnection.certificateChain = .bytes(certificateBytes)
+        secureConnection.privateKey = .privateKey(
+            .init(client.privateKeyURL.absolutePath(percentEncoded: false), format: .pem)
+        )
+
+        // When / Then
+        #expect(throws: Internals.ClientIdentityDescriptor.ResolutionError.nonFileBackedSource) {
+            try Internals.ClientIdentityDescriptor.resolve(from: secureConnection)
+        }
+    }
+
+    @Test
+    func resolve_whenPrivateKeyIsBytesBacked_throwsNonFileBackedSource() async throws {
+        // Given
+        let client = Certificates().client()
+        let privateKeyBytes = try [UInt8](Data(contentsOf: client.privateKeyURL))
+
+        var secureConnection = Internals.SecureConnection()
+        secureConnection.certificateChain = .file(client.certificateURL.absolutePath(percentEncoded: false))
+        secureConnection.privateKey = .privateKey(.init(privateKeyBytes, format: .pem))
+
+        // When / Then
+        #expect(throws: Internals.ClientIdentityDescriptor.ResolutionError.nonFileBackedSource) {
+            try Internals.ClientIdentityDescriptor.resolve(from: secureConnection)
+        }
+    }
+
+    @Test
+    func resolve_whenPrivateKeyIsPasswordProtected_throwsPasswordProtectedPrivateKey() async throws {
+        // Given
+        let client = Certificates().client(password: true)
+
+        var secureConnection = Internals.SecureConnection()
+        secureConnection.certificateChain = .file(client.certificateURL.absolutePath(percentEncoded: false))
+        secureConnection.privateKey = .privateKey(
+            .init(
+                client.privateKeyURL.absolutePath(percentEncoded: false),
+                format: .pem,
+                password: NIOSSLSecureBytes("password".utf8)
+            )
+        )
+
+        // When / Then
+        #expect(throws: Internals.ClientIdentityDescriptor.ResolutionError.passwordProtectedPrivateKey) {
+            try Internals.ClientIdentityDescriptor.resolve(from: secureConnection)
+        }
+    }
+
+    @Test
+    func resolve_whenOnlyCertificateChainConfigured_throwsIncompleteClientIdentity() async throws {
+        // Given
+        let client = Certificates().client()
+
+        var secureConnection = Internals.SecureConnection()
+        secureConnection.certificateChain = .file(client.certificateURL.absolutePath(percentEncoded: false))
+
+        // When / Then
+        #expect(throws: Internals.ClientIdentityDescriptor.ResolutionError.incompleteClientIdentity) {
+            try Internals.ClientIdentityDescriptor.resolve(from: secureConnection)
+        }
+    }
+
+    @Test
+    func resolve_whenOnlyPrivateKeyConfigured_throwsIncompleteClientIdentity() async throws {
+        // Given
+        let client = Certificates().client()
+
+        var secureConnection = Internals.SecureConnection()
+        secureConnection.privateKey = .privateKey(
+            .init(client.privateKeyURL.absolutePath(percentEncoded: false), format: .pem)
+        )
+
+        // When / Then
+        #expect(throws: Internals.ClientIdentityDescriptor.ResolutionError.incompleteClientIdentity) {
+            try Internals.ClientIdentityDescriptor.resolve(from: secureConnection)
+        }
+    }
+
+    // MARK: - Descriptor round trip
+
+    @Test
+    func descriptor_isCodableRoundTrippable() async throws {
+        // Given
+        let descriptor = Internals.ClientIdentityDescriptor(
+            certificateChainFilePath: "/tmp/client.pem",
+            privateKeyFilePath: "/tmp/client.key",
+            privateKeyFormat: .pem
+        )
+
+        // When
+        let encoded = try JSONEncoder().encode(descriptor)
+        let decoded = try JSONDecoder().decode(Internals.ClientIdentityDescriptor.self, from: encoded)
+
+        // Then
+        #expect(decoded == descriptor)
+    }
+
+    // MARK: - makeIdentity() -- real handshake, rebuilt identity
+
+    /// The whole point of splitting this type out: an identity rebuilt from nothing but a
+    /// `Descriptor` -- just a certificate/key file path on disk, no `Internals.SecureConnection`,
+    /// no `Property` tree -- still has to genuinely authenticate against a real server requiring
+    /// a client certificate, not just hold the right bytes in memory. Known issue in this bare
+    /// SwiftPM test harness specifically (no Keychain Sharing entitlement), same gap
+    /// `RequestConfigurationURLSessionClientMTLSTests` already documents at the live-executor
+    /// layer -- this proves the same wiring one layer further removed (via a JSON round trip
+    /// simulating a relaunch), not a new one.
+    @Test
+    func rebuiltIdentity_whenPresentedToServerRequiringClientCertificate_completesHandshake() async throws {
+        // Given
+        let server = Certificates().server()
+        let client = Certificates().client()
+        let uri = "/" + UUID().uuidString
+
+        let localServer = try await LocalServer(
+            LocalServer.Configuration(
+                host: "localhost",
+                port: 8890,
+                option: .client(client)
+            )
+        )
+
+        let output = "Hello World"
+        let response = try LocalServer.ResponseConfiguration(jsonObject: output)
+        localServer.cleanup(at: uri)
+        localServer.insert(response, at: uri)
+        defer { localServer.cleanup(at: uri) }
+
+        var secureConnection = Internals.SecureConnection()
+        secureConnection.certificateChain = .file(client.certificateURL.absolutePath(percentEncoded: false))
+        secureConnection.privateKey = .privateKey(
+            .init(client.privateKeyURL.absolutePath(percentEncoded: false), format: .pem)
+        )
+        secureConnection.trustRoots = .file(server.certificateURL.absolutePath(percentEncoded: false))
+
+        let clientIdentityDescriptor = try #require(
+            try Internals.ClientIdentityDescriptor.resolve(from: secureConnection)
+        )
+        let serverTrustDescriptor = try Internals.ServerTrustPolicy.resolve(from: secureConnection).descriptor
+
+        // Simulates a relaunch: the only things carried forward are the two `Descriptor`s, JSON
+        // round-tripped, exactly like `taskDescription`.
+        let rebuiltClientIdentityDescriptor = try JSONDecoder().decode(
+            Internals.ClientIdentityDescriptor.self,
+            from: JSONEncoder().encode(clientIdentityDescriptor)
+        )
+        let rebuiltServerTrustPolicy = Internals.ServerTrustPolicy(
+            descriptor: try JSONDecoder().decode(
+                Internals.ServerTrustPolicy.Descriptor.self,
+                from: JSONEncoder().encode(serverTrustDescriptor)
+            )
+        )
+
+        // Then
+        await withKnownIssue(
+            "this SwiftPM test harness has no Keychain Sharing entitlement on any platform -- see RequestConfigurationURLSessionClientMTLSTests's type doc comment",
+            {
+                let (handle, intermediates) = try rebuiltClientIdentityDescriptor.makeIdentity()
+                defer { Internals.RawBytesIdentityBuilder.remove(handle) }
+
+                let delegate = ClientCertificateForwardingDelegate(
+                    identity: handle.identity,
+                    intermediates: intermediates,
+                    serverTrustPolicy: rebuiltServerTrustPolicy
+                )
+                let session = URLSession(configuration: .ephemeral, delegate: delegate, delegateQueue: nil)
+
+                var request = URLRequest(url: try #require(URL(string: "https://\(localServer.baseURL)\(uri)")))
+                request.httpMethod = "GET"
+
+                let (data, response2) = try await session.data(for: request)
+
+                #expect((response2 as? HTTPURLResponse)?.statusCode == 200)
+                let decodedBody = try HTTPResult<String>(data)
+                #expect(decodedBody.response == output)
+            }
+        )
+    }
+}
+
+/// Answers both halves of an mTLS handshake by hand -- the client-certificate credential directly
+/// (this suite already has the identity in hand), and the server-trust half via
+/// `Internals.ServerTrustPolicy`, the same hookup `BackgroundDownloads.Session`'s own challenge
+/// delegate uses for each.
+private final class ClientCertificateForwardingDelegate: NSObject, URLSessionTaskDelegate, @unchecked Sendable {
+
+    private let identity: SecIdentity
+    private let intermediates: [SecCertificate]
+    private let serverTrustPolicy: Internals.ServerTrustPolicy
+
+    init(identity: SecIdentity, intermediates: [SecCertificate], serverTrustPolicy: Internals.ServerTrustPolicy) {
+        self.identity = identity
+        self.intermediates = intermediates
+        self.serverTrustPolicy = serverTrustPolicy
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        didReceive challenge: URLAuthenticationChallenge,
+        completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+    ) {
+        guard challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodClientCertificate else {
+            serverTrustPolicy.handle(challenge: challenge, completionHandler: completionHandler)
+            return
+        }
+
+        completionHandler(
+            .useCredential,
+            URLCredential(
+                identity: identity,
+                certificates: intermediates.isEmpty ? nil : intermediates,
+                persistence: .forSession
+            )
+        )
+    }
+}
+
+#endif

--- a/Tests/RequestDLTests/Request/InternalsServerTrustPolicyTests.swift
+++ b/Tests/RequestDLTests/Request/InternalsServerTrustPolicyTests.swift
@@ -1,0 +1,216 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+import NIOSSL
+import RequestDLInternals
+import Testing
+
+@testable import RequestDL
+@testable import RequestDLTestSupport
+
+#if canImport(Darwin)
+
+import Foundation
+import Security
+
+/// Covers `Internals.ServerTrustPolicy` -- the server-trust half `Internals.URLSessionIdentityPolicy`
+/// now composes rather than duplicates, and the piece `BackgroundDownloadTask` resolves at
+/// schedule time and rebuilds again from a persisted ``Internals/ServerTrustPolicy/Descriptor``,
+/// simulating what happens after a relaunch with nothing else in memory.
+struct InternalsServerTrustPolicyTests {
+
+    // MARK: - resolve(from:)
+
+    @Test
+    func resolve_whenTrustRootsConfigured_capturesCertificateAndDefaultsToFullVerification() async throws {
+        // Given
+        let server = Certificates().server()
+
+        var secureConnection = Internals.SecureConnection()
+        secureConnection.trustRoots = .file(server.certificateURL.absolutePath(percentEncoded: false))
+
+        // When
+        let descriptor = try Internals.ServerTrustPolicy.resolve(from: secureConnection).descriptor
+
+        // Then
+        #expect(descriptor.trustedRootCertificatesDER.count == 1)
+        #expect(descriptor.verification == .fullVerification)
+    }
+
+    @Test
+    func resolve_whenNoTrustRootsConfigured_capturesNoCertificates() async throws {
+        // Given
+        let secureConnection = Internals.SecureConnection()
+
+        // When
+        let descriptor = try Internals.ServerTrustPolicy.resolve(from: secureConnection).descriptor
+
+        // Then
+        #expect(descriptor.trustedRootCertificatesDER.isEmpty)
+    }
+
+    @Test(
+        arguments: [
+            (NIOSSL.CertificateVerification.none, Internals.ServerTrustPolicy.Descriptor.Verification.none),
+            (.fullVerification, .fullVerification),
+            (.noHostnameVerification, .noHostnameVerification),
+        ]
+    )
+    func resolve_capturesConfiguredVerificationMode(
+        _ pair: (NIOSSL.CertificateVerification, Internals.ServerTrustPolicy.Descriptor.Verification)
+    ) async throws {
+        // Given
+        var secureConnection = Internals.SecureConnection()
+        secureConnection.certificateVerification = pair.0
+
+        // When
+        let descriptor = try Internals.ServerTrustPolicy.resolve(from: secureConnection).descriptor
+
+        // Then
+        #expect(descriptor.verification == pair.1)
+    }
+
+    @Test
+    func resolve_whenAdditionalTrustRootsConfigured_appendsToTrustRoots() async throws {
+        // Given
+        let server = Certificates().server()
+
+        var secureConnection = Internals.SecureConnection()
+        secureConnection.trustRoots = .file(server.certificateURL.absolutePath(percentEncoded: false))
+        secureConnection.additionalTrustRoots = [
+            .file(server.certificateURL.absolutePath(percentEncoded: false))
+        ]
+
+        // When
+        let descriptor = try Internals.ServerTrustPolicy.resolve(from: secureConnection).descriptor
+
+        // Then
+        #expect(descriptor.trustedRootCertificatesDER.count == 2)
+    }
+
+    // MARK: - Descriptor round trip
+
+    @Test
+    func descriptor_roundTripsThroughInit() async throws {
+        // Given
+        let server = Certificates().server()
+
+        var secureConnection = Internals.SecureConnection()
+        secureConnection.trustRoots = .file(server.certificateURL.absolutePath(percentEncoded: false))
+        secureConnection.certificateVerification = .noHostnameVerification
+
+        let original = try Internals.ServerTrustPolicy.resolve(from: secureConnection)
+
+        // When -- exactly what survives a relaunch: the `Descriptor`, JSON round-tripped the same
+        // way `BackgroundDownloads.Session` persists it on `taskDescription`, then rebuilt from
+        // that alone.
+        let encoded = try JSONEncoder().encode(original.descriptor)
+        let decoded = try JSONDecoder().decode(Internals.ServerTrustPolicy.Descriptor.self, from: encoded)
+        let rebuilt = Internals.ServerTrustPolicy(descriptor: decoded)
+
+        // Then
+        #expect(rebuilt.descriptor == original.descriptor)
+    }
+
+    // MARK: - handle(challenge:completionHandler:) -- real handshake, rebuilt policy
+
+    /// The whole point of splitting this type out: a policy rebuilt from nothing but a
+    /// `Descriptor` -- no `Internals.SecureConnection`, no `Property` tree, exactly what a
+    /// `BackgroundDownloadTask` delegate callback has after a relaunch -- still has to genuinely
+    /// validate a real server certificate against real trust roots, not just hold the right bytes
+    /// in memory.
+    @Test
+    func rebuiltPolicy_whenTrustRootsConfigured_stillVerifiesRealServerCertificateAgainstThem() async throws {
+        // Given
+        let server = Certificates().server()
+        let localServer = try await LocalServer(.standard)
+        let uri = "/" + UUID().uuidString
+        let output = "Hello World"
+
+        let response = try LocalServer.ResponseConfiguration(jsonObject: output)
+        localServer.cleanup(at: uri)
+        localServer.insert(response, at: uri)
+        defer { localServer.cleanup(at: uri) }
+
+        var secureConnection = Internals.SecureConnection()
+        secureConnection.trustRoots = .file(server.certificateURL.absolutePath(percentEncoded: false))
+        secureConnection.certificateVerification = .fullVerification
+
+        let descriptor = try Internals.ServerTrustPolicy.resolve(from: secureConnection).descriptor
+
+        // Simulates a relaunch: the only thing carried forward is the `Descriptor` itself, JSON
+        // round-tripped, exactly like `taskDescription`.
+        let encoded = try JSONEncoder().encode(descriptor)
+        let decoded = try JSONDecoder().decode(Internals.ServerTrustPolicy.Descriptor.self, from: encoded)
+        let rebuiltPolicy = Internals.ServerTrustPolicy(descriptor: decoded)
+
+        let delegate = ForwardingChallengeDelegate(policy: rebuiltPolicy)
+        let session = URLSession(configuration: .ephemeral, delegate: delegate, delegateQueue: nil)
+
+        var request = URLRequest(url: try #require(URL(string: "https://\(localServer.baseURL)\(uri)")))
+        request.httpMethod = "GET"
+
+        // When
+        let (data, response2) = try await session.data(for: request)
+
+        // Then
+        #expect((response2 as? HTTPURLResponse)?.statusCode == 200)
+        let decodedBody = try HTTPResult<String>(data)
+        #expect(decodedBody.response == output)
+    }
+
+    @Test
+    func rebuiltPolicy_whenTrustRootsDoNotMatch_rejectsRealServerCertificate() async throws {
+        // Given -- the client fixture's own certificate is not the one `LocalServer` presents, so
+        // anchoring to it specifically must fail the handshake.
+        let unrelatedCertificate = Certificates().client()
+        let localServer = try await LocalServer(.standard)
+        let uri = "/" + UUID().uuidString
+
+        localServer.cleanup(at: uri)
+        defer { localServer.cleanup(at: uri) }
+
+        var secureConnection = Internals.SecureConnection()
+        secureConnection.trustRoots = .file(unrelatedCertificate.certificateURL.absolutePath(percentEncoded: false))
+        secureConnection.certificateVerification = .fullVerification
+
+        let descriptor = try Internals.ServerTrustPolicy.resolve(from: secureConnection).descriptor
+        let rebuiltPolicy = Internals.ServerTrustPolicy(descriptor: descriptor)
+
+        let delegate = ForwardingChallengeDelegate(policy: rebuiltPolicy)
+        let session = URLSession(configuration: .ephemeral, delegate: delegate, delegateQueue: nil)
+
+        var request = URLRequest(url: try #require(URL(string: "https://\(localServer.baseURL)\(uri)")))
+        request.httpMethod = "GET"
+
+        // When / Then
+        await #expect(throws: (any Error).self) {
+            try await session.data(for: request)
+        }
+    }
+}
+
+/// Forwards a session's server-trust challenge straight to a `ServerTrustPolicy` -- the same
+/// hookup `BackgroundDownloads.Session`'s own `urlSession(_:task:didReceive:completionHandler:)`
+/// does, minus the `taskDescription` decoding step, since this suite already has the policy in
+/// hand directly.
+private final class ForwardingChallengeDelegate: NSObject, URLSessionTaskDelegate, @unchecked Sendable {
+
+    private let policy: Internals.ServerTrustPolicy
+
+    init(policy: Internals.ServerTrustPolicy) {
+        self.policy = policy
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        didReceive challenge: URLAuthenticationChallenge,
+        completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+    ) {
+        policy.handle(challenge: challenge, completionHandler: completionHandler)
+    }
+}
+
+#endif

--- a/Tests/RequestDLTests/Tasks/Sources/Background Download/BackgroundDownloadTaskTests.swift
+++ b/Tests/RequestDLTests/Tasks/Sources/Background Download/BackgroundDownloadTaskTests.swift
@@ -1,0 +1,70 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+#if canImport(Darwin)
+
+import Testing
+
+@testable import RequestDL
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import struct Foundation.URL
+#endif
+
+/// Only covers `result()`'s validation guard -- the part that runs and throws before ever
+/// touching `BackgroundDownloads.Session.shared`. Actually scheduling a download would start a
+/// real `URLSessionConfiguration.background` session from this bare SwiftPM test harness, an
+/// unsigned CLI process with none of the entitlements a real app target has; that path is not
+/// exercised here, the same way this suite's mTLS tests don't exercise a real Keychain round trip
+/// either.
+struct BackgroundDownloadTaskTests {
+
+    @Test
+    func result_whenContentConfiguresSecureConnection_throwsUnsupportedConfigurationError() async throws {
+        // Given
+        let task = BackgroundDownloadTask(
+            id: "episode-42",
+            destination: URL(fileURLWithPath: "/tmp/episode-42.mp3")
+        ) {
+            BaseURL("localhost")
+
+            SecureConnection {
+                TrustRoots("/dev/null")
+            }
+        }
+
+        // When / Then
+        await #expect(throws: BackgroundDownloadUnsupportedConfigurationError.self) {
+            try await task.result()
+        }
+    }
+
+    @Test
+    func result_whenContentConfiguresSecureConnection_errorReadsActionably() async throws {
+        // Given
+        let task = BackgroundDownloadTask(
+            id: "episode-42",
+            destination: URL(fileURLWithPath: "/tmp/episode-42.mp3")
+        ) {
+            BaseURL("localhost")
+
+            SecureConnection {
+                TrustRoots("/dev/null")
+            }
+        }
+
+        // When / Then
+        do {
+            try await task.result()
+            Issue.record("Expected BackgroundDownloadUnsupportedConfigurationError")
+        } catch let error as BackgroundDownloadUnsupportedConfigurationError {
+            #expect((error as any Error).localizedDescription == error.description)
+            #expect(error.description.contains("SecureConnection"))
+        }
+    }
+}
+
+#endif

--- a/Tests/RequestDLTests/Tasks/Sources/Background Download/BackgroundDownloadTaskTests.swift
+++ b/Tests/RequestDLTests/Tasks/Sources/Background Download/BackgroundDownloadTaskTests.swift
@@ -7,6 +7,7 @@
 import Testing
 
 @testable import RequestDL
+@testable import RequestDLTestSupport
 
 #if canImport(FoundationEssentials)
 import FoundationEssentials
@@ -14,17 +15,22 @@ import FoundationEssentials
 import struct Foundation.URL
 #endif
 
-/// Only covers `result()`'s validation guard -- the part that runs and throws before ever
-/// touching `BackgroundDownloads.Session.shared`. Actually scheduling a download would start a
-/// real `URLSessionConfiguration.background` session from this bare SwiftPM test harness, an
-/// unsigned CLI process with none of the entitlements a real app target has; that path is not
-/// exercised here, the same way this suite's mTLS tests don't exercise a real Keychain round trip
-/// either.
+/// Only covers `result()`'s validation guard -- the part that runs and throws (or doesn't) before
+/// ever reaching `BackgroundDownloads.Session.shared.schedule(...)`. Actually scheduling a
+/// download would start a real `URLSessionConfiguration.background` session from this bare
+/// SwiftPM test harness, an unsigned CLI process with none of the entitlements a real app target
+/// has; that path is not exercised here, the same way this suite's mTLS tests don't exercise a
+/// real Keychain round trip either. `TrustRoots`/`AdditionalTrustRoots` resolving correctly is
+/// covered directly against `Internals.ServerTrustPolicy` in `RequestDLInternalsTests`, including
+/// a real handshake -- nothing here needs `Session` involved to prove that part works.
 struct BackgroundDownloadTaskTests {
 
     @Test
-    func result_whenContentConfiguresSecureConnection_throwsUnsupportedConfigurationError() async throws {
-        // Given
+    func result_whenContentConfiguresClientCertificate_throwsUnsupportedConfigurationError() async throws {
+        // Given -- a real client certificate/key pair (mTLS), still rejected regardless of trust
+        // roots being supported now.
+        let client = Certificates().client()
+
         let task = BackgroundDownloadTask(
             id: "episode-42",
             destination: URL(fileURLWithPath: "/tmp/episode-42.mp3")
@@ -32,7 +38,8 @@ struct BackgroundDownloadTaskTests {
             BaseURL("localhost")
 
             SecureConnection {
-                TrustRoots("/dev/null")
+                RequestDL.Certificates(client.certificateURL.absolutePath(percentEncoded: false))
+                PrivateKey(client.privateKeyURL.absolutePath(percentEncoded: false))
             }
         }
 
@@ -43,8 +50,10 @@ struct BackgroundDownloadTaskTests {
     }
 
     @Test
-    func result_whenContentConfiguresSecureConnection_errorReadsActionably() async throws {
+    func result_whenContentConfiguresClientCertificate_errorReadsActionably() async throws {
         // Given
+        let client = Certificates().client()
+
         let task = BackgroundDownloadTask(
             id: "episode-42",
             destination: URL(fileURLWithPath: "/tmp/episode-42.mp3")
@@ -52,7 +61,8 @@ struct BackgroundDownloadTaskTests {
             BaseURL("localhost")
 
             SecureConnection {
-                TrustRoots("/dev/null")
+                RequestDL.Certificates(client.certificateURL.absolutePath(percentEncoded: false))
+                PrivateKey(client.privateKeyURL.absolutePath(percentEncoded: false))
             }
         }
 
@@ -62,7 +72,33 @@ struct BackgroundDownloadTaskTests {
             Issue.record("Expected BackgroundDownloadUnsupportedConfigurationError")
         } catch let error as BackgroundDownloadUnsupportedConfigurationError {
             #expect((error as any Error).localizedDescription == error.description)
-            #expect(error.description.contains("SecureConnection"))
+            #expect(error.description.contains("mTLS") || error.description.contains("client identity"))
+        }
+    }
+
+    /// Only half a client identity configured (`Certificates` without `PrivateKey`) must still be
+    /// rejected the same way a complete pair is -- it's just as unable to survive a relaunch, and
+    /// `Internals.URLSessionIdentityPolicy` would reject it anyway once actually scheduled, just
+    /// later and less clearly than doing it here.
+    @Test
+    func result_whenContentConfiguresOnlyCertificateChain_throwsUnsupportedConfigurationError() async throws {
+        // Given
+        let client = Certificates().client()
+
+        let task = BackgroundDownloadTask(
+            id: "episode-42",
+            destination: URL(fileURLWithPath: "/tmp/episode-42.mp3")
+        ) {
+            BaseURL("localhost")
+
+            SecureConnection {
+                RequestDL.Certificates(client.certificateURL.absolutePath(percentEncoded: false))
+            }
+        }
+
+        // When / Then
+        await #expect(throws: BackgroundDownloadUnsupportedConfigurationError.self) {
+            try await task.result()
         }
     }
 }

--- a/Tests/RequestDLTests/Tasks/Sources/Background Download/BackgroundDownloadTaskTests.swift
+++ b/Tests/RequestDLTests/Tasks/Sources/Background Download/BackgroundDownloadTaskTests.swift
@@ -4,6 +4,7 @@
 
 #if canImport(Darwin)
 
+import NIOSSL
 import Testing
 
 @testable import RequestDL
@@ -12,6 +13,7 @@ import Testing
 #if canImport(FoundationEssentials)
 import FoundationEssentials
 #else
+import struct Foundation.Data
 import struct Foundation.URL
 #endif
 
@@ -20,16 +22,18 @@ import struct Foundation.URL
 /// download would start a real `URLSessionConfiguration.background` session from this bare
 /// SwiftPM test harness, an unsigned CLI process with none of the entitlements a real app target
 /// has; that path is not exercised here, the same way this suite's mTLS tests don't exercise a
-/// real Keychain round trip either. `TrustRoots`/`AdditionalTrustRoots` resolving correctly is
-/// covered directly against `Internals.ServerTrustPolicy` in `RequestDLInternalsTests`, including
-/// a real handshake -- nothing here needs `Session` involved to prove that part works.
+/// real Keychain round trip either. A file-backed client certificate is legitimately *accepted*
+/// now (no longer a rejection case) -- see `InternalsClientIdentityDescriptorTests` for that half,
+/// since proving it doesn't throw here would mean letting `result()` run all the way to
+/// `schedule(...)`.
 struct BackgroundDownloadTaskTests {
 
     @Test
-    func result_whenContentConfiguresClientCertificate_throwsUnsupportedConfigurationError() async throws {
-        // Given -- a real client certificate/key pair (mTLS), still rejected regardless of trust
-        // roots being supported now.
+    func result_whenClientCertificateIsBytesBacked_throwsUnsupportedConfigurationError() async throws {
+        // Given -- valid, complete, in-memory bytes rather than a file path.
         let client = Certificates().client()
+        let certificateBytes = try [UInt8](Data(contentsOf: client.certificateURL))
+        let privateKeyBytes = try [UInt8](Data(contentsOf: client.privateKeyURL))
 
         let task = BackgroundDownloadTask(
             id: "episode-42",
@@ -38,31 +42,8 @@ struct BackgroundDownloadTaskTests {
             BaseURL("localhost")
 
             SecureConnection {
-                RequestDL.Certificates(client.certificateURL.absolutePath(percentEncoded: false))
-                PrivateKey(client.privateKeyURL.absolutePath(percentEncoded: false))
-            }
-        }
-
-        // When / Then
-        await #expect(throws: BackgroundDownloadUnsupportedConfigurationError.self) {
-            try await task.result()
-        }
-    }
-
-    @Test
-    func result_whenContentConfiguresClientCertificate_errorReadsActionably() async throws {
-        // Given
-        let client = Certificates().client()
-
-        let task = BackgroundDownloadTask(
-            id: "episode-42",
-            destination: URL(fileURLWithPath: "/tmp/episode-42.mp3")
-        ) {
-            BaseURL("localhost")
-
-            SecureConnection {
-                RequestDL.Certificates(client.certificateURL.absolutePath(percentEncoded: false))
-                PrivateKey(client.privateKeyURL.absolutePath(percentEncoded: false))
+                RequestDL.Certificates(certificateBytes)
+                PrivateKey(privateKeyBytes)
             }
         }
 
@@ -71,15 +52,49 @@ struct BackgroundDownloadTaskTests {
             try await task.result()
             Issue.record("Expected BackgroundDownloadUnsupportedConfigurationError")
         } catch let error as BackgroundDownloadUnsupportedConfigurationError {
+            guard case .nonFileBackedSource = error.reason else {
+                Issue.record("Expected .nonFileBackedSource, got \(error.reason)")
+                return
+            }
             #expect((error as any Error).localizedDescription == error.description)
-            #expect(error.description.contains("mTLS") || error.description.contains("client identity"))
+            #expect(error.description.contains("file path"))
+        }
+    }
+
+    @Test
+    func result_whenPrivateKeyIsPasswordProtected_throwsUnsupportedConfigurationError() async throws {
+        // Given
+        let client = Certificates().client(password: true)
+
+        let task = BackgroundDownloadTask(
+            id: "episode-42",
+            destination: URL(fileURLWithPath: "/tmp/episode-42.mp3")
+        ) {
+            BaseURL("localhost")
+
+            SecureConnection {
+                RequestDL.Certificates(client.certificateURL.absolutePath(percentEncoded: false))
+                PrivateKey(
+                    client.privateKeyURL.absolutePath(percentEncoded: false),
+                    password: NIOSSLSecureBytes("password".utf8)
+                )
+            }
+        }
+
+        // When / Then
+        do {
+            try await task.result()
+            Issue.record("Expected BackgroundDownloadUnsupportedConfigurationError")
+        } catch let error as BackgroundDownloadUnsupportedConfigurationError {
+            guard case .passwordProtectedPrivateKey = error.reason else {
+                Issue.record("Expected .passwordProtectedPrivateKey, got \(error.reason)")
+                return
+            }
         }
     }
 
     /// Only half a client identity configured (`Certificates` without `PrivateKey`) must still be
-    /// rejected the same way a complete pair is -- it's just as unable to survive a relaunch, and
-    /// `Internals.URLSessionIdentityPolicy` would reject it anyway once actually scheduled, just
-    /// later and less clearly than doing it here.
+    /// rejected -- it's just as unable to answer a challenge as any other unsupported shape.
     @Test
     func result_whenContentConfiguresOnlyCertificateChain_throwsUnsupportedConfigurationError() async throws {
         // Given
@@ -97,8 +112,14 @@ struct BackgroundDownloadTaskTests {
         }
 
         // When / Then
-        await #expect(throws: BackgroundDownloadUnsupportedConfigurationError.self) {
+        do {
             try await task.result()
+            Issue.record("Expected BackgroundDownloadUnsupportedConfigurationError")
+        } catch let error as BackgroundDownloadUnsupportedConfigurationError {
+            guard case .incompleteClientIdentity = error.reason else {
+                Issue.record("Expected .incompleteClientIdentity, got \(error.reason)")
+                return
+            }
         }
     }
 }

--- a/Tests/RequestDLTests/Tasks/Sources/Background Download/Models/BackgroundDownloadsSessionDelegateTests.swift
+++ b/Tests/RequestDLTests/Tasks/Sources/Background Download/Models/BackgroundDownloadsSessionDelegateTests.swift
@@ -1,0 +1,313 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+#if canImport(Darwin)
+
+import SwiftAsyncStream
+import Testing
+
+@testable import RequestDL
+@testable import RequestDLTestSupport
+
+import Foundation
+
+/// Covers `BackgroundDownloads.Session`'s `URLSessionDownloadDelegate` callbacks directly, against
+/// a task built from an ordinary (non-background) `URLSession.shared` -- never resumed, only ever
+/// used as a way to get a real `URLSessionDownloadTask` object to set `taskDescription` on and
+/// hand to the delegate method by hand. This exercises the same code a real background transfer
+/// would run through, without starting one: this SwiftPM test harness has none of the entitlements
+/// a real background session needs to actually schedule anything (the same gap already documented
+/// for Keychain-backed mTLS), so this is the ceiling of what can be verified here -- see
+/// `BackgroundDownloadTaskTests`'s own doc comment for the same reasoning applied to `result()`.
+///
+/// Every delegate method under test is synchronous by contract (that's the whole reason `Session`
+/// isn't an `actor` -- see its own doc comment), so every assertion below runs immediately after
+/// the call that's supposed to have triggered it, with no `await`/polling needed. Every test also
+/// builds its own `BackgroundDownloads.Session()` rather than reusing `.shared`, so `onEvent`
+/// assertions never race another test's.
+struct BackgroundDownloadsSessionDelegateTests {
+
+    // MARK: - didFinishDownloadingTo
+
+    @Test
+    func didFinishDownloadingTo_whenTaskDescriptionValid_movesFileToDestinationAndReportsCompleted() async throws {
+        try await withTemporaryFileURL("source.tmp") { location in
+            try await withTemporaryFileURL("destination.bin") { destination in
+                // Given
+                try Data("downloaded content".utf8).write(to: location)
+
+                let session = BackgroundDownloads.Session()
+                let events = EventBox()
+                session.onEvent = { events.append($0) }
+
+                let task = URLSession.shared.downloadTask(with: try #require(URL(string: "https://example.com")))
+                task.taskDescription = BackgroundDownloads.Session.encode(id: "episode-42", destination: destination)
+
+                // When
+                session.urlSession(.shared, downloadTask: task, didFinishDownloadingTo: location)
+
+                // Then
+                #expect(try Data(contentsOf: destination) == Data("downloaded content".utf8))
+                #expect(!FileManager.default.fileExists(atPath: location.path))
+
+                let recorded = events.all
+                #expect(recorded.count == 1)
+
+                guard case .completed(let id, let recordedDestination) = try #require(recorded.first) else {
+                    Issue.record("Expected .completed, got \(String(describing: recorded.first))")
+                    return
+                }
+                #expect(id == "episode-42")
+                #expect(recordedDestination == destination)
+            }
+        }
+    }
+
+    @Test
+    func didFinishDownloadingTo_whenDestinationAlreadyExists_overwritesIt() async throws {
+        try await withTemporaryFileURL("source.tmp") { location in
+            try await withTemporaryFileURL("destination.bin") { destination in
+                // Given -- `withTemporaryFileURL` itself already creates an empty file at
+                // `destination`, so this is already exercising the overwrite path; write
+                // something recognizable there first to make sure it really gets replaced, not
+                // just left alone as "already existing."
+                try Data("stale content".utf8).write(to: destination)
+                try Data("fresh content".utf8).write(to: location)
+
+                let session = BackgroundDownloads.Session()
+
+                let task = URLSession.shared.downloadTask(with: try #require(URL(string: "https://example.com")))
+                task.taskDescription = BackgroundDownloads.Session.encode(id: "episode-42", destination: destination)
+
+                // When
+                session.urlSession(.shared, downloadTask: task, didFinishDownloadingTo: location)
+
+                // Then
+                #expect(try Data(contentsOf: destination) == Data("fresh content".utf8))
+            }
+        }
+    }
+
+    @Test
+    func didFinishDownloadingTo_whenSourceFileIsMissing_reportsFailed() async throws {
+        try await withTemporaryFileURL("destination.bin") { destination in
+            // Given -- `location` deliberately never gets a file written to it, so `moveItem`
+            // has nothing to move.
+            let missingLocation = temporaryDirectoryURL.appendingPathComponent("RequestDL.\(UUID()).missing")
+
+            let session = BackgroundDownloads.Session()
+            let events = EventBox()
+            session.onEvent = { events.append($0) }
+
+            let task = URLSession.shared.downloadTask(with: try #require(URL(string: "https://example.com")))
+            task.taskDescription = BackgroundDownloads.Session.encode(id: "episode-42", destination: destination)
+
+            // When
+            session.urlSession(.shared, downloadTask: task, didFinishDownloadingTo: missingLocation)
+
+            // Then
+            let recorded = events.all
+            #expect(recorded.count == 1)
+
+            guard case .failed(let id, let recordedDestination, _) = try #require(recorded.first) else {
+                Issue.record("Expected .failed, got \(String(describing: recorded.first))")
+                return
+            }
+            #expect(id == "episode-42")
+            #expect(recordedDestination == destination)
+        }
+    }
+
+    @Test
+    func didFinishDownloadingTo_whenTaskDescriptionMissing_doesNothing() async throws {
+        try await withTemporaryFileURL("source.tmp") { location in
+            // Given -- no `taskDescription` set at all, the shape a task RequestDL didn't create
+            // would have.
+            try Data("content".utf8).write(to: location)
+
+            let session = BackgroundDownloads.Session()
+            let events = EventBox()
+            session.onEvent = { events.append($0) }
+
+            let task = URLSession.shared.downloadTask(with: try #require(URL(string: "https://example.com")))
+
+            // When
+            session.urlSession(.shared, downloadTask: task, didFinishDownloadingTo: location)
+
+            // Then -- neither reported nor moved; this task simply isn't this delegate's to
+            // handle.
+            #expect(events.all.isEmpty)
+            #expect(FileManager.default.fileExists(atPath: location.path))
+        }
+    }
+
+    // MARK: - didWriteData
+
+    @Test
+    func didWriteData_reportsProgressWithRunningTotals() async throws {
+        try await withTemporaryFileURL("destination.bin") { destination in
+            // Given
+            let session = BackgroundDownloads.Session()
+            let events = EventBox()
+            session.onEvent = { events.append($0) }
+
+            let task = URLSession.shared.downloadTask(with: try #require(URL(string: "https://example.com")))
+            task.taskDescription = BackgroundDownloads.Session.encode(id: "episode-42", destination: destination)
+
+            // When
+            session.urlSession(
+                .shared,
+                downloadTask: task,
+                didWriteData: 1_024,
+                totalBytesWritten: 4_096,
+                totalBytesExpectedToWrite: 16_384
+            )
+
+            // Then -- the running totals, not the size of this one callback.
+            let recorded = events.all
+            #expect(recorded.count == 1)
+
+            guard
+                case .progress(let id, let recordedDestination, let bytesWritten, let totalBytesExpected) =
+                    try #require(recorded.first)
+            else {
+                Issue.record("Expected .progress, got \(String(describing: recorded.first))")
+                return
+            }
+            #expect(id == "episode-42")
+            #expect(recordedDestination == destination)
+            #expect(bytesWritten == 4_096)
+            #expect(totalBytesExpected == 16_384)
+        }
+    }
+
+    // MARK: - didCompleteWithError
+
+    @Test
+    func didCompleteWithError_whenErrorPresent_reportsFailed() async throws {
+        try await withTemporaryFileURL("destination.bin") { destination in
+            // Given
+            struct SomeError: Error {}
+
+            let session = BackgroundDownloads.Session()
+            let events = EventBox()
+            session.onEvent = { events.append($0) }
+
+            let task = URLSession.shared.downloadTask(with: try #require(URL(string: "https://example.com")))
+            task.taskDescription = BackgroundDownloads.Session.encode(id: "episode-42", destination: destination)
+
+            // When
+            session.urlSession(.shared, task: task, didCompleteWithError: SomeError())
+
+            // Then
+            let recorded = events.all
+            #expect(recorded.count == 1)
+
+            guard case .failed(let id, let recordedDestination, let error) = try #require(recorded.first) else {
+                Issue.record("Expected .failed, got \(String(describing: recorded.first))")
+                return
+            }
+            #expect(id == "episode-42")
+            #expect(recordedDestination == destination)
+            #expect(error is SomeError)
+        }
+    }
+
+    /// The delegate also fires this on success, with `error == nil` -- must not double-report on
+    /// top of `didFinishDownloadingTo`'s own `.completed` event.
+    @Test
+    func didCompleteWithError_whenErrorIsNil_reportsNothing() async throws {
+        try await withTemporaryFileURL("destination.bin") { destination in
+            // Given
+            let session = BackgroundDownloads.Session()
+            let events = EventBox()
+            session.onEvent = { events.append($0) }
+
+            let task = URLSession.shared.downloadTask(with: try #require(URL(string: "https://example.com")))
+            task.taskDescription = BackgroundDownloads.Session.encode(id: "episode-42", destination: destination)
+
+            // When
+            session.urlSession(.shared, task: task, didCompleteWithError: nil)
+
+            // Then
+            #expect(events.all.isEmpty)
+        }
+    }
+
+    // MARK: - handleEvents / urlSessionDidFinishEvents
+
+    @Test
+    func handleEvents_whenIdentifierMatches_storesHandlerAndFinishEventsCallsAndClearsIt() async throws {
+        // Given
+        let session = BackgroundDownloads.Session()
+        let firstCalled = CallBox()
+
+        session.handleEvents(forIdentifier: BackgroundDownloads.Session.identifier) {
+            firstCalled.markCalled()
+        }
+
+        // When
+        session.urlSessionDidFinishEvents(forBackgroundURLSession: .shared)
+
+        // Then
+        #expect(firstCalled.wasCalled)
+
+        // And -- a second finish-events call with no new `handleEvents` in between must not
+        // re-invoke a stale handler.
+        let secondCalled = CallBox()
+        session.urlSessionDidFinishEvents(forBackgroundURLSession: .shared)
+        #expect(!secondCalled.wasCalled)
+    }
+
+    @Test
+    func handleEvents_whenIdentifierDoesNotMatch_neverStoresHandler() async throws {
+        // Given
+        let session = BackgroundDownloads.Session()
+        let called = CallBox()
+
+        // When
+        session.handleEvents(forIdentifier: "some.other.session") {
+            called.markCalled()
+        }
+        session.urlSessionDidFinishEvents(forBackgroundURLSession: .shared)
+
+        // Then
+        #expect(!called.wasCalled)
+    }
+}
+
+// MARK: - Test helpers
+
+/// Both helpers below are plain, lock-backed classes, not actors -- every callback under test
+/// (`onEvent`, `handleEvents`'s `completionHandler`) is synchronous by contract, so an `actor`
+/// would force an `await` onto assertions that need to run immediately, not after a hop.
+private final class EventBox: @unchecked Sendable {
+
+    private let lock = Lock()
+    private var _all: [BackgroundDownloads.Event] = []
+
+    var all: [BackgroundDownloads.Event] {
+        lock.withLock { _all }
+    }
+
+    func append(_ event: BackgroundDownloads.Event) {
+        lock.withLock { _all.append(event) }
+    }
+}
+
+private final class CallBox: @unchecked Sendable {
+
+    private let lock = Lock()
+    private var _wasCalled = false
+
+    var wasCalled: Bool {
+        lock.withLock { _wasCalled }
+    }
+
+    func markCalled() {
+        lock.withLock { _wasCalled = true }
+    }
+}
+
+#endif

--- a/Tests/RequestDLTests/Tasks/Sources/Background Download/Models/BackgroundDownloadsSessionTests.swift
+++ b/Tests/RequestDLTests/Tasks/Sources/Background Download/Models/BackgroundDownloadsSessionTests.swift
@@ -1,0 +1,49 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+#if canImport(Darwin)
+
+import Testing
+
+@testable import RequestDL
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import struct Foundation.URL
+#endif
+
+/// Covers `BackgroundDownloads.Session`'s `taskDescription` encoding directly, independent of any
+/// real `URLSessionTask` -- this is what a delegate callback decodes after a relaunch, when
+/// nothing else about the original request survives, so it needs to round-trip correctly on its
+/// own merits, not just "happen to work" against whatever a live download produces.
+struct BackgroundDownloadsSessionTests {
+
+    @Test
+    func encodeThenDecode_roundTripsIdAndDestination() async throws {
+        // Given
+        let id = "episode-42"
+        let destination = URL(fileURLWithPath: "/tmp/episode-42.mp3")
+
+        // When
+        let encoded = try #require(BackgroundDownloads.Session.encode(id: id, destination: destination))
+        let decoded = try #require(BackgroundDownloads.Session.decode(encoded))
+
+        // Then
+        #expect(decoded.id == id)
+        #expect(decoded.destination == destination)
+    }
+
+    @Test
+    func decode_whenTaskDescriptionIsNil_returnsNil() async throws {
+        #expect(BackgroundDownloads.Session.decode(nil) == nil)
+    }
+
+    @Test
+    func decode_whenTaskDescriptionIsNotEncodedByThisType_returnsNil() async throws {
+        #expect(BackgroundDownloads.Session.decode("not a descriptor") == nil)
+    }
+}
+
+#endif

--- a/Tests/RequestDLTests/Tasks/Sources/Background Download/Models/BackgroundDownloadsSessionTests.swift
+++ b/Tests/RequestDLTests/Tasks/Sources/Background Download/Models/BackgroundDownloadsSessionTests.swift
@@ -4,6 +4,7 @@
 
 #if canImport(Darwin)
 
+import RequestDLInternals
 import Testing
 
 @testable import RequestDL
@@ -39,6 +40,45 @@ struct BackgroundDownloadsSessionTests {
     @Test
     func decode_whenTaskDescriptionIsNotEncodedByThisType_returnsNil() async throws {
         #expect(BackgroundDownloads.Session.decode("not a descriptor") == nil)
+    }
+
+    // MARK: - serverTrust encoding
+
+    @Test
+    func encodeThenDecodeServerTrust_roundTripsDescriptor() async throws {
+        // Given
+        let descriptor = Internals.ServerTrustPolicy.Descriptor(
+            trustedRootCertificatesDER: [Data([0x01, 0x02, 0x03])],
+            verification: .noHostnameVerification
+        )
+
+        // When
+        let encoded = BackgroundDownloads.Session.encode(
+            id: "episode-42",
+            destination: URL(fileURLWithPath: "/tmp/episode-42.mp3"),
+            serverTrust: descriptor
+        )
+        let decoded = BackgroundDownloads.Session.decodeServerTrust(encoded)
+
+        // Then
+        #expect(decoded == descriptor)
+    }
+
+    @Test
+    func decodeServerTrust_whenNoneWasEncoded_returnsNil() async throws {
+        // Given -- the common case: a plain download, `serverTrust` defaulted to `nil`.
+        let encoded = BackgroundDownloads.Session.encode(
+            id: "episode-42",
+            destination: URL(fileURLWithPath: "/tmp/episode-42.mp3")
+        )
+
+        // When / Then
+        #expect(BackgroundDownloads.Session.decodeServerTrust(encoded) == nil)
+    }
+
+    @Test
+    func decodeServerTrust_whenTaskDescriptionIsNotEncodedByThisType_returnsNil() async throws {
+        #expect(BackgroundDownloads.Session.decodeServerTrust("not a descriptor") == nil)
     }
 
     // MARK: - firstTask(matching:in:)

--- a/Tests/RequestDLTests/Tasks/Sources/Background Download/Models/BackgroundDownloadsSessionTests.swift
+++ b/Tests/RequestDLTests/Tasks/Sources/Background Download/Models/BackgroundDownloadsSessionTests.swift
@@ -81,6 +81,72 @@ struct BackgroundDownloadsSessionTests {
         #expect(BackgroundDownloads.Session.decodeServerTrust("not a descriptor") == nil)
     }
 
+    // MARK: - clientIdentity encoding
+
+    @Test
+    func encodeThenDecodeClientIdentity_roundTripsDescriptor() async throws {
+        // Given
+        let descriptor = Internals.ClientIdentityDescriptor(
+            certificateChainFilePath: "/tmp/client.pem",
+            privateKeyFilePath: "/tmp/client.key",
+            privateKeyFormat: .pem
+        )
+
+        // When
+        let encoded = BackgroundDownloads.Session.encode(
+            id: "episode-42",
+            destination: URL(fileURLWithPath: "/tmp/episode-42.mp3"),
+            clientIdentity: descriptor
+        )
+        let decoded = BackgroundDownloads.Session.decodeClientIdentity(encoded)
+
+        // Then
+        #expect(decoded == descriptor)
+    }
+
+    @Test
+    func decodeClientIdentity_whenNoneWasEncoded_returnsNil() async throws {
+        // Given -- the common case: no client certificate configured.
+        let encoded = BackgroundDownloads.Session.encode(
+            id: "episode-42",
+            destination: URL(fileURLWithPath: "/tmp/episode-42.mp3")
+        )
+
+        // When / Then
+        #expect(BackgroundDownloads.Session.decodeClientIdentity(encoded) == nil)
+    }
+
+    @Test
+    func decodeClientIdentity_whenTaskDescriptionIsNotEncodedByThisType_returnsNil() async throws {
+        #expect(BackgroundDownloads.Session.decodeClientIdentity("not a descriptor") == nil)
+    }
+
+    @Test
+    func encodeThenDecode_carriesBothServerTrustAndClientIdentityIndependently() async throws {
+        // Given -- both configured at once, the mTLS + custom-trust-roots combination.
+        let serverTrust = Internals.ServerTrustPolicy.Descriptor(
+            trustedRootCertificatesDER: [Data([0x01])],
+            verification: .fullVerification
+        )
+        let clientIdentity = Internals.ClientIdentityDescriptor(
+            certificateChainFilePath: "/tmp/client.pem",
+            privateKeyFilePath: "/tmp/client.key",
+            privateKeyFormat: .pem
+        )
+
+        // When
+        let encoded = BackgroundDownloads.Session.encode(
+            id: "episode-42",
+            destination: URL(fileURLWithPath: "/tmp/episode-42.mp3"),
+            serverTrust: serverTrust,
+            clientIdentity: clientIdentity
+        )
+
+        // Then
+        #expect(BackgroundDownloads.Session.decodeServerTrust(encoded) == serverTrust)
+        #expect(BackgroundDownloads.Session.decodeClientIdentity(encoded) == clientIdentity)
+    }
+
     // MARK: - firstTask(matching:in:)
 
     /// `cancel(id:)`'s own matching logic, pulled out so it's testable against a plain array of

--- a/Tests/RequestDLTests/Tasks/Sources/Background Download/Models/BackgroundDownloadsSessionTests.swift
+++ b/Tests/RequestDLTests/Tasks/Sources/Background Download/Models/BackgroundDownloadsSessionTests.swift
@@ -8,11 +8,7 @@ import Testing
 
 @testable import RequestDL
 
-#if canImport(FoundationEssentials)
-import FoundationEssentials
-#else
-import struct Foundation.URL
-#endif
+import Foundation
 
 /// Covers `BackgroundDownloads.Session`'s `taskDescription` encoding directly, independent of any
 /// real `URLSessionTask` -- this is what a delegate callback decodes after a relaunch, when
@@ -43,6 +39,85 @@ struct BackgroundDownloadsSessionTests {
     @Test
     func decode_whenTaskDescriptionIsNotEncodedByThisType_returnsNil() async throws {
         #expect(BackgroundDownloads.Session.decode("not a descriptor") == nil)
+    }
+
+    // MARK: - firstTask(matching:in:)
+
+    /// `cancel(id:)`'s own matching logic, pulled out so it's testable against a plain array of
+    /// tasks instead of a real background `URLSession.allTasks`. Every task below comes from
+    /// `URLSession.shared`, created but never resumed -- just a way to get a real
+    /// `URLSessionTask` object to set `taskDescription` on.
+    @Test
+    func firstTaskMatching_whenOneTaskHasMatchingID_returnsIt() async throws {
+        // Given
+        let url = try #require(URL(string: "https://example.com"))
+        let wanted = URLSession.shared.downloadTask(with: url)
+        wanted.taskDescription = BackgroundDownloads.Session.encode(
+            id: "episode-42",
+            destination: URL(fileURLWithPath: "/tmp/episode-42.mp3")
+        )
+
+        let other = URLSession.shared.downloadTask(with: url)
+        other.taskDescription = BackgroundDownloads.Session.encode(
+            id: "episode-1",
+            destination: URL(fileURLWithPath: "/tmp/episode-1.mp3")
+        )
+
+        // When
+        let match = BackgroundDownloads.Session.firstTask(matching: "episode-42", in: [other, wanted])
+
+        // Then
+        #expect(match === wanted)
+    }
+
+    @Test
+    func firstTaskMatching_whenNoTaskHasMatchingID_returnsNil() async throws {
+        // Given
+        let url = try #require(URL(string: "https://example.com"))
+        let task = URLSession.shared.downloadTask(with: url)
+        task.taskDescription = BackgroundDownloads.Session.encode(
+            id: "episode-1",
+            destination: URL(fileURLWithPath: "/tmp/episode-1.mp3")
+        )
+
+        // When / Then
+        #expect(BackgroundDownloads.Session.firstTask(matching: "episode-42", in: [task]) == nil)
+    }
+
+    @Test
+    func firstTaskMatching_ignoresTasksWithNoOrUnrecognizedTaskDescription() async throws {
+        // Given
+        let url = try #require(URL(string: "https://example.com"))
+
+        let noDescription = URLSession.shared.downloadTask(with: url)
+
+        let unrecognized = URLSession.shared.downloadTask(with: url)
+        unrecognized.taskDescription = "not a descriptor"
+
+        // When / Then -- neither crashes nor false-matches; a task this type didn't create simply
+        // isn't a candidate.
+        let match = BackgroundDownloads.Session.firstTask(
+            matching: "episode-42",
+            in: [noDescription, unrecognized]
+        )
+        #expect(match == nil)
+    }
+
+    @Test
+    func firstTaskMatching_whenListIsEmpty_returnsNil() async throws {
+        #expect(BackgroundDownloads.Session.firstTask(matching: "episode-42", in: []) == nil)
+    }
+
+    // MARK: - cancel(id:)
+
+    @Test
+    func cancel_whenNoDownloadHasEverBeenScheduled_returnsFalse() async throws {
+        // Given -- a fresh `Session` that has never scheduled anything, so there is no
+        // `URLSession` to even ask.
+        let session = BackgroundDownloads.Session()
+
+        // When / Then
+        #expect(await session.cancel(id: "episode-42") == false)
     }
 }
 


### PR DESCRIPTION
## Summary

Adds `BackgroundDownloadTask`, a new task type that schedules a download via `URLSessionConfiguration.background` — one that keeps running even if the app is suspended or terminated, independent of the existing `RawTask`/`RequestExecutingClient` pipeline entirely. Background sessions need a session-level delegate created up front, file-based tasks only, and per-download state that survives a full process relaunch with nothing else in memory — none of which the live-request pipeline is shaped for, so this is a self-contained new code path rather than a variant of `DownloadTask`.

- **`BackgroundDownloadTask<Content>`** — schedules the download and returns as soon as it's scheduled (`result()` does not wait for completion, which may happen in a different process launch entirely). Does not conform to `RequestTask`: modifiers/interceptors assume an in-process result, which doesn't hold here.
- **`BackgroundDownloads`** — a deliberately non-generic namespace (a generic type's static storage is per-specialization in Swift) holding:
  - `onEvent` — one process-wide handler for `.progress`/`.completed`/`.failed`.
  - `handleEvents(forBackgroundURLSession:completionHandler:)` — forwards `application(_:handleEventsForBackgroundURLSession:completionHandler:)`, required for the system to reconnect after a relaunch.
  - `cancel(id:)` — finds the live task via `URLSession.allTasks` (no in-memory `id -> task` index, which would be useless after a relaunch anyway) and cancels it; a cancellation surfaces through `onEvent` as an ordinary `.failed` event (`NSURLErrorCancelled`), not a distinct case.
- **Per-download correlation rides on `URLSessionTask.taskDescription`** (JSON-encoded `id`/`destination`/optional server-trust and client-identity descriptors) instead of a separate on-disk registry — the system already persists it across a relaunch for free.
- **Full `SecureConnection` support**, including mTLS:
  - `TrustRoots`/`AdditionalTrustRoots`/`verification(_:)` — their certificate bytes (public data) travel directly in `taskDescription`, no Keychain involved.
  - **A client certificate (mTLS) also works now**, as long as both `Certificate` and `PrivateKey` come from a **file path**, not in-memory bytes, and the key isn't password-protected. Only the file path is persisted — never the key material — and the identity is rebuilt fresh from disk via a Keychain round-trip on every challenge, live or after a relaunch alike, then removed again immediately after use (no identity is ever cached across calls). `BackgroundDownloadUnsupportedConfigurationError` carries a `Reason` for the three cases that still can't be supported (in-memory bytes, a pre-built certificate, or a password-protected key).

### Refactor along the way

Extracted the server-trust half of `Internals.URLSessionIdentityPolicy` into its own `Internals.ServerTrustPolicy` (behavior-preserving — the existing mTLS/trust-roots suite passes unmodified). It gained a `Codable`, `NIOSSL`-free `Descriptor` (raw DER bytes + a `String`-backed verification enum) specifically so `BackgroundDownloadTask` can resolve one at schedule time and `BackgroundDownloads.Session` can rebuild an equivalent policy from nothing but that `Descriptor` at challenge time — exactly what's left after a relaunch. `Internals.ClientIdentityDescriptor` does the analogous job for the client-identity half, except it persists a file *path*, never key bytes, given the sensitivity of what it represents.

## Test coverage and its limits

This SwiftPM test harness is an unsigned CLI process with none of the entitlements a real app target has, so actually scheduling a background transfer isn't exercised here. What is covered directly:

- `BackgroundDownloadTask.result()`'s validation guard (every rejection reason, and trust-roots/server config accepted) — throws before ever touching a real session.
- Every `BackgroundDownloads.Session` delegate callback (`didFinishDownloadingTo`, `didWriteData`, `didCompleteWithError`, the challenge delegate for both server-trust and client-certificate, `handleEvents`/`urlSessionDidFinishEvents`), called directly against tasks built from `URLSession.shared` — created, never resumed, just a way to get a real `URLSessionTask` to set `taskDescription` on.
- `taskDescription` encode/decode round-trips for all three descriptors, and the `cancel(id:)` task-matching logic against a plain array of tasks.
- **Real handshake tests** (`InternalsServerTrustPolicyTests`, `InternalsClientIdentityDescriptorTests`) proving a policy/identity rebuilt from a JSON-round-tripped `Descriptor` alone — simulating exactly what survives a relaunch — still genuinely validates against `LocalServer`. The client-identity one is a confirmed, documented `withKnownIssue` in this harness specifically (no Keychain Sharing entitlement — the same gap already tracked for the live executor's own mTLS suite): it proves the wiring, not that this harness can complete the round trip.

## Test plan
- [x] `swift build` — clean
- [x] `swift test` — 883 + 426 tests passing, 2 + 3 known issues (one new: the client-identity handshake test above; everything else matches the base branch)
- [x] `swift format lint --recursive --strict` — clean
- [x] `xcodebuild docbuild` — clean, all `<doc:>`/symbol links resolve
- [x] New DocC article, `Downloading-in-the-Background.md`, cross-linked from `RequestDL.md` and `Exploring-task.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)