### PR TITLE
Fix HeaderGroup/QueryGroup silently dropping headers/queries

### DIFF
--- a/Sources/RequestDL/Properties/Sources/Headers/Header Group/HeaderGroup.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Header Group/HeaderGroup.swift
@@ -15,17 +15,6 @@
 /// ```
 public struct HeaderGroup<Content: Property>: Property {
 
-    private struct Node: PropertyNode {
-
-        let nodes: [LeafNode<HeaderNode>]
-
-        func make(_ make: inout Make) async throws {
-            for node in nodes {
-                try await node.make(&make)
-            }
-        }
-    }
-
     // MARK: - Public properties
 
     /// Returns an exception since `Never` is a type that can never be constructed.
@@ -62,7 +51,19 @@ public struct HeaderGroup<Content: Property>: Property {
             inputs: inputs
         )
 
-        return .leaf(Node(nodes: outputs.node.search(for: HeaderNode.self)))
+        // Kept as individual `LeafNode<HeaderNode>` children rather than collapsed into one
+        // opaque wrapper node: consumers that search the resolved graph for `HeaderNode`
+        // directly — `Proxy`'s `connectHeaders`, `Form`'s per-part headers — need each header
+        // to still be structurally discoverable. A single combined leaf hid them from that
+        // search entirely, silently dropping every header composed through `HeaderGroup` in
+        // those contexts.
+        var children = ChildrenNode()
+
+        for header in outputs.node.search(for: HeaderNode.self) {
+            children.append(header)
+        }
+
+        return .children(children)
     }
 }
 

--- a/Sources/RequestDL/Properties/Sources/URL/Query Group/QueryGroup.swift
+++ b/Sources/RequestDL/Properties/Sources/URL/Query Group/QueryGroup.swift
@@ -15,21 +15,6 @@
 ///  ```
 public struct QueryGroup<Content: Property>: Property {
 
-    struct Node: PropertyNode {
-
-        let leafs: [LeafNode<QueryNode>]
-
-        fileprivate init(_ leafs: [LeafNode<QueryNode>]) {
-            self.leafs = leafs
-        }
-
-        func make(_ make: inout Make) async throws {
-            for leaf in leafs {
-                try await leaf.make(&make)
-            }
-        }
-    }
-
     // MARK: - Public properties
 
     /// Returns an exception since `Never` is a type that can never be constructed.
@@ -66,7 +51,20 @@ public struct QueryGroup<Content: Property>: Property {
             inputs: inputs
         )
 
-        return .leaf(Node(output.node.search(for: QueryNode.self)))
+        // Kept as individual `LeafNode<QueryNode>` children rather than collapsed into one
+        // opaque wrapper node: a `QueryGroup` nested inside another `QueryGroup` needs its own
+        // resolved queries to still be structurally discoverable by the outer group's own
+        // `search(for: QueryNode.self)`. A single combined leaf hid them from that search
+        // entirely, silently dropping every query composed through a nested `QueryGroup` — the
+        // same class of bug fixed for `HeaderGroup`, whose leaf-wrapping broke `Proxy`'s and
+        // `Form`'s external searches for `HeaderNode` the same way.
+        var children = ChildrenNode()
+
+        for query in output.node.search(for: QueryNode.self) {
+            children.append(query)
+        }
+
+        return .children(children)
     }
 }
 

--- a/Tests/RequestDLTests/Properties/Sources/Graph/Resolve/ResolveTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Graph/Resolve/ResolveTests.swift
@@ -201,29 +201,25 @@ extension ResolveTests {
                         }
                     }
                 },
-                LeafNode<Node> {
-                    property = Node {
-                        leafs = [
-                            LeafNode<QueryNode> {
-                                property = QueryNode {
-                                    name = q,
-                                    value = some question,
-                                    urlEncoder = URLEncoder {
-                                        lock = Lock,
-                                        _configuration = Configuration {
-                                            date = .iso8601,
-                                            key = .literal,
-                                            data = .base64,
-                                            bool = .literal,
-                                            optional = .literal,
-                                            array = .droppingIndex,
-                                            dictionary = .subscripted,
-                                            whitespace = .percentEscaping
-                                        }
-                                    }
+                ChildrenNode {
+                    LeafNode<QueryNode> {
+                        property = QueryNode {
+                            name = q,
+                            value = some question,
+                            urlEncoder = URLEncoder {
+                                lock = Lock,
+                                _configuration = Configuration {
+                                    date = .iso8601,
+                                    key = .literal,
+                                    data = .base64,
+                                    bool = .literal,
+                                    optional = .literal,
+                                    array = .droppingIndex,
+                                    dictionary = .subscripted,
+                                    whitespace = .percentEscaping
                                 }
                             }
-                        ]
+                        }
                     }
                 }
             }

--- a/Tests/RequestDLTests/Properties/Sources/Graph/Resolve/ResolveTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Graph/Resolve/ResolveTests.swift
@@ -181,28 +181,24 @@ extension ResolveTests {
                         path = v2
                     }
                 },
-                LeafNode<Node> {
-                    property = Node {
-                        nodes = [
-                            LeafNode<HeaderNode> {
-                                property = HeaderNode {
-                                    key = Accept,
-                                    value = application/json,
-                                    strategy = .adding,
-                                    separator = nil
-                                }
-                            },
-                            LeafNode<HeaderNode> {
-                                property = HeaderNode {
-                                    key = Cache-Control,
-                                    value = public,
-                                    strategy = .adding,
-                                    separator = Optional<String> {
-                                        some = ,
-                                    }
-                                }
+                ChildrenNode {
+                    LeafNode<HeaderNode> {
+                        property = HeaderNode {
+                            key = Accept,
+                            value = application/json,
+                            strategy = .adding,
+                            separator = nil
+                        }
+                    },
+                    LeafNode<HeaderNode> {
+                        property = HeaderNode {
+                            key = Cache-Control,
+                            value = public,
+                            strategy = .adding,
+                            separator = Optional<String> {
+                                some = ,
                             }
-                        ]
+                        }
                     }
                 },
                 LeafNode<Node> {

--- a/Tests/RequestDLTests/Properties/Sources/Payloads/Form/FormTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Payloads/Form/FormTests.swift
@@ -192,6 +192,51 @@ struct FormTests {
     }
 
     @Test
+    func form_whenInitDataWithHeadersFromHeaderGroup() async throws {
+        // Given
+        // Regression test: `HeaderGroup` used to wrap its resolved headers into an opaque leaf
+        // node, invisible to `Form`'s `search(for: HeaderNode.self)` over its per-part `headers`
+        // content, so every header composed through it here silently disappeared.
+        let name = "foo"
+        let filename = "bar.raw"
+        let data = await Data.randomData(length: 1_024)
+
+        // When
+        let resolved = try await resolve(
+            TestProperty {
+                Form(
+                    name: name,
+                    filename: filename,
+                    data: data,
+                    headers: {
+                        HeaderGroup {
+                            CustomHeader(name: "Accept-Language", value: "en-US")
+                        }
+                    }
+                )
+            }
+        )
+
+        let parser = try await MultipartFormParser(resolved.requestConfiguration)
+        let parsed = try await parser.parse()
+
+        // Then
+        #expect(
+            parsed.items == [
+                PartForm(
+                    headers: HTTPHeaders([
+                        ("Content-Disposition", "form-data; name=\"\(name)\"; filename=\"\(filename)\""),
+                        ("Content-Type", "application/octet-stream"),
+                        ("Content-Length", String(data.count)),
+                        ("Accept-Language", "en-US"),
+                    ]),
+                    contents: data
+                )
+            ]
+        )
+    }
+
+    @Test
     func form_whenCustomHeaderOverridesAGeneratedHeader_shouldKeepTheCallersValue() async throws {
         // Given
         let name = "foo"

--- a/Tests/RequestDLTests/Properties/Sources/Session/Proxy/ProxyTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Session/Proxy/ProxyTests.swift
@@ -126,6 +126,32 @@ struct ProxyTests {
     }
 
     @Test
+    func proxy_whenHTTPConnectionWithConnectHeadersFromHeaderGroup() async throws {
+        // Given
+        // Regression test: `HeaderGroup` used to wrap its resolved headers into an opaque leaf
+        // node, invisible to `Proxy`'s `search(for: HeaderNode.self)` over its `connectHeaders`
+        // content, so every header composed through it here silently disappeared.
+        let host = UUID().uuidString
+        let port = 1_090
+        let name = UUID().uuidString
+        let value = UUID().uuidString
+
+        // When
+        let resolved = try await resolve(
+            Proxy(host: host, port: port) {
+                HeaderGroup {
+                    CustomHeader(name: name, value: value)
+                }
+            }
+        )
+
+        // Then
+        #expect(resolved.session.configuration.proxy?.host == host)
+        #expect(resolved.session.configuration.proxy?.port == port)
+        #expect(resolved.session.configuration.proxy?.connectHeaders.first(name: name) == value)
+    }
+
+    @Test
     func proxy_whenHTTPConnectionWithAuthorizationAndConnectHeaders() async throws {
         // Given
         let host = UUID().uuidString

--- a/Tests/RequestDLTests/Properties/Sources/URL/Query Group/QueryGroupTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/URL/Query Group/QueryGroupTests.swift
@@ -92,6 +92,38 @@ struct QueryGroupTests {
     }
 
     @Test
+    func groupOfQueriesFromNestedQueryGroup() async throws {
+        // Given
+        // Regression test: `QueryGroup` used to wrap its resolved queries into an opaque leaf
+        // node, invisible to an outer `QueryGroup`'s own `search(for: QueryNode.self)` over its
+        // content, so every query composed through a nested `QueryGroup` silently disappeared —
+        // the same class of bug fixed for `HeaderGroup`.
+        let property = QueryGroup {
+            QueryGroup {
+                Query(name: "number", value: 123)
+            }
+            Query(name: "page", value: 1)
+        }
+
+        // When
+        let resolved = try await resolve(
+            TestProperty {
+                BaseURL("127.0.0.1")
+                property
+            }
+        )
+
+        // Then
+        #expect(
+            resolved.requestConfiguration.url == """
+                https://127.0.0.1?\
+                number=123&\
+                page=1
+                """
+        )
+    }
+
+    @Test
     func neverBody() async throws {
         // Given
         let property = QueryGroup {}


### PR DESCRIPTION
## Summary
- `HeaderGroup` and `QueryGroup` both wrap their resolved leaves (`HeaderNode`/`QueryNode`) into a private opaque `.leaf(...)` node instead of leaving them as individually discoverable graph children.
- Anything that discovers its content by structurally searching the resolved graph for those raw leaf types — `Proxy`'s `connectHeaders`, `Form`'s per-part `headers`, and a `QueryGroup`/`HeaderGroup` nested inside another one of the same kind — finds nothing and silently produces zero headers/queries. No error, no warning.
- `Proxy`'s own doc comment explicitly claims `HeaderGroup` is supported as `connectHeaders` content; it wasn't, until this fix.

## Fix
Both `HeaderGroup._makeProperty` and `QueryGroup._makeProperty` now return `.children(...)` containing the individual `LeafNode<HeaderNode>`/`LeafNode<QueryNode>` leaves they find, instead of collapsing them into a private wrapper `PropertyNode`. Verified via `Node._make`/`_PartialContent` that this doesn't change execution order or behavior for ordinary top-level resolution (graph traversal already recurses into children when applying `Make`) — it only keeps the leaves structurally searchable for external consumers.

## Test plan
- [x] New regression test: `Proxy(host:port:) { HeaderGroup { ... } }` connect headers resolve correctly (`ProxyTests.swift`)
- [x] New regression test: `Form(..., headers: { HeaderGroup { ... } })` per-part headers resolve correctly (`FormTests.swift`)
- [x] New regression test: `QueryGroup` nested inside another `QueryGroup` resolves correctly (`QueryGroupTests.swift`)
- [x] Updated golden `debugDescription` strings in `ResolveTests.swift` to match the new (flatter) graph shape
- [x] Full suite green: `swift test` — 822 + 347 tests passing

The same underlying pattern also affected `SecureConnection` (a nested `SecureConnection` silently drops the inner one's certs/TLS settings), but that fix is split out to a separate branch/PR since it involves a design decision worth its own review: [`claude/secure-connection-nested-search`](https://github.com/request-dl/request-dl-nio/tree/claude/secure-connection-nested-search).

🤖 Generated with [Claude Code](https://claude.com/claude-code)