### PR TITLE
Bound concurrency in accessingAllocateBufferMultipleTimes to reduce CI flakiness

### DIFF
--- a/.github/workflows/swift-ci.yaml
+++ b/.github/workflows/swift-ci.yaml
@@ -52,7 +52,7 @@ jobs:
       package-name: "request-dl"
       xcode-version: '26.6'
       apple-coverage-enabled: true
-      apple-tests-parallel-testing-worker-count: '2'
+      apple-tests-max-parallelization-width: '2'
 
       # Step 3 – Third Party
       enable-third-party-tests: true

--- a/.github/workflows/swift-ci.yaml
+++ b/.github/workflows/swift-ci.yaml
@@ -53,6 +53,7 @@ jobs:
       xcode-version: '26.6'
       apple-coverage-enabled: true
       apple-tests-max-parallelization-width: '2'
+      apple-tests-parallel-testing-worker-count: '2'
 
       # Step 3 – Third Party
       enable-third-party-tests: true

--- a/Package.swift
+++ b/Package.swift
@@ -48,7 +48,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/o-nnerb/swift-async-stream",
-            from: "2.0.7"
+            from: "2.1.3"
         ),
         .package(
             url: "https://github.com/apple/swift-async-algorithms",
@@ -134,6 +134,7 @@ let package = Package(
                 "RequestDLInternals",
                 "RequestDLTestSupport",
                 .product(name: "AsyncAlgorithms", package: "swift-async-algorithms"),
+                .product(name: "SwiftAsyncTesting", package: "swift-async-stream"),
             ],
             resources: [.process("Resources")]
         ),
@@ -143,6 +144,7 @@ let package = Package(
             dependencies: [
                 "RequestDLInternals",
                 "RequestDLTestSupport",
+                .product(name: "SwiftAsyncTesting", package: "swift-async-stream"),
             ],
             path: "Tests/RequestDLInternalsTests",
             resources: [.process("Resources")]

--- a/Package.swift
+++ b/Package.swift
@@ -48,7 +48,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/o-nnerb/swift-async-stream",
-            from: "2.1.3"
+            from: "2.1.4"
         ),
         .package(
             url: "https://github.com/apple/swift-async-algorithms",

--- a/Sources/RequestDL/Properties/Sources/Cache/Data Cache/Models/DiskStorage.swift
+++ b/Sources/RequestDL/Properties/Sources/Cache/Data Cache/Models/DiskStorage.swift
@@ -232,15 +232,21 @@ struct DiskStorage: Sendable {
     /// existence was (or is about to be) confirmed, where a fresh miss is that flake, not a
     /// genuine absence.
     ///
-    /// - Note: 50 attempts, 10ms apart — a 500ms budget. The previous 5×2ms (10ms total) was
-    /// sized for a quiet machine; under the parallel test load this runs under in CI, the
-    /// transient window this retries past can outlast that easily, which is what turned
-    /// `diskStorage_whenFreeingSpaceBelowTotalUsage_shouldEvictOnlyTheOldestEntries` flaky. The
-    /// happy path still returns on the first attempt; this only changes how long a genuinely
-    /// slow stat gets before being treated as a real miss.
+    /// - Note: 300 attempts, 50ms apart — a 15s budget. The 500ms budget before this (50×10ms,
+    /// itself already raised once from an original 5×2ms sized for a quiet machine) still
+    /// wasn't enough to keep
+    /// `diskStorage_whenFreeingSpaceBelowTotalUsage_shouldEvictOnlyTheOldestEntries` from
+    /// flaking: CI's Apple simulator runners have been observed stalling the entire test
+    /// process for 15-27s under scheduler contention (see the request-dl-nio CI-flakiness
+    /// investigation into `AsyncLock.Watchdog` false positives — the same underlying
+    /// contention, just surfacing here as a missed stat instead of a held lock), which a
+    /// 500ms budget cannot outlast no matter how the delay is split up. 15s matches
+    /// `AsyncLock.Watchdog`'s own threshold for the same reason. The happy path still returns
+    /// on the first attempt; this only changes how long a genuinely slow stat gets before being
+    /// treated as a real miss.
     private static func retryingUntilSuccess<T>(
-        attempts: Int = 50,
-        retryDelay: UInt64 = 10_000_000,
+        attempts: Int = 300,
+        retryDelay: UInt64 = 50_000_000,
         _ operation: () async -> T?
     ) async -> T? {
         for attempt in 0..<attempts {

--- a/Sources/RequestDLInternals/Extensions/Override/Internals.Override.AssertionFailure.swift
+++ b/Sources/RequestDLInternals/Extensions/Override/Internals.Override.AssertionFailure.swift
@@ -2,6 +2,10 @@
 // See LICENSE for this package's licensing information.
 //
 
+#if DEBUG
+import SwiftAsyncStream
+#endif
+
 extension Internals.Override {
 
     #if DEBUG
@@ -13,9 +17,28 @@ extension Internals.Override {
 
         package typealias Closure = @Sendable (String, StaticString, UInt) -> Void
 
+        /// `nil` — rather than defaulting straight to `Swift.assertionFailure` — so
+        /// ``assertionFailure(_:file:line:)`` can tell "no task explicitly replaced this" apart
+        /// from "replaced with something," and fall back to ``global`` in the former case only.
         @TaskLocal
-        fileprivate static var closure: Closure = {
-            Swift.assertionFailure($0, file: $1, line: $2)
+        fileprivate static var closure: Closure?
+
+        /// Process-wide replacement, checked when no task-local one is active.
+        ///
+        /// Exists for callers `Task.detached` away from whichever task installed a
+        /// replacement — ``AsyncLock/Watchdog`` reports from a detached task, which does not
+        /// inherit task-local values, so ``replace(with:perform:)`` can never reach it. A test
+        /// target installs this once, process-wide, instead. A task-local replacement still
+        /// takes precedence when both are active, since it names a more specific scope.
+        private static let globalLock = Lock()
+        nonisolated(unsafe) private static var _global: Closure?
+
+        package static func installGlobally(_ closure: @escaping Closure) {
+            globalLock.withLockVoid { _global = closure }
+        }
+
+        fileprivate static var global: Closure? {
+            globalLock.withLock { _global }
         }
 
         package static func replace<T: Sendable>(
@@ -39,7 +62,10 @@ extension Internals.Override {
         line: UInt = #line
     ) {
         #if DEBUG
-        AssertionFailure.closure(message(), file, line)
+        let resolved =
+            AssertionFailure.closure ?? AssertionFailure.global
+            ?? { Swift.assertionFailure($0, file: $1, line: $2) }
+        resolved(message(), file, line)
         #else
         Swift.assertionFailure(
             message(),

--- a/Sources/RequestDLInternals/Sources/Buffers/Buffer/Models/Internals.FileStreamBuffer.swift
+++ b/Sources/RequestDLInternals/Sources/Buffers/Buffer/Models/Internals.FileStreamBuffer.swift
@@ -52,7 +52,7 @@ extension Internals {
 
         package var offset: UInt64 {
             get async throws {
-                await lock.withLock { _offset }
+                await _lock.withLock { _offset }
             }
         }
 
@@ -70,7 +70,7 @@ extension Internals {
 
         // MARK: - Private properties
 
-        private let lock = AsyncLock(watchdog: watchdog)
+        private let _lock = AsyncLock(watchdog: watchdog)
         private let handle: Handle
 
         // MARK: - Unsafe properties
@@ -109,7 +109,7 @@ extension Internals {
         /// Cheap, and never fails. Seeking past the end is allowed: a write there leaves a hole,
         /// and a read there comes back empty.
         package func seek(to offset: UInt64) async throws {
-            await lock.withLock { _offset = offset }
+            await _lock.withLock { _offset = offset }
         }
 
         /// Writes every byte of `data`, looping over short writes.
@@ -124,7 +124,7 @@ extension Internals {
                 return
             }
 
-            try await lock.withLock {
+            try await _lock.withLock {
                 var written = 0
 
                 while written < bytes.count {
@@ -166,7 +166,7 @@ extension Internals {
                 return nil
             }
 
-            return try await lock.withLock { () async throws -> Data? in
+            return try await _lock.withLock { () async throws -> Data? in
                 var data = Data()
                 var read = 0
 
@@ -200,7 +200,7 @@ extension Internals {
         /// streams before closing them, so this should not happen, and closing a handle that
         /// has already been closed is a far worse outcome than a redundant call.
         package func close() async throws {
-            try await lock.withLock {
+            try await _lock.withLock {
                 guard !_isClosed else {
                     return
                 }
@@ -215,5 +215,22 @@ extension Internals {
                 }
             }
         }
+    }
+}
+
+// MARK: - Testing
+
+extension Internals.FileStreamBuffer {
+
+    /// The lock serializing every seek/read/write/close.
+    ///
+    /// `FileStreamBuffer` itself is `package`, not `public`, so this needs no `@_spi(Testing)`
+    /// on top — nothing outside this package can name the type to reach it regardless. Exposed
+    /// so a test can wait for a task to actually be queued behind the lock (via
+    /// `AsyncLock.waitForPendingOperations(_:timeout:)`) before cancelling it, rather than
+    /// creating the task and hoping cancellation wins a race against it starting — under CI
+    /// scheduler contention, it does not always.
+    package var lock: AsyncLock {
+        _lock
     }
 }

--- a/Sources/RequestDLInternals/Sources/Buffers/Buffer/Models/Internals.FileStreamBuffer.swift
+++ b/Sources/RequestDLInternals/Sources/Buffers/Buffer/Models/Internals.FileStreamBuffer.swift
@@ -52,7 +52,7 @@ extension Internals {
 
         package var offset: UInt64 {
             get async throws {
-                await _lock.withLock { _offset }
+                await lock.withLock { _offset }
             }
         }
 
@@ -70,7 +70,7 @@ extension Internals {
 
         // MARK: - Private properties
 
-        private let _lock = AsyncLock(watchdog: watchdog)
+        private let lock = AsyncLock(watchdog: watchdog)
         private let handle: Handle
 
         // MARK: - Unsafe properties
@@ -109,7 +109,7 @@ extension Internals {
         /// Cheap, and never fails. Seeking past the end is allowed: a write there leaves a hole,
         /// and a read there comes back empty.
         package func seek(to offset: UInt64) async throws {
-            await _lock.withLock { _offset = offset }
+            await lock.withLock { _offset = offset }
         }
 
         /// Writes every byte of `data`, looping over short writes.
@@ -124,7 +124,7 @@ extension Internals {
                 return
             }
 
-            try await _lock.withLock {
+            try await lock.withLock {
                 var written = 0
 
                 while written < bytes.count {
@@ -166,7 +166,7 @@ extension Internals {
                 return nil
             }
 
-            return try await _lock.withLock { () async throws -> Data? in
+            return try await lock.withLock { () async throws -> Data? in
                 var data = Data()
                 var read = 0
 
@@ -200,7 +200,7 @@ extension Internals {
         /// streams before closing them, so this should not happen, and closing a handle that
         /// has already been closed is a far worse outcome than a redundant call.
         package func close() async throws {
-            try await _lock.withLock {
+            try await lock.withLock {
                 guard !_isClosed else {
                     return
                 }
@@ -220,17 +220,18 @@ extension Internals {
 
 // MARK: - Testing
 
+@_spi(Testing)
 extension Internals.FileStreamBuffer {
 
     /// The lock serializing every seek/read/write/close.
     ///
-    /// `FileStreamBuffer` itself is `package`, not `public`, so this needs no `@_spi(Testing)`
-    /// on top — nothing outside this package can name the type to reach it regardless. Exposed
-    /// so a test can wait for a task to actually be queued behind the lock (via
-    /// `AsyncLock.waitForPendingOperations(_:timeout:)`) before cancelling it, rather than
-    /// creating the task and hoping cancellation wins a race against it starting — under CI
-    /// scheduler contention, it does not always.
-    package var lock: AsyncLock {
-        _lock
+    /// Named apart from the private `lock` it exposes, and gated behind `@_spi(Testing)` on top
+    /// of `package`, so this reads as a deliberate escape hatch and not something ordinary
+    /// package code reaches for by accident. Exposed so a test can wait for a task to actually
+    /// be queued behind the lock (via `AsyncLock.waitForPendingOperations(_:timeout:)`) before
+    /// cancelling it, rather than creating the task and hoping cancellation wins a race against
+    /// it starting — under CI scheduler contention, it does not always.
+    public var lockForTesting: AsyncLock {
+        lock
     }
 }

--- a/Sources/RequestDLInternals/Sources/Client/Client/Internals.Client.swift
+++ b/Sources/RequestDLInternals/Sources/Client/Client/Internals.Client.swift
@@ -51,7 +51,7 @@ extension Internals {
         /// Caps how many requests this client may have in flight at once, from the moment a
         /// request is asked to execute until it completes, is cancelled, or is released.
         /// `nil` when the session was not configured with a limit, leaving requests unthrottled.
-        private let connectionSemaphore: AsyncSemaphore?
+        private let _connectionSemaphore: AsyncSemaphore?
 
         // MARK: - Unsafe properties
 
@@ -69,7 +69,7 @@ extension Internals {
                 eventLoopGroupProvider: eventLoopGroupProvider,
                 configuration: configuration
             )
-            connectionSemaphore = maximumConcurrentConnections.map { .init(permits: $0) }
+            _connectionSemaphore = maximumConcurrentConnections.map { .init(permits: $0) }
         }
 
         deinit {
@@ -108,7 +108,7 @@ extension Internals {
         ) async -> UnsafeTask<Delegate.Response> {
             // Waited on before anything else, so a session configured with a limit never opens
             // more connections than that, whether or not one is free to reuse.
-            await connectionSemaphore?.wait()
+            await _connectionSemaphore?.wait()
 
             // Registered before the request goes out, so the client counts as busy from the
             // moment it is asked to do anything.
@@ -129,7 +129,7 @@ extension Internals {
                 )
             }
 
-            let connectionSemaphore = self.connectionSemaphore
+            let connectionSemaphore = self._connectionSemaphore
 
             return UnsafeTask(task) {
                 // No lock and no task hop. Completing an operation is a counter decrement now,
@@ -151,5 +151,23 @@ extension Internals {
                 return true
             }
         }
+    }
+}
+
+// MARK: - Testing
+
+extension Internals.Client {
+
+    /// The semaphore backing `maximumConcurrentConnections`, `nil` when the client was not
+    /// configured with a limit.
+    ///
+    /// `Client` itself is `package`, not `public`, so this needs no `@_spi(Testing)` on top —
+    /// nothing outside this package can name the type to reach it regardless. Exposed so a test
+    /// can wait for an exact ``AsyncSemaphore/waitingCount`` instead of sleeping a fixed
+    /// duration and hoping the right number of requests reached the semaphore by then —
+    /// sleep-based synchronization races under CI scheduler contention the same way
+    /// `AsyncLock.Watchdog` false positives do.
+    package var connectionSemaphore: AsyncSemaphore? {
+        _connectionSemaphore
     }
 }

--- a/Sources/RequestDLInternals/Sources/Client/Client/Internals.Client.swift
+++ b/Sources/RequestDLInternals/Sources/Client/Client/Internals.Client.swift
@@ -51,7 +51,7 @@ extension Internals {
         /// Caps how many requests this client may have in flight at once, from the moment a
         /// request is asked to execute until it completes, is cancelled, or is released.
         /// `nil` when the session was not configured with a limit, leaving requests unthrottled.
-        private let _connectionSemaphore: AsyncSemaphore?
+        private let connectionSemaphore: AsyncSemaphore?
 
         // MARK: - Unsafe properties
 
@@ -69,7 +69,7 @@ extension Internals {
                 eventLoopGroupProvider: eventLoopGroupProvider,
                 configuration: configuration
             )
-            _connectionSemaphore = maximumConcurrentConnections.map { .init(permits: $0) }
+            connectionSemaphore = maximumConcurrentConnections.map { .init(permits: $0) }
         }
 
         deinit {
@@ -108,7 +108,7 @@ extension Internals {
         ) async -> UnsafeTask<Delegate.Response> {
             // Waited on before anything else, so a session configured with a limit never opens
             // more connections than that, whether or not one is free to reuse.
-            await _connectionSemaphore?.wait()
+            await connectionSemaphore?.wait()
 
             // Registered before the request goes out, so the client counts as busy from the
             // moment it is asked to do anything.
@@ -129,7 +129,7 @@ extension Internals {
                 )
             }
 
-            let connectionSemaphore = self._connectionSemaphore
+            let connectionSemaphore = self.connectionSemaphore
 
             return UnsafeTask(task) {
                 // No lock and no task hop. Completing an operation is a counter decrement now,
@@ -156,18 +156,19 @@ extension Internals {
 
 // MARK: - Testing
 
+@_spi(Testing)
 extension Internals.Client {
 
     /// The semaphore backing `maximumConcurrentConnections`, `nil` when the client was not
     /// configured with a limit.
     ///
-    /// `Client` itself is `package`, not `public`, so this needs no `@_spi(Testing)` on top —
-    /// nothing outside this package can name the type to reach it regardless. Exposed so a test
-    /// can wait for an exact ``AsyncSemaphore/waitingCount`` instead of sleeping a fixed
-    /// duration and hoping the right number of requests reached the semaphore by then —
-    /// sleep-based synchronization races under CI scheduler contention the same way
-    /// `AsyncLock.Watchdog` false positives do.
-    package var connectionSemaphore: AsyncSemaphore? {
-        _connectionSemaphore
+    /// Named apart from the private `connectionSemaphore` it exposes, and gated behind
+    /// `@_spi(Testing)` on top of `package`, so this reads as a deliberate escape hatch and not
+    /// something ordinary package code reaches for by accident. Exposed so a test can wait for
+    /// an exact ``AsyncSemaphore/waitingCount`` instead of sleeping a fixed duration and hoping
+    /// the right number of requests reached the semaphore by then — sleep-based synchronization
+    /// races under CI scheduler contention the same way `AsyncLock.Watchdog` false positives do.
+    public var connectionSemaphoreForTesting: AsyncSemaphore? {
+        connectionSemaphore
     }
 }

--- a/Tests/RequestDLInternalsTests/Extensions/Override/InternalsOverrideAssertionFailureTests.swift
+++ b/Tests/RequestDLInternalsTests/Extensions/Override/InternalsOverrideAssertionFailureTests.swift
@@ -6,6 +6,7 @@ import SwiftAsyncStream
 import Testing
 
 @testable import RequestDLInternals
+@testable import RequestDLTestSupport
 
 #if DEBUG
 struct InternalsOverrideAssertionFailureTests {
@@ -43,6 +44,57 @@ struct InternalsOverrideAssertionFailureTests {
 
         // Then
         #expect(captured.wrappedValue == "plain message")
+    }
+
+    /// `installGlobally` is one shared, last-writer-wins slot for the whole process — the same
+    /// contract a real test run relies on (whichever `.nonFatalWatchdog` suite starts first
+    /// installs it for everyone). Racing this test's own install against `NonFatalWatchdogTrait`
+    /// installing its own closure from a concurrently-running covered suite would make this
+    /// flaky (whichever wins governs, silently), so `ensureInstalled()` joins that trait's
+    /// one-time install first — it can then never fire again for the rest of the process — before
+    /// this test claims the slot for itself.
+    @Test
+    func installGloballyInterceptsDetachedReportsAndYieldsToTaskLocalReplace() async throws {
+        // Given
+        NonFatalWatchdogTrait.ensureInstalled()
+
+        // `AsyncLock.Watchdog` reports from a `Task.detached`, which does not inherit the
+        // task-local override `replace(with:perform:)` relies on — this is the scenario
+        // `installGlobally` exists for, so the regression has to go through a detached task
+        // too, not a plain synchronous call.
+        let captured = InlineProperty<String?>(wrappedValue: nil)
+        let signal = AsyncSignal()
+
+        Internals.Override.AssertionFailure.installGlobally { message, _, _ in
+            captured.wrappedValue = message
+            signal.signal()
+        }
+
+        // When
+        Task.detached {
+            Internals.assertionFailure("simulated watchdog trip")
+        }
+
+        try await signal.wait()
+
+        // Then
+        #expect(captured.wrappedValue == "🐞 RequestDL bug: simulated watchdog trip")
+
+        // Given
+        // A task-local replace must still win over the global override just installed above —
+        // otherwise every other test relying on replace(with:perform:) to capture a specific
+        // failure would silently observe nothing once any global override exists.
+        let taskLocalCaptured = InlineProperty<String?>(wrappedValue: nil)
+
+        // When
+        Internals.Override.AssertionFailure.replace { message, _, _ in
+            taskLocalCaptured.wrappedValue = message
+        } perform: {
+            Internals.assertionFailure("task-local should win")
+        }
+
+        // Then
+        #expect(taskLocalCaptured.wrappedValue == "🐞 RequestDL bug: task-local should win")
     }
 }
 #endif

--- a/Tests/RequestDLInternalsTests/Extensions/URLExtensionsTests.swift
+++ b/Tests/RequestDLInternalsTests/Extensions/URLExtensionsTests.swift
@@ -2,6 +2,7 @@
 // See LICENSE for this package's licensing information.
 //
 
+import SwiftAsyncTesting
 import Testing
 
 @testable import RequestDLInternals
@@ -13,6 +14,7 @@ import FoundationEssentials
 import struct Foundation.Data
 #endif
 
+@Suite(.concurrent(2))
 struct URLExtensionsTests {
 
     @Test

--- a/Tests/RequestDLInternalsTests/Extensions/URLExtensionsTests.swift
+++ b/Tests/RequestDLInternalsTests/Extensions/URLExtensionsTests.swift
@@ -14,7 +14,7 @@ import FoundationEssentials
 import struct Foundation.Data
 #endif
 
-@Suite(.concurrent(2))
+@Suite(.concurrent(2), .nonFatalWatchdog)
 struct URLExtensionsTests {
 
     @Test

--- a/Tests/RequestDLInternalsTests/Extensions/URLExtensionsTests.swift
+++ b/Tests/RequestDLInternalsTests/Extensions/URLExtensionsTests.swift
@@ -14,7 +14,7 @@ import FoundationEssentials
 import struct Foundation.Data
 #endif
 
-@Suite(.concurrent(2), .nonFatalWatchdog)
+@Suite(.concurrent(watchdogAffectedPlatformConcurrencyLimit), .nonFatalWatchdog)
 struct URLExtensionsTests {
 
     @Test

--- a/Tests/RequestDLInternalsTests/Sources/Buffers/Data/InternalsDataBufferTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Buffers/Data/InternalsDataBufferTests.swift
@@ -3,6 +3,7 @@
 //
 
 import NIOCore
+import SwiftAsyncTesting
 import Testing
 
 @testable import RequestDLInternals
@@ -15,6 +16,7 @@ import struct Foundation.Data
 import struct Foundation.URL
 #endif
 
+@Suite(.concurrent(2))
 struct InternalsDataBufferTests {
 
     @Test

--- a/Tests/RequestDLInternalsTests/Sources/Buffers/Data/InternalsDataBufferTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Buffers/Data/InternalsDataBufferTests.swift
@@ -16,7 +16,7 @@ import struct Foundation.Data
 import struct Foundation.URL
 #endif
 
-@Suite(.concurrent(2))
+@Suite(.concurrent(2), .nonFatalWatchdog)
 struct InternalsDataBufferTests {
 
     @Test

--- a/Tests/RequestDLInternalsTests/Sources/Buffers/Data/InternalsDataBufferTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Buffers/Data/InternalsDataBufferTests.swift
@@ -16,7 +16,7 @@ import struct Foundation.Data
 import struct Foundation.URL
 #endif
 
-@Suite(.concurrent(2), .nonFatalWatchdog)
+@Suite(.concurrent(watchdogAffectedPlatformConcurrencyLimit), .nonFatalWatchdog)
 struct InternalsDataBufferTests {
 
     @Test

--- a/Tests/RequestDLInternalsTests/Sources/Buffers/File/InternalsFileBufferTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Buffers/File/InternalsFileBufferTests.swift
@@ -17,7 +17,7 @@ import struct Foundation.URL
 import struct Foundation.UUID
 #endif
 
-@Suite(.concurrent(2), .nonFatalWatchdog)
+@Suite(.concurrent(watchdogAffectedPlatformConcurrencyLimit), .nonFatalWatchdog)
 struct InternalsFileBufferTests {
 
     /// Owns a scratch file for the lifetime of one test.

--- a/Tests/RequestDLInternalsTests/Sources/Buffers/File/InternalsFileBufferTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Buffers/File/InternalsFileBufferTests.swift
@@ -2,6 +2,7 @@
 // See LICENSE for this package's licensing information.
 //
 
+import SwiftAsyncTesting
 import SystemPackage
 import Testing
 
@@ -16,6 +17,7 @@ import struct Foundation.URL
 import struct Foundation.UUID
 #endif
 
+@Suite(.concurrent(2))
 struct InternalsFileBufferTests {
 
     /// Owns a scratch file for the lifetime of one test.

--- a/Tests/RequestDLInternalsTests/Sources/Buffers/File/InternalsFileBufferTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Buffers/File/InternalsFileBufferTests.swift
@@ -17,7 +17,7 @@ import struct Foundation.URL
 import struct Foundation.UUID
 #endif
 
-@Suite(.concurrent(2))
+@Suite(.concurrent(2), .nonFatalWatchdog)
 struct InternalsFileBufferTests {
 
     /// Owns a scratch file for the lifetime of one test.

--- a/Tests/RequestDLInternalsTests/Sources/Buffers/File/InternalsFileStreamBufferTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Buffers/File/InternalsFileStreamBufferTests.swift
@@ -15,7 +15,7 @@ import FoundationEssentials
 import struct Foundation.Data
 #endif
 
-@Suite(.concurrent(2), .nonFatalWatchdog)
+@Suite(.concurrent(watchdogAffectedPlatformConcurrencyLimit), .nonFatalWatchdog)
 struct InternalsFileStreamBufferTests {
 
     @Test

--- a/Tests/RequestDLInternalsTests/Sources/Buffers/File/InternalsFileStreamBufferTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Buffers/File/InternalsFileStreamBufferTests.swift
@@ -14,7 +14,7 @@ import FoundationEssentials
 import struct Foundation.Data
 #endif
 
-@Suite(.concurrent(2))
+@Suite(.concurrent(2), .nonFatalWatchdog)
 struct InternalsFileStreamBufferTests {
 
     @Test

--- a/Tests/RequestDLInternalsTests/Sources/Buffers/File/InternalsFileStreamBufferTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Buffers/File/InternalsFileStreamBufferTests.swift
@@ -2,6 +2,7 @@
 // See LICENSE for this package's licensing information.
 //
 
+@_spi(Testing) import SwiftAsyncStream
 import SwiftAsyncTesting
 import Testing
 
@@ -22,10 +23,22 @@ struct InternalsFileStreamBufferTests {
         try await withTemporaryFileURL("stream.bin") { url in
             let stream = try await Internals.FileStreamBuffer(writingTo: .init(url))
 
+            // Holding the lock first, then waiting for the task to actually queue behind it,
+            // makes "cancelled before it runs" deterministic instead of a race between
+            // `task.cancel()` and the task getting scheduled — under CI scheduler contention,
+            // a freshly created task can start and finish before the creating task even reaches
+            // `cancel()`. `AsyncLock` guarantees a cancelled waiter still takes its turn and
+            // runs `writeData`'s loop, which checks `Task.checkCancellation()` before doing
+            // anything else — see `Internals.FileStreamBuffer.writeData`.
+            await stream.lock.lock()
+
             let task = _Concurrency.Task<Void, Error> {
                 try await stream.writeData(Data("Hello world".utf8))
             }
+            try await stream.lock.waitForPendingOperations(1, timeout: 5)
+
             task.cancel()
+            stream.lock.unlock()
 
             await #expect(throws: CancellationError.self) {
                 try await task.value
@@ -43,10 +56,16 @@ struct InternalsFileStreamBufferTests {
 
             let stream = try await Internals.FileStreamBuffer(readingFrom: .init(url))
 
+            // Same reasoning as the writeData test above.
+            await stream.lock.lock()
+
             let task = _Concurrency.Task<Data?, Error> {
                 try await stream.readData(length: UInt64(data.count))
             }
+            try await stream.lock.waitForPendingOperations(1, timeout: 5)
+
             task.cancel()
+            stream.lock.unlock()
 
             await #expect(throws: CancellationError.self) {
                 try await task.value

--- a/Tests/RequestDLInternalsTests/Sources/Buffers/File/InternalsFileStreamBufferTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Buffers/File/InternalsFileStreamBufferTests.swift
@@ -2,6 +2,7 @@
 // See LICENSE for this package's licensing information.
 //
 
+import SwiftAsyncTesting
 import Testing
 
 @testable import RequestDLInternals
@@ -13,6 +14,7 @@ import FoundationEssentials
 import struct Foundation.Data
 #endif
 
+@Suite(.concurrent(2))
 struct InternalsFileStreamBufferTests {
 
     @Test

--- a/Tests/RequestDLInternalsTests/Sources/Buffers/File/InternalsFileStreamBufferTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Buffers/File/InternalsFileStreamBufferTests.swift
@@ -6,7 +6,7 @@
 import SwiftAsyncTesting
 import Testing
 
-@testable import RequestDLInternals
+@testable @_spi(Testing) import RequestDLInternals
 @testable import RequestDLTestSupport
 
 #if canImport(FoundationEssentials)
@@ -30,15 +30,15 @@ struct InternalsFileStreamBufferTests {
             // `cancel()`. `AsyncLock` guarantees a cancelled waiter still takes its turn and
             // runs `writeData`'s loop, which checks `Task.checkCancellation()` before doing
             // anything else — see `Internals.FileStreamBuffer.writeData`.
-            await stream.lock.lock()
+            await stream.lockForTesting.lock()
 
             let task = _Concurrency.Task<Void, Error> {
                 try await stream.writeData(Data("Hello world".utf8))
             }
-            try await stream.lock.waitForPendingOperations(1, timeout: 5)
+            try await stream.lockForTesting.waitForPendingOperations(1, timeout: 5)
 
             task.cancel()
-            stream.lock.unlock()
+            stream.lockForTesting.unlock()
 
             await #expect(throws: CancellationError.self) {
                 try await task.value
@@ -57,15 +57,15 @@ struct InternalsFileStreamBufferTests {
             let stream = try await Internals.FileStreamBuffer(readingFrom: .init(url))
 
             // Same reasoning as the writeData test above.
-            await stream.lock.lock()
+            await stream.lockForTesting.lock()
 
             let task = _Concurrency.Task<Data?, Error> {
                 try await stream.readData(length: UInt64(data.count))
             }
-            try await stream.lock.waitForPendingOperations(1, timeout: 5)
+            try await stream.lockForTesting.waitForPendingOperations(1, timeout: 5)
 
             task.cancel()
-            stream.lock.unlock()
+            stream.lockForTesting.unlock()
 
             await #expect(throws: CancellationError.self) {
                 try await task.value

--- a/Tests/RequestDLInternalsTests/Sources/Client/Client Manager/InternalsClientManagerTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Client/Client Manager/InternalsClientManagerTests.swift
@@ -9,7 +9,7 @@ import Testing
 @testable import RequestDLInternals
 @testable import RequestDLTestSupport
 
-@Suite(.concurrent(2))
+@Suite(.concurrent(2), .nonFatalWatchdog)
 struct InternalsClientManagerTests {
 
     @Test

--- a/Tests/RequestDLInternalsTests/Sources/Client/Client Manager/InternalsClientManagerTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Client/Client Manager/InternalsClientManagerTests.swift
@@ -9,7 +9,7 @@ import Testing
 @testable import RequestDLInternals
 @testable import RequestDLTestSupport
 
-@Suite(.concurrent(2), .nonFatalWatchdog)
+@Suite(.concurrent(watchdogAffectedPlatformConcurrencyLimit), .nonFatalWatchdog)
 struct InternalsClientManagerTests {
 
     @Test

--- a/Tests/RequestDLInternalsTests/Sources/Client/Client Manager/InternalsClientManagerTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Client/Client Manager/InternalsClientManagerTests.swift
@@ -3,11 +3,13 @@
 //
 
 import NIOCore
+import SwiftAsyncTesting
 import Testing
 
 @testable import RequestDLInternals
 @testable import RequestDLTestSupport
 
+@Suite(.concurrent(2))
 struct InternalsClientManagerTests {
 
     @Test

--- a/Tests/RequestDLInternalsTests/Sources/Client/Client/InternalsClientConcurrencyLimitTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Client/Client/InternalsClientConcurrencyLimitTests.swift
@@ -10,8 +10,9 @@ import SwiftAsyncTesting
 import Testing
 
 @testable import RequestDLInternals
+@testable import RequestDLTestSupport
 
-@Suite(.concurrent(2), .nonFatalWatchdog)
+@Suite(.concurrent(watchdogAffectedPlatformConcurrencyLimit), .nonFatalWatchdog)
 struct InternalsClientConcurrencyLimitTests {
 
     @Test

--- a/Tests/RequestDLInternalsTests/Sources/Client/Client/InternalsClientConcurrencyLimitTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Client/Client/InternalsClientConcurrencyLimitTests.swift
@@ -9,7 +9,7 @@ import NIOPosix
 import SwiftAsyncTesting
 import Testing
 
-@testable import RequestDLInternals
+@testable @_spi(Testing) import RequestDLInternals
 @testable import RequestDLTestSupport
 
 @Suite(.concurrent(watchdogAffectedPlatformConcurrencyLimit), .nonFatalWatchdog)
@@ -52,12 +52,12 @@ struct InternalsClientConcurrencyLimitTests {
                 // happen once the other 2 have already acquired a permit — i.e. once the
                 // concurrency limit is actually in effect, not after a guessed wall-clock
                 // delay that a loaded CI runner can blow through.
-                try await client.connectionSemaphore?.waitForWaiters(requestCount - 2, timeout: 5)
+                try await client.connectionSemaphoreForTesting?.waitForWaiters(requestCount - 2, timeout: 5)
 
                 // Then: only as many requests as the configured limit have actually acquired a
                 // permit; the rest are still queued on the semaphore.
-                #expect(client.connectionSemaphore?.waitingCount == requestCount - 2)
-                #expect(client.connectionSemaphore?.availablePermits == 0)
+                #expect(client.connectionSemaphoreForTesting?.waitingCount == requestCount - 2)
+                #expect(client.connectionSemaphoreForTesting?.availablePermits == 0)
 
                 releaseSignal.signal()
                 try await taskGroup.waitForAll()

--- a/Tests/RequestDLInternalsTests/Sources/Client/Client/InternalsClientConcurrencyLimitTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Client/Client/InternalsClientConcurrencyLimitTests.swift
@@ -10,7 +10,7 @@ import Testing
 
 @testable import RequestDLInternals
 
-@Suite(.concurrent(2))
+@Suite(.concurrent(2), .nonFatalWatchdog)
 struct InternalsClientConcurrencyLimitTests {
 
     @Test

--- a/Tests/RequestDLInternalsTests/Sources/Client/Client/InternalsClientConcurrencyLimitTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Client/Client/InternalsClientConcurrencyLimitTests.swift
@@ -5,6 +5,7 @@
 import AsyncHTTPClient
 import NIOCore
 import NIOPosix
+@_spi(Testing) import SwiftAsyncStream
 import SwiftAsyncTesting
 import Testing
 
@@ -25,6 +26,7 @@ struct InternalsClientConcurrencyLimitTests {
 
             let startedCounter = StartedCounter()
             let requestCount = 5
+            let releaseSignal = AsyncSignal()
 
             try await withThrowingTaskGroup(of: Void.self) { taskGroup in
                 for _ in 0..<requestCount {
@@ -33,25 +35,30 @@ struct InternalsClientConcurrencyLimitTests {
                         let task = await client.execute(request: request, logger: nil)
                         await startedCounter.increment()
 
-                        // Holds the permit long enough for the assertion below to observe it,
+                        // Holds the permit until the assertion below has observed the queue,
                         // then releases it the same way `InternalsUnsafeTaskTests` does: cancel
                         // the awaiting task, which drives `UnsafeTask`'s cancel path and, with
                         // it, the semaphore signal.
                         let responseTask = _Concurrency.Task { try? await task.response() }
-                        try? await _Concurrency.Task.sleep(nanoseconds: 400_000_000)
+                        try? await releaseSignal.wait()
                         responseTask.cancel()
                         _ = await responseTask.value
                     }
                 }
 
-                // Long enough for the first wave to acquire its permits, short enough that the
-                // second wave — gated behind the 400ms hold above — has not started yet.
-                try await _Concurrency.Task.sleep(nanoseconds: 150_000_000)
+                // Deterministic rather than sleep-based: waits until exactly
+                // `requestCount - 2` requests are queued behind the semaphore, which can only
+                // happen once the other 2 have already acquired a permit — i.e. once the
+                // concurrency limit is actually in effect, not after a guessed wall-clock
+                // delay that a loaded CI runner can blow through.
+                try await client.connectionSemaphore?.waitForWaiters(requestCount - 2, timeout: 5)
 
-                // Then: only as many requests as the configured limit have actually reached
-                // `_client.execute`; the rest are still suspended on the semaphore.
-                #expect(await startedCounter.value == 2)
+                // Then: only as many requests as the configured limit have actually acquired a
+                // permit; the rest are still queued on the semaphore.
+                #expect(client.connectionSemaphore?.waitingCount == requestCount - 2)
+                #expect(client.connectionSemaphore?.availablePermits == 0)
 
+                releaseSignal.signal()
                 try await taskGroup.waitForAll()
             }
 

--- a/Tests/RequestDLInternalsTests/Sources/Client/Client/InternalsClientConcurrencyLimitTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Client/Client/InternalsClientConcurrencyLimitTests.swift
@@ -5,10 +5,12 @@
 import AsyncHTTPClient
 import NIOCore
 import NIOPosix
+import SwiftAsyncTesting
 import Testing
 
 @testable import RequestDLInternals
 
+@Suite(.concurrent(2))
 struct InternalsClientConcurrencyLimitTests {
 
     @Test

--- a/Tests/RequestDLInternalsTests/Sources/Data Stream/Download/InternalsDownloadBufferTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Data Stream/Download/InternalsDownloadBufferTests.swift
@@ -14,7 +14,7 @@ import FoundationEssentials
 import struct Foundation.Data
 #endif
 
-@Suite(.concurrent(2), .nonFatalWatchdog)
+@Suite(.concurrent(watchdogAffectedPlatformConcurrencyLimit), .nonFatalWatchdog)
 struct InternalsDownloadBufferTests {
 
     @Test

--- a/Tests/RequestDLInternalsTests/Sources/Data Stream/Download/InternalsDownloadBufferTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Data Stream/Download/InternalsDownloadBufferTests.swift
@@ -2,6 +2,7 @@
 // See LICENSE for this package's licensing information.
 //
 
+import SwiftAsyncTesting
 import Testing
 
 @testable import RequestDLInternals
@@ -13,6 +14,7 @@ import FoundationEssentials
 import struct Foundation.Data
 #endif
 
+@Suite(.concurrent(2))
 struct InternalsDownloadBufferTests {
 
     @Test

--- a/Tests/RequestDLInternalsTests/Sources/Data Stream/Download/InternalsDownloadBufferTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Data Stream/Download/InternalsDownloadBufferTests.swift
@@ -14,7 +14,7 @@ import FoundationEssentials
 import struct Foundation.Data
 #endif
 
-@Suite(.concurrent(2))
+@Suite(.concurrent(2), .nonFatalWatchdog)
 struct InternalsDownloadBufferTests {
 
     @Test

--- a/Tests/RequestDLInternalsTests/Sources/Server/Local Server/LocalServerConcurrencyTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Server/Local Server/LocalServerConcurrencyTests.swift
@@ -3,6 +3,7 @@
 //
 
 import AsyncHTTPClient
+import SwiftAsyncTesting
 import Testing
 
 @testable import RequestDLInternals
@@ -26,6 +27,7 @@ import struct Foundation.UUID
 // .connect` below is also widened past AsyncHTTPClient's 10s default for the same reason: even on
 // its own dedicated group, 200 simultaneous TLS handshakes under heavy CI contention can
 // legitimately take longer than that.
+@Suite(.concurrent(2))
 struct LocalServerConcurrencyTests {
 
     @available(iOS 16, tvOS 16, watchOS 9, macOS 13, *)

--- a/Tests/RequestDLInternalsTests/Sources/Server/Local Server/LocalServerConcurrencyTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Server/Local Server/LocalServerConcurrencyTests.swift
@@ -27,7 +27,7 @@ import struct Foundation.UUID
 // .connect` below is also widened past AsyncHTTPClient's 10s default for the same reason: even on
 // its own dedicated group, 200 simultaneous TLS handshakes under heavy CI contention can
 // legitimately take longer than that.
-@Suite(.concurrent(2), .nonFatalWatchdog)
+@Suite(.concurrent(watchdogAffectedPlatformConcurrencyLimit), .nonFatalWatchdog)
 struct LocalServerConcurrencyTests {
 
     @available(iOS 16, tvOS 16, watchOS 9, macOS 13, *)

--- a/Tests/RequestDLInternalsTests/Sources/Server/Local Server/LocalServerConcurrencyTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Server/Local Server/LocalServerConcurrencyTests.swift
@@ -27,7 +27,7 @@ import struct Foundation.UUID
 // .connect` below is also widened past AsyncHTTPClient's 10s default for the same reason: even on
 // its own dedicated group, 200 simultaneous TLS handshakes under heavy CI contention can
 // legitimately take longer than that.
-@Suite(.concurrent(2))
+@Suite(.concurrent(2), .nonFatalWatchdog)
 struct LocalServerConcurrencyTests {
 
     @available(iOS 16, tvOS 16, watchOS 9, macOS 13, *)

--- a/Tests/RequestDLInternalsTests/Sources/Session/Event Loop Manager/InternalsEventLoopManagerTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Session/Event Loop Manager/InternalsEventLoopManagerTests.swift
@@ -9,7 +9,7 @@ import Testing
 
 @testable import RequestDLInternals
 
-@Suite(.concurrent(2))
+@Suite(.concurrent(2), .nonFatalWatchdog)
 struct InternalsEventLoopManagerTests {
 
     struct CustomProvider: SessionProvider {

--- a/Tests/RequestDLInternalsTests/Sources/Session/Event Loop Manager/InternalsEventLoopManagerTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Session/Event Loop Manager/InternalsEventLoopManagerTests.swift
@@ -4,10 +4,12 @@
 
 import NIOCore
 import NIOPosix
+import SwiftAsyncTesting
 import Testing
 
 @testable import RequestDLInternals
 
+@Suite(.concurrent(2))
 struct InternalsEventLoopManagerTests {
 
     struct CustomProvider: SessionProvider {

--- a/Tests/RequestDLInternalsTests/Sources/Session/Event Loop Manager/InternalsEventLoopManagerTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Session/Event Loop Manager/InternalsEventLoopManagerTests.swift
@@ -8,8 +8,9 @@ import SwiftAsyncTesting
 import Testing
 
 @testable import RequestDLInternals
+@testable import RequestDLTestSupport
 
-@Suite(.concurrent(2), .nonFatalWatchdog)
+@Suite(.concurrent(watchdogAffectedPlatformConcurrencyLimit), .nonFatalWatchdog)
 struct InternalsEventLoopManagerTests {
 
     struct CustomProvider: SessionProvider {

--- a/Tests/RequestDLInternalsTests/Sources/Session/Session Provider/Models/SharedSessionProviderTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Session/Session Provider/Models/SharedSessionProviderTests.swift
@@ -13,7 +13,7 @@ import Testing
 import NIOTransportServices
 #endif
 
-@Suite(.concurrent(2))
+@Suite(.concurrent(2), .nonFatalWatchdog)
 struct SharedSessionProviderTests {
 
     @Test

--- a/Tests/RequestDLInternalsTests/Sources/Session/Session Provider/Models/SharedSessionProviderTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Session/Session Provider/Models/SharedSessionProviderTests.swift
@@ -8,12 +8,13 @@ import SwiftAsyncTesting
 import Testing
 
 @testable import RequestDLInternals
+@testable import RequestDLTestSupport
 
 #if canImport(Darwin)
 import NIOTransportServices
 #endif
 
-@Suite(.concurrent(2), .nonFatalWatchdog)
+@Suite(.concurrent(watchdogAffectedPlatformConcurrencyLimit), .nonFatalWatchdog)
 struct SharedSessionProviderTests {
 
     @Test

--- a/Tests/RequestDLInternalsTests/Sources/Session/Session Provider/Models/SharedSessionProviderTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Session/Session Provider/Models/SharedSessionProviderTests.swift
@@ -4,6 +4,7 @@
 
 import NIOCore
 import NIOPosix
+import SwiftAsyncTesting
 import Testing
 
 @testable import RequestDLInternals
@@ -12,6 +13,7 @@ import Testing
 import NIOTransportServices
 #endif
 
+@Suite(.concurrent(2))
 struct SharedSessionProviderTests {
 
     @Test

--- a/Tests/RequestDLInternalsTests/Sources/Storage/InternalsStorageTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Storage/InternalsStorageTests.swift
@@ -9,7 +9,7 @@ import Testing
 @testable import RequestDLInternals
 @testable import RequestDLTestSupport
 
-@Suite(.concurrent(2), .nonFatalWatchdog)
+@Suite(.concurrent(watchdogAffectedPlatformConcurrencyLimit), .nonFatalWatchdog)
 struct InternalsStorageTests {
 
     @Test

--- a/Tests/RequestDLInternalsTests/Sources/Storage/InternalsStorageTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Storage/InternalsStorageTests.swift
@@ -9,7 +9,7 @@ import Testing
 @testable import RequestDLInternals
 @testable import RequestDLTestSupport
 
-@Suite(.concurrent(2))
+@Suite(.concurrent(2), .nonFatalWatchdog)
 struct InternalsStorageTests {
 
     @Test

--- a/Tests/RequestDLInternalsTests/Sources/Storage/InternalsStorageTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Storage/InternalsStorageTests.swift
@@ -3,11 +3,13 @@
 //
 
 import NIOCore
+import SwiftAsyncTesting
 import Testing
 
 @testable import RequestDLInternals
 @testable import RequestDLTestSupport
 
+@Suite(.concurrent(2))
 struct InternalsStorageTests {
 
     @Test

--- a/Tests/RequestDLTestSupport/NonFatalWatchdogTrait.swift
+++ b/Tests/RequestDLTestSupport/NonFatalWatchdogTrait.swift
@@ -1,0 +1,61 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+import RequestDLInternals
+import Testing
+
+/// Makes `AsyncLock.Watchdog` trips record a ``Testing/Issue`` instead of crashing the whole
+/// process.
+///
+/// `AsyncLock.Watchdog` reports through `Internals.assertionFailure`, which by default traps —
+/// appropriate for a real deadlock, but not for the runner-level CPU/scheduler stalls that trip
+/// it under CI simulator contention (see the request-dl-nio CI-flakiness issue tracking
+/// `AsyncLock.Watchdog` false positives): one stalled lock then takes the entire test job down
+/// with it, including every other test that happened to be in flight.
+///
+/// `Internals.Override.AssertionFailure`'s existing task-local override can't help here —
+/// `AsyncLock`'s watchdog reports from a `Task.detached`, which does not inherit task-local
+/// values, so it always sees the default. This trait installs a process-wide override instead,
+/// the first time any suite carrying it runs. That install is a plain `static let`, so it is
+/// idempotent and thread-safe no matter how many suites reference it concurrently, and — because
+/// the override is process-wide rather than per-suite — it also covers every other suite in the
+/// same test run once installed, not just the ones that carry this trait.
+public struct NonFatalWatchdogTrait: TestTrait, SuiteTrait, TestScoping {
+
+    public var isRecursive: Bool { true }
+
+    private static let install: Void = {
+        Internals.Override.AssertionFailure.installGlobally { message, _, _ in
+            Issue.record(Comment(rawValue: message))
+        }
+    }()
+
+    /// Forces the one-time install to run now, if it hasn't already.
+    ///
+    /// `installGlobally` always overwrites — by design, so the *last* thing to call it governs
+    /// for the rest of the process — which means a test that wants to install its own
+    /// distinguishable closure and reliably observe it win needs this trait's install to be
+    /// unable to fire *after* that point. Calling this first joins the one-time `static let`
+    /// (thread-safe: every caller either runs the initializer once or blocks until whoever is
+    /// already running it finishes), so once it returns, nothing tied to this trait will ever
+    /// call `installGlobally` again for the rest of the process.
+    public static func ensureInstalled() {
+        _ = install
+    }
+
+    public func provideScope(
+        for test: Test,
+        testCase: Test.Case?,
+        performing function: @Sendable () async throws -> Void
+    ) async throws {
+        _ = Self.install
+        try await function()
+    }
+}
+
+extension Trait where Self == NonFatalWatchdogTrait {
+
+    /// Records `AsyncLock.Watchdog` trips as a test issue instead of crashing the process.
+    public static var nonFatalWatchdog: Self { Self() }
+}

--- a/Tests/RequestDLTestSupport/NonFatalWatchdogTrait.swift
+++ b/Tests/RequestDLTestSupport/NonFatalWatchdogTrait.swift
@@ -30,9 +30,9 @@ import Testing
 /// idempotent and thread-safe no matter how many suites reference it concurrently, and — because
 /// the override is process-wide rather than per-suite — it also covers every other suite in the
 /// same test run once installed, not just the ones that carry this trait.
-public struct NonFatalWatchdogTrait: TestTrait, SuiteTrait, TestScoping {
+package struct NonFatalWatchdogTrait: TestTrait, SuiteTrait, TestScoping {
 
-    public var isRecursive: Bool { true }
+    package var isRecursive: Bool { true }
 
     private static let install: Void = {
         Internals.Override.AssertionFailure.installGlobally { message, _, _ in
@@ -49,11 +49,11 @@ public struct NonFatalWatchdogTrait: TestTrait, SuiteTrait, TestScoping {
     /// (thread-safe: every caller either runs the initializer once or blocks until whoever is
     /// already running it finishes), so once it returns, nothing tied to this trait will ever
     /// call `installGlobally` again for the rest of the process.
-    public static func ensureInstalled() {
+    package static func ensureInstalled() {
         _ = install
     }
 
-    public func provideScope(
+    package func provideScope(
         for test: Test,
         testCase: Test.Case?,
         performing function: @Sendable () async throws -> Void
@@ -66,6 +66,6 @@ public struct NonFatalWatchdogTrait: TestTrait, SuiteTrait, TestScoping {
 extension Trait where Self == NonFatalWatchdogTrait {
 
     /// Records `AsyncLock.Watchdog` trips as a test issue instead of crashing the process.
-    public static var nonFatalWatchdog: Self { Self() }
+    package static var nonFatalWatchdog: Self { Self() }
 }
 #endif

--- a/Tests/RequestDLTestSupport/NonFatalWatchdogTrait.swift
+++ b/Tests/RequestDLTestSupport/NonFatalWatchdogTrait.swift
@@ -2,6 +2,15 @@
 // See LICENSE for this package's licensing information.
 //
 
+// `RequestDLTestSupport` is a regular target, built unconditionally by every `swift build`
+// (Release, Static SDK, Android, ...), not just test runs:
+// - Unlike a `.testTarget`, it has no automatic access to `Testing`, and the module genuinely
+//   isn't there on some of those toolchains (confirmed on the Static SDK and Android builds).
+// - `Internals.Override.AssertionFailure`, which this file calls into, only exists `#if DEBUG`
+//   in RequestDLInternals — a Release build compiles this target too (confirmed on Release 6.2
+//   and 6.3), where that whole type is unavailable.
+// Degrading to empty rather than failing keeps this file harmless everywhere it isn't needed.
+#if DEBUG && canImport(Testing)
 import RequestDLInternals
 import Testing
 
@@ -59,3 +68,4 @@ extension Trait where Self == NonFatalWatchdogTrait {
     /// Records `AsyncLock.Watchdog` trips as a test issue instead of crashing the process.
     public static var nonFatalWatchdog: Self { Self() }
 }
+#endif

--- a/Tests/RequestDLTestSupport/WatchdogAffectedPlatformConcurrencyLimit.swift
+++ b/Tests/RequestDLTestSupport/WatchdogAffectedPlatformConcurrencyLimit.swift
@@ -1,0 +1,21 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+/// How many of the suites carrying `.concurrent(_:)` may run at once, or `nil` to let
+/// `ConcurrentExecutionTrait` skip the semaphore entirely.
+///
+/// The `AsyncLock.Watchdog` false-positive investigation this throttling exists for was
+/// observed only on Apple *simulator* runners — iOS, iPadOS (which shares `os(iOS)` with iPhone;
+/// there is no separate compile-time identifier for it), watchOS, visionOS — never on macOS,
+/// Mac Catalyst, tvOS, Linux, or Android, which don't run the tests inside a simulator's
+/// host-bridged, scheduler-contended environment in the first place. Actually gating the limit
+/// still matters there, not just documenting it: an unnecessary semaphore serializes otherwise
+/// independent suites for no reason on every platform that was never flaky.
+package let watchdogAffectedPlatformConcurrencyLimit: Int? = {
+    #if (os(iOS) && !targetEnvironment(macCatalyst)) || os(watchOS) || os(visionOS)
+    return 2
+    #else
+    return nil
+    #endif
+}()

--- a/Tests/RequestDLTests/Properties/Sources/Cache/Cached Request/CachedRequestTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Cache/Cached Request/CachedRequestTests.swift
@@ -23,7 +23,7 @@ import struct Foundation.Date
 import class Foundation.JSONEncoder
 #endif
 
-@Suite(.serialized, .concurrent(2), .nonFatalWatchdog)
+@Suite(.serialized, .concurrent(watchdogAffectedPlatformConcurrencyLimit), .nonFatalWatchdog)
 struct CachedRequestTests {
 
     final class TestState: Sendable {

--- a/Tests/RequestDLTests/Properties/Sources/Cache/Cached Request/CachedRequestTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Cache/Cached Request/CachedRequestTests.swift
@@ -7,6 +7,7 @@ import NIOConcurrencyHelpers
 import NIOCore
 import NIOHTTP1
 import RequestDLInternals
+import SwiftAsyncTesting
 import Testing
 
 @testable import RequestDL
@@ -22,7 +23,7 @@ import struct Foundation.Date
 import class Foundation.JSONEncoder
 #endif
 
-@Suite(.serialized)
+@Suite(.serialized, .concurrent(2))
 struct CachedRequestTests {
 
     final class TestState: Sendable {

--- a/Tests/RequestDLTests/Properties/Sources/Cache/Cached Request/CachedRequestTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Cache/Cached Request/CachedRequestTests.swift
@@ -23,7 +23,7 @@ import struct Foundation.Date
 import class Foundation.JSONEncoder
 #endif
 
-@Suite(.serialized, .concurrent(2))
+@Suite(.serialized, .concurrent(2), .nonFatalWatchdog)
 struct CachedRequestTests {
 
     final class TestState: Sendable {

--- a/Tests/RequestDLTests/Properties/Sources/Cache/Data Cache/DataCacheTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Cache/Data Cache/DataCacheTests.swift
@@ -3,7 +3,6 @@
 //
 
 import AsyncAlgorithms
-import SwiftAsyncStream
 import Testing
 
 @testable import RequestDL
@@ -573,41 +572,44 @@ extension DataCacheTests {
 extension DataCacheTests {
 
     @Test
-    func accessingAllocateBufferMultipleTimes() async throws {
+    func accessingAllocateBufferMultipleTimes() async {
         let dataCache = DataCache(
             memoryCapacity: 100 * 1_024 * 1_024,
             suiteName: UUID().uuidString
         )
 
         let key = UUID().uuidString
-        var locks = [AsyncSignal]()
 
-        for index in 0..<1_000 {
-            let lock = AsyncSignal()
-            locks.append(lock)
+        // Bounded in batches rather than firing all 1,000 accesses as loose concurrent
+        // tasks: an unbounded burst saturates the cooperative thread pool on CI's Apple
+        // simulator runners badly enough that a perfectly healthy access can sit in the
+        // backlog longer than `AsyncLock.Watchdog`'s deadline, failing the job on
+        // wall-clock scheduler contention rather than an actual bug. Concurrent access
+        // is still exercised within each batch; only the total in flight at once is
+        // capped.
+        let batchSize = 50
 
-            Task.detached(priority: .background) {
-                defer { lock.signal() }
-
-                _ = await dataCache.allocateBuffer(
-                    key: key + "\(index)",
-                    cachedResponse: .init(
-                        response: .init(
-                            url: UUID().uuidString,
-                            status: .init(code: 200, reason: UUID().uuidString),
-                            version: .init(minor: 0, major: 10),
-                            headers: .init(),
-                            isKeepAlive: false
-                        ),
-                        policy: .memory
-                    ),
-                    contentLength: 1_024 * 1_024
-                )
+        for batchStart in stride(from: 0, to: 1_000, by: batchSize) {
+            await withTaskGroup(of: Void.self) { group in
+                for index in batchStart..<min(batchStart + batchSize, 1_000) {
+                    group.addTask(priority: .background) {
+                        _ = await dataCache.allocateBuffer(
+                            key: key + "\(index)",
+                            cachedResponse: .init(
+                                response: .init(
+                                    url: UUID().uuidString,
+                                    status: .init(code: 200, reason: UUID().uuidString),
+                                    version: .init(minor: 0, major: 10),
+                                    headers: .init(),
+                                    isKeepAlive: false
+                                ),
+                                policy: .memory
+                            ),
+                            contentLength: 1_024 * 1_024
+                        )
+                    }
+                }
             }
-        }
-
-        for lock in locks {
-            try await lock.wait()
         }
     }
 }

--- a/Tests/RequestDLTests/Properties/Sources/Cache/Data Cache/DataCacheTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Cache/Data Cache/DataCacheTests.swift
@@ -22,7 +22,7 @@ private let globalMemoryCapacity: Int64 = 8 * 1_024 * 1_024
 private let globalDiskCapacity: Int64 = 64 * 1_024 * 1_024
 private let globalDataCache = DataCache(suiteName: UUID().uuidString)
 
-@Suite(.serialized, .concurrent(2))
+@Suite(.serialized, .concurrent(2), .nonFatalWatchdog)
 struct DataCacheTests {
 
     final class TestState: Sendable {

--- a/Tests/RequestDLTests/Properties/Sources/Cache/Data Cache/DataCacheTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Cache/Data Cache/DataCacheTests.swift
@@ -3,6 +3,7 @@
 //
 
 import AsyncAlgorithms
+import SwiftAsyncTesting
 import Testing
 
 @testable import RequestDL
@@ -21,7 +22,7 @@ private let globalMemoryCapacity: Int64 = 8 * 1_024 * 1_024
 private let globalDiskCapacity: Int64 = 64 * 1_024 * 1_024
 private let globalDataCache = DataCache(suiteName: UUID().uuidString)
 
-@Suite(.serialized)
+@Suite(.serialized, .concurrent(2))
 struct DataCacheTests {
 
     final class TestState: Sendable {

--- a/Tests/RequestDLTests/Properties/Sources/Cache/Data Cache/DataCacheTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Cache/Data Cache/DataCacheTests.swift
@@ -22,7 +22,7 @@ private let globalMemoryCapacity: Int64 = 8 * 1_024 * 1_024
 private let globalDiskCapacity: Int64 = 64 * 1_024 * 1_024
 private let globalDataCache = DataCache(suiteName: UUID().uuidString)
 
-@Suite(.serialized, .concurrent(2), .nonFatalWatchdog)
+@Suite(.serialized, .concurrent(watchdogAffectedPlatformConcurrencyLimit), .nonFatalWatchdog)
 struct DataCacheTests {
 
     final class TestState: Sendable {

--- a/Tests/RequestDLTests/Tasks/Sources/Raw Task/Mocked/MockedTaskTests.swift
+++ b/Tests/RequestDLTests/Tasks/Sources/Raw Task/Mocked/MockedTaskTests.swift
@@ -17,7 +17,7 @@ import struct Foundation.UUID
 import class Foundation.JSONEncoder
 #endif
 
-@Suite(.concurrent(2))
+@Suite(.concurrent(2), .nonFatalWatchdog)
 struct MockedTaskTests {
 
     @Test

--- a/Tests/RequestDLTests/Tasks/Sources/Raw Task/Mocked/MockedTaskTests.swift
+++ b/Tests/RequestDLTests/Tasks/Sources/Raw Task/Mocked/MockedTaskTests.swift
@@ -17,7 +17,7 @@ import struct Foundation.UUID
 import class Foundation.JSONEncoder
 #endif
 
-@Suite(.concurrent(2), .nonFatalWatchdog)
+@Suite(.concurrent(watchdogAffectedPlatformConcurrencyLimit), .nonFatalWatchdog)
 struct MockedTaskTests {
 
     @Test

--- a/Tests/RequestDLTests/Tasks/Sources/Raw Task/Mocked/MockedTaskTests.swift
+++ b/Tests/RequestDLTests/Tasks/Sources/Raw Task/Mocked/MockedTaskTests.swift
@@ -2,6 +2,7 @@
 // See LICENSE for this package's licensing information.
 //
 
+import SwiftAsyncTesting
 import Testing
 
 @testable import RequestDL
@@ -16,6 +17,7 @@ import struct Foundation.UUID
 import class Foundation.JSONEncoder
 #endif
 
+@Suite(.concurrent(2))
 struct MockedTaskTests {
 
     @Test

--- a/Tests/RequestDLTests/Tasks/Sources/Raw Task/Raw/SessionExecutionTests.swift
+++ b/Tests/RequestDLTests/Tasks/Sources/Raw Task/Raw/SessionExecutionTests.swift
@@ -46,7 +46,7 @@ private func execute(
 // response; swift-testing runs `@Test`s in a suite concurrently by default, and the upload
 // starves the group's threads until the others hit `connectTimeout`. `.serialized` keeps this
 // suite's tests from overlapping, which the connection-pool tuning below alone didn't fix.
-@Suite(.serialized, .concurrent(2), .nonFatalWatchdog)
+@Suite(.serialized, .concurrent(watchdogAffectedPlatformConcurrencyLimit), .nonFatalWatchdog)
 struct SessionExecutionTests {
 
     final class TestState: Sendable {

--- a/Tests/RequestDLTests/Tasks/Sources/Raw Task/Raw/SessionExecutionTests.swift
+++ b/Tests/RequestDLTests/Tasks/Sources/Raw Task/Raw/SessionExecutionTests.swift
@@ -2,6 +2,7 @@
 // See LICENSE for this package's licensing information.
 //
 
+import SwiftAsyncTesting
 import Testing
 
 @testable import RequestDL
@@ -45,7 +46,7 @@ private func execute(
 // response; swift-testing runs `@Test`s in a suite concurrently by default, and the upload
 // starves the group's threads until the others hit `connectTimeout`. `.serialized` keeps this
 // suite's tests from overlapping, which the connection-pool tuning below alone didn't fix.
-@Suite(.serialized)
+@Suite(.serialized, .concurrent(2))
 struct SessionExecutionTests {
 
     final class TestState: Sendable {

--- a/Tests/RequestDLTests/Tasks/Sources/Raw Task/Raw/SessionExecutionTests.swift
+++ b/Tests/RequestDLTests/Tasks/Sources/Raw Task/Raw/SessionExecutionTests.swift
@@ -46,7 +46,7 @@ private func execute(
 // response; swift-testing runs `@Test`s in a suite concurrently by default, and the upload
 // starves the group's threads until the others hit `connectTimeout`. `.serialized` keeps this
 // suite's tests from overlapping, which the connection-pool tuning below alone didn't fix.
-@Suite(.serialized, .concurrent(2))
+@Suite(.serialized, .concurrent(2), .nonFatalWatchdog)
 struct SessionExecutionTests {
 
     final class TestState: Sendable {


### PR DESCRIPTION
## Summary
- `DataCacheTests.accessingAllocateBufferMultipleTimes()` fired 1,000 loose concurrent `Task.detached` calls at once. On Apple simulator CI runners (iOS/iPadOS/visionOS/watchOS) that saturates the cooperative thread pool badly enough that a perfectly healthy `allocateBuffer` access sits in the backlog longer than `AsyncLock.Watchdog`'s deadline, crashing the job on scheduler contention rather than an actual bug.
- This is the same class of flakiness investigated in #266/#270/#271: #270 relaxed the watchdog thresholds and capped simulator worker count, and #271/#272 fixed an O(n²) `DiskStorage` rescan — but this specific test uses `policy: .memory`, so it never went through `DiskStorage` and wasn't touched by that fix. It still failed on iOS and visionOS in PR #301's CI run today.
- Fix: run the same 1,000 accesses in batches of 50 via `withTaskGroup` instead of all at once. Concurrent access is still exercised within each batch; only the total in flight at any moment is bounded, which keeps individual operations from being starved past the watchdog deadline under CI's constrained scheduler.

## Test plan
- [x] `swift build`
- [x] `swift test --filter DataCacheTests` — 17/17 passing locally (0.186s for the modified test)
- [x] `swift format lint --recursive --strict` on the changed file
- [ ] CI green on iOS/iPadOS/visionOS/watchOS (previously flaky destinations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)