### PR TITLE
Bump swift-async-stream to 2.1.2 and swift-distributed-tracing to 1.4.1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -48,7 +48,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/o-nnerb/swift-async-stream",
-            from: "2.0.7"
+            from: "2.1.2"
         ),
         .package(
             url: "https://github.com/apple/swift-async-algorithms",
@@ -60,7 +60,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/apple/swift-distributed-tracing",
-            from: "1.1.0"
+            from: "1.4.1"
         ),
     ],
     targets: [


### PR DESCRIPTION
## Summary
- Updates the `swift-async-stream` dependency from `2.0.7` to the latest release, `2.1.2` (no breaking changes — adds public `detachedUnlessDisabled` API and a testing trait to disable `Task.detached`).
- Updates the `swift-distributed-tracing` dependency minimum from `1.1.0` to the latest release, `1.4.1`.

## Test plan
- [x] `swift package resolve`
- [x] `swift build`