### PR TITLE
ci: enable license header validation

### DIFF
--- a/.github/workflows/swift-ci.yaml
+++ b/.github/workflows/swift-ci.yaml
@@ -43,35 +43,42 @@ jobs:
       platform: macos-26
 
       # Step 1
+      enable-header-validation: true
+      header-template: |
+        //
+        // See LICENSE for this package's licensing information.
+        //
+
+      # Step 2
       enable-format: true
       format-swift-version: '6.3'
 
-      # Step 2
+      # Step 3
       enable-breaking-changes: true
       skip-on-major-update: true
       force-skip-breaking-changes: ${{ contains(github.event.pull_request.labels.*.name, 'force-skip-ci') }}
 
-      # Step 3 – Apple
+      # Step 4 – Apple
       enable-apple-tests: true
       package-name: "request-dl"
       xcode-version: '26.6'
       apple-coverage-enabled: true
       apple-tests-parallel-testing-worker-count: '2'
 
-      # Step 3 – Third Party
+      # Step 4 – Third Party
       enable-third-party-tests: true
       third-party-coverage-enabled: true
 
-      # Step 3 – Linkage Test (renomeado de test-foundation-essentials)
+      # Step 4 – Linkage Test (renomeado de test-foundation-essentials)
       enable-linkage-test: true
 
-      # Step 3 – Android Build
+      # Step 4 – Android Build
       enable-android-build: true
 
-      # Step 3 – Release Builds / Static SDK
+      # Step 4 – Release Builds / Static SDK
       enable-release-builds: true
       enable-static-sdk: true
 
-      # Step 4
+      # Step 5
       enable-coverage-upload: true
     secrets: inherit

--- a/Sources/RequestDL/Tasks/Sources/Modifiers/Environment/TaskEnvironment.swift
+++ b/Sources/RequestDL/Tasks/Sources/Modifiers/Environment/TaskEnvironment.swift
@@ -1,8 +1,5 @@
 //
-//  File.swift
-//  request-dl
-//
-//  Created by Brenno de Moura on 23/09/25.
+// See LICENSE for this package's licensing information.
 //
 
 /// A property wrapper that provides safe, dynamic access to task-scoped environment values.

--- a/Sources/RequestDLInternals/Sources/Session/Async Bytes/Internals.AsyncBytes.swift
+++ b/Sources/RequestDLInternals/Sources/Session/Async Bytes/Internals.AsyncBytes.swift
@@ -1,8 +1,9 @@
-import NIOCore
-
 //
 // See LICENSE for this package's licensing information.
 //
+
+import NIOCore
+
 #if canImport(FoundationEssentials)
 import FoundationEssentials
 #else


### PR DESCRIPTION
## Summary
- Turns on the opt-in `header-validation` step added in [request-dl/.github#99](https://github.com/request-dl/.github/pull/99), as the new Step 1, with `header-template` set to this repo's existing `// See LICENSE for this package's licensing information.` block.
- Uses the default `header-paths: ["."]` (whole repo) — the reusable workflow now excludes `Package.swift`/`Package@swift-*.swift` on its own, so no per-repo path scoping is needed.
- Renumbers the downstream Step comments (+1) to match the reusable workflow's new numbering.
- Fixes two `Sources/` files that would otherwise fail the new check: a leftover Xcode-template header in `TaskEnvironment.swift`, and a header placed after an `import` instead of at the top of the file in `Internals.AsyncBytes.swift`.

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/swift-ci.yaml'))"` — valid YAML
- [x] `actionlint` — no findings
- [x] Replicated the reusable workflow's header-check logic in a standalone script and ran it against all 560 `*.swift` files in the repo (excluding `Package.swift`) — 0 mismatches

🤖 Generated with [Claude Code](https://claude.com/claude-code)