### PR TITLE
Add Swift Package Manager ecosystem to Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+
+  - package-ecosystem: "swift"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary
- Adds a `swift` package-ecosystem entry to `.github/dependabot.yml`, enabling weekly Dependabot updates for `Package.swift` dependencies alongside the existing `github-actions` updates.

## Test plan
- [ ] Confirm Dependabot picks up the new `swift` ecosystem config after merge (visible under repo Insights > Dependency graph > Dependabot)

🤖 Generated with [Claude Code](https://claude.com/claude-code)