### PR TITLE
Curate RequestServiceContext, ProxyAuthorization, and NetworkAvailabilityError in DocC

### DIFF
--- a/Sources/RequestDL/Documentation.docc/Essentials/Building the Request/Essentials/Creating-requests-from-scratch.md
+++ b/Sources/RequestDL/Documentation.docc/Essentials/Building the Request/Essentials/Creating-requests-from-scratch.md
@@ -212,10 +212,12 @@ Learn more in:
 
 - ``RequestDL/Session``
 - ``RequestDL/Proxy``
+- ``RequestDL/ProxyAuthorization``
 - ``RequestDL/SystemProxy``
 - ``RequestDL/DNSOverride``
 - ``RequestDL/URLOverride``
 - ``RequestDL/URLOverrideError``
+- ``RequestDL/NetworkAvailabilityError``
 
 ### Adding request timeout
 

--- a/Sources/RequestDL/Documentation.docc/Essentials/Executing the Request/Distributed Tracing/Distributed-tracing.md
+++ b/Sources/RequestDL/Documentation.docc/Essentials/Executing the Request/Distributed Tracing/Distributed-tracing.md
@@ -1,0 +1,38 @@
+# Distributed tracing
+
+Record a distributed-tracing span for a request by opting a session into a `Tracer` and, optionally, binding the `ServiceContext` it should be a child of.
+
+## Overview
+
+Tracing is opt-in per session, not ambient: a request only produces a span when its session has been given a `Tracer` via ``RequestDL/Session/tracer(_:)``. Without one, the session falls back to a no-op tracer, regardless of whether some other part of the process has globally bootstrapped an instrumentation backend.
+
+```swift
+DataTask {
+    BaseURL("example.com")
+    Session().tracer(myTracer)
+}
+```
+
+RequestDL owns the whole span lifecycle itself — starting the span, injecting W3C trace headers, setting attributes, and ending it — rather than delegating to `async-http-client`'s own tracing configuration. That's what makes it possible to bind a specific `ServiceContext` to a single request and have the started span actually pick it up as its parent.
+
+### Binding a ServiceContext
+
+Use ``RequestDL/RequestServiceContext`` to bind a `ServiceContext` to a request, overriding whatever `ServiceContext.current` task-local happens to be ambient at the point the request executes:
+
+```swift
+DataTask {
+    BaseURL("example.com")
+    Session().tracer(myTracer)
+    RequestServiceContext(context)
+}
+```
+
+## Topics
+
+### Configuring the session
+
+- ``RequestDL/Session/tracer(_:)``
+
+### Binding a ServiceContext
+
+- ``RequestDL/RequestServiceContext``

--- a/Sources/RequestDL/Documentation.docc/Essentials/Executing the Request/Executing-the-request.md
+++ b/Sources/RequestDL/Documentation.docc/Essentials/Executing the Request/Executing-the-request.md
@@ -21,3 +21,7 @@ Discover the possibilities to execute your request and manipulate the received d
 ### Loading images
 
 - <doc:Loading-images>
+
+### Distributed tracing
+
+- <doc:Distributed-tracing>

--- a/Sources/RequestDL/Documentation.docc/RequestDL.md
+++ b/Sources/RequestDL/Documentation.docc/RequestDL.md
@@ -78,6 +78,7 @@ try await DataTask {
 - [x] [Swift Concurrency](<doc:Swift-concurrency>);
 - [x] [Combine support](<doc:Exploring-combine>) (Apple platforms only);
 - [x] [Image loading for SwiftUI, UIKit, AppKit and watchOS](<doc:Loading-images>) (Apple platforms only);
+- [x] [Distributed tracing](<doc:Distributed-tracing>);
 
 We are excited to expand this list with many other features. Start by making your contribution in [Discussions](https://github.com/orgs/request-dl/discussions) or by opening a PR (Pull Request).
 


### PR DESCRIPTION
## Summary

- `RequestServiceContext` (and `Session.tracer(_:)`), `ProxyAuthorization`, and `NetworkAvailabilityError` were all public, documented types referenced by zero Topics group in `Documentation.docc`. DocC's default behavior auto-dumps any uncurated public symbol into the module's automatic "Other Symbols" section — the leak reported in discussion #284.
- Adds a new `Distributed-tracing.md` article (mirroring the existing `Loading-images.md` pattern) curating `RequestServiceContext` and `Session.tracer(_:)`, linked from `Executing-the-request.md` and the `RequestDL.md` Features list.
- Adds `ProxyAuthorization` and `NetworkAvailabilityError` to the existing "Configuration of Session" Topics group in `Creating-requests-from-scratch.md`, next to `Proxy`/`URLOverrideError`.

## Test plan

- [x] `swift package dump-symbol-graph` — clean build, no new warnings
- [x] `xcrun docc convert` (RequestDL symbol graph only, `--warnings-as-errors`) — zero warnings
- [x] Verified in the generated `.doccarchive` JSON that the module landing page's `automaticTaskGroups` is empty (previously included `RequestServiceContext`, `ProxyAuthorization`, `NetworkAvailabilityError` under an auto-generated "Structures" group)

🤖 Generated with [Claude Code](https://claude.com/claude-code)