### PR TITLE
Deprecate Proxy.Authorization in favor of top-level ProxyAuthorization

### DIFF
--- a/Sources/RequestDL/Properties/Sources/Session/Proxy/Models/Proxy.Authorization.swift
+++ b/Sources/RequestDL/Properties/Sources/Session/Proxy/Models/Proxy.Authorization.swift
@@ -2,76 +2,15 @@
 // See LICENSE for this package's licensing information.
 //
 
-import RequestDLInternals
-
 extension Proxy {
 
-    ///
-    /// `Proxy.Authorization` is a struct that defines the authorization credentials required to connect to a proxy server.
-    /// This configuration is typically used in conjunction with HTTP or HTTPS proxies.
-    ///
-    /// You can create an instance of `Proxy.Authorization` using one of its static methods, like `.basic`.
-    ///
-    /// ```swift
-    /// let auth = Proxy.Authorization.basic(username: "myuser", password: "mypass")
-    /// ```
-    ///
-    /// In the example below, a request is made using an HTTP proxy with basic authentication.
-    ///
-    /// ```swift
-    /// DataTask {
-    ///     BaseURL("example.com")
-    ///     Proxy(
-    ///         host: "my-proxy.com",
-    ///         port: 8080,
-    ///         authorization: .basic(username: "user", password: "pass")
-    ///     )
-    /// }
-    /// ```
-    ///
-    public struct Authorization: Sendable {
-
-        private let authorization: Internals.Proxy.Authorization
-
-        ///
-        /// Creates an authorization instance using the HTTP Basic Authentication scheme with a username and password.
-        ///
-        /// - Parameters:
-        ///    - username: The username for the proxy authentication.
-        ///    - password: The password for the proxy authentication.
-        ///
-        /// - Returns: A new instance of `Proxy.Authorization`.
-        ///
-        public static func basic(username: String, password: String) -> Self {
-            .init(authorization: .basic(username: username, password: password))
-        }
-
-        ///
-        /// Creates an authorization instance using a raw credentials string for the HTTP Basic Authentication scheme.
-        ///
-        /// - Parameters:
-        ///    - credentials: The raw credentials string, typically a base64-encoded "username:password".
-        ///
-        /// - Returns: A new instance of `Proxy.Authorization`.
-        ///
-        public static func basic(credentials: String) -> Self {
-            .init(authorization: .basicRawCredentials(credentials))
-        }
-
-        ///
-        /// Creates an authorization instance using the HTTP Bearer Authentication scheme.
-        ///
-        /// - Parameters:
-        ///    - tokens: The token string used for the proxy authentication.
-        ///
-        /// - Returns: A new instance of `Proxy.Authorization`.
-        ///
-        public static func bearer(tokens: String) -> Self {
-            .init(authorization: .bearer(tokens: tokens))
-        }
-
-        func build() -> Internals.Proxy.Authorization {
-            authorization
-        }
-    }
+    /// Deprecated: `Authorization` never used `Headers`, but being declared as a `struct` nested
+    /// inside the generic `Proxy<Headers>` meant `Proxy<A>.Authorization` and
+    /// `Proxy<B>.Authorization` were formally different types to the compiler — a trap for any
+    /// code referencing the type outside a context where `Headers` is already pinned by argument
+    /// inference (e.g. a standalone helper function). Use the top-level ``ProxyAuthorization``
+    /// instead: as a `typealias` (not a new nominal type), `Proxy<Headers>.Authorization` now
+    /// resolves to the same ``ProxyAuthorization`` regardless of `Headers`.
+    @available(*, deprecated, renamed: "ProxyAuthorization")
+    public typealias Authorization = ProxyAuthorization
 }

--- a/Sources/RequestDL/Properties/Sources/Session/Proxy/Models/ProxyAuthorization.swift
+++ b/Sources/RequestDL/Properties/Sources/Session/Proxy/Models/ProxyAuthorization.swift
@@ -1,0 +1,74 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+import RequestDLInternals
+
+///
+/// `ProxyAuthorization` is a struct that defines the authorization credentials required to connect to a proxy server.
+/// This configuration is typically used in conjunction with HTTP or HTTPS proxies.
+///
+/// You can create an instance of `ProxyAuthorization` using one of its static methods, like `.basic`.
+///
+/// ```swift
+/// let auth = ProxyAuthorization.basic(username: "myuser", password: "mypass")
+/// ```
+///
+/// In the example below, a request is made using an HTTP proxy with basic authentication.
+///
+/// ```swift
+/// DataTask {
+///     BaseURL("example.com")
+///     Proxy(
+///         host: "my-proxy.com",
+///         port: 8080,
+///         authorization: .basic(username: "user", password: "pass")
+///     )
+/// }
+/// ```
+///
+public struct ProxyAuthorization: Sendable {
+
+    private let authorization: Internals.Proxy.Authorization
+
+    ///
+    /// Creates an authorization instance using the HTTP Basic Authentication scheme with a username and password.
+    ///
+    /// - Parameters:
+    ///    - username: The username for the proxy authentication.
+    ///    - password: The password for the proxy authentication.
+    ///
+    /// - Returns: A new instance of `ProxyAuthorization`.
+    ///
+    public static func basic(username: String, password: String) -> Self {
+        .init(authorization: .basic(username: username, password: password))
+    }
+
+    ///
+    /// Creates an authorization instance using a raw credentials string for the HTTP Basic Authentication scheme.
+    ///
+    /// - Parameters:
+    ///    - credentials: The raw credentials string, typically a base64-encoded "username:password".
+    ///
+    /// - Returns: A new instance of `ProxyAuthorization`.
+    ///
+    public static func basic(credentials: String) -> Self {
+        .init(authorization: .basicRawCredentials(credentials))
+    }
+
+    ///
+    /// Creates an authorization instance using the HTTP Bearer Authentication scheme.
+    ///
+    /// - Parameters:
+    ///    - tokens: The token string used for the proxy authentication.
+    ///
+    /// - Returns: A new instance of `ProxyAuthorization`.
+    ///
+    public static func bearer(tokens: String) -> Self {
+        .init(authorization: .bearer(tokens: tokens))
+    }
+
+    func build() -> Internals.Proxy.Authorization {
+        authorization
+    }
+}

--- a/Sources/RequestDL/Properties/Sources/Session/Proxy/Proxy.swift
+++ b/Sources/RequestDL/Properties/Sources/Session/Proxy/Proxy.swift
@@ -74,7 +74,7 @@ public struct Proxy<Headers: Property>: Property {
     let host: String
     let port: Int
     let connectionProtocol: ConnectionProtocol
-    let authorization: Authorization?
+    let authorization: ProxyAuthorization?
     let connectHeaders: Headers
 
     // MARK: - Inits
@@ -91,7 +91,7 @@ public struct Proxy<Headers: Property>: Property {
     ///
     /// > Note: This initializer is available when `Headers` is `EmptyProperty`.
     ///
-    public init(host: String, port: Int, authorization: Authorization) where Headers == EmptyProperty {
+    public init(host: String, port: Int, authorization: ProxyAuthorization) where Headers == EmptyProperty {
         self.host = host
         self.port = port
         self.connectionProtocol = .http
@@ -144,7 +144,7 @@ public struct Proxy<Headers: Property>: Property {
     public init(
         host: String,
         port: Int,
-        authorization: Authorization? = nil,
+        authorization: ProxyAuthorization? = nil,
         @PropertyBuilder connectHeaders: () -> Headers
     ) {
         self.host = host

--- a/Tests/RequestDLTests/Properties/Sources/Session/Proxy/ProxyAuthorizationTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Session/Proxy/ProxyAuthorizationTests.swift
@@ -1,0 +1,57 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+import Testing
+
+@testable import RequestDL
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import struct Foundation.UUID
+#endif
+
+struct ProxyAuthorizationTests {
+
+    @Test
+    func standaloneUsage_notPinnedToAnyHeadersSpecialization() async throws {
+        // Given
+        // `ProxyAuthorization` is a top-level type, not nested inside the generic
+        // `Proxy<Headers>`. A standalone helper returning it (unlike the old
+        // `Proxy<SomeSpecificHeaders>.Authorization`) never forces a `Headers` specialization
+        // on its own — the regression this type exists to fix.
+        func makeAuthorization(credentials: String) -> ProxyAuthorization {
+            .basic(credentials: credentials)
+        }
+
+        let credentials = UUID().uuidString
+        let host = UUID().uuidString
+        let port = 1_090
+
+        // When
+        let resolved = try await resolve(
+            Proxy(host: host, port: port, authorization: makeAuthorization(credentials: credentials))
+        )
+
+        // Then
+        #expect(resolved.session.configuration.proxy?.authorization == .basicRawCredentials(credentials))
+    }
+
+    @Test
+    func deprecatedProxyAuthorizationAliasStillResolves() async throws {
+        // Given
+        // Source compatibility: `Proxy.Authorization` is a deprecated `typealias` to
+        // `ProxyAuthorization`, so old call sites spelling it out explicitly still compile.
+        let credentials = UUID().uuidString
+        let deprecatedSpelling: Proxy<EmptyProperty>.Authorization = .basic(credentials: credentials)
+
+        // When
+        let resolved = try await resolve(
+            Proxy(host: "proxy.example.com", port: 8080, authorization: deprecatedSpelling)
+        )
+
+        // Then
+        #expect(resolved.session.configuration.proxy?.authorization == .basicRawCredentials(credentials))
+    }
+}


### PR DESCRIPTION
## Summary
- `Proxy.Authorization` never used `Proxy`'s `Headers` generic parameter, but being declared as a `struct` nested inside `Proxy<Headers>` meant `Proxy<A>.Authorization` and `Proxy<B>.Authorization` were formally different types to the compiler. This is a trap for any code referencing the type outside a context where `Headers` is already pinned by argument inference — e.g. a standalone helper function returning `Proxy<SomeSpecificHeaders>.Authorization?`, which I hit while implementing `swift-configuration` support for `Proxy` in a separate branch.
- Introduces a new top-level `ProxyAuthorization` type (same API: `.basic(username:password:)`, `.basic(credentials:)`, `.bearer(tokens:)`) and turns `Proxy.Authorization` into a `@available(*, deprecated, renamed: "ProxyAuthorization")` typealias. Since a typealias doesn't introduce a new nominal type, `Proxy<Headers>.Authorization` now resolves to the exact same `ProxyAuthorization` regardless of `Headers` — the root cause is gone, not just worked around.
- `Proxy`'s own initializers and stored property now reference `ProxyAuthorization` directly (not the deprecated alias), so no new deprecation warnings appear in the package's own code. Existing call sites like `Proxy(host:port:authorization: .basic(...))` are untouched and keep compiling warning-free, since they never spell out the type name explicitly.

## Test plan
- [x] Added `ProxyAuthorizationTests.swift`: one test proving a standalone helper returning `ProxyAuthorization` is no longer pinned to any `Headers` specialization (the actual regression), one proving the deprecated `Proxy.Authorization` spelling still compiles and resolves correctly (with the expected deprecation warning).
- [x] Full suite green: `swift test` — 821 + 347 tests passing.
- [x] `swift build --build-tests` shows no new deprecation warnings anywhere else in the package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)