### PR TITLE
Add Configured property for swift-configuration integration

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -64,7 +64,8 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/apple/swift-configuration",
-            from: "1.2.0"
+            from: "1.2.0",
+            traits: []
         ),
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -62,6 +62,10 @@ let package = Package(
             url: "https://github.com/apple/swift-distributed-tracing",
             from: "1.1.0"
         ),
+        .package(
+            url: "https://github.com/apple/swift-configuration",
+            from: "1.0.0"
+        ),
     ],
     targets: [
         .target(
@@ -104,6 +108,7 @@ let package = Package(
                 .product(name: "Logging", package: "swift-log"),
                 .product(name: "Collections", package: "swift-collections"),
                 .product(name: "Tracing", package: "swift-distributed-tracing"),
+                .product(name: "Configuration", package: "swift-configuration"),
             ],
             swiftSettings: [.defaultIsolation(nil)],
         ),
@@ -134,6 +139,7 @@ let package = Package(
                 "RequestDLInternals",
                 "RequestDLTestSupport",
                 .product(name: "AsyncAlgorithms", package: "swift-async-algorithms"),
+                .product(name: "Configuration", package: "swift-configuration"),
             ],
             resources: [.process("Resources")]
         ),

--- a/Sources/RequestDL/Documentation.docc/Essentials/Building the Request/Building-the-request.md
+++ b/Sources/RequestDL/Documentation.docc/Essentials/Building the Request/Building-the-request.md
@@ -17,3 +17,7 @@ Explore the various types and configurations available to make your request.
 ### Working with cache
 
 - <doc:Cache-support>
+
+### Configuration-driven requests
+
+- <doc:Configuration-driven-requests>

--- a/Sources/RequestDL/Documentation.docc/Essentials/Building the Request/Configuration-driven Requests/Configuration-driven-requests.md
+++ b/Sources/RequestDL/Documentation.docc/Essentials/Building the Request/Configuration-driven Requests/Configuration-driven-requests.md
@@ -1,0 +1,100 @@
+# Configuration-driven requests
+
+Drive a request's properties — base URL, headers, authentication, proxy, secure connection, caching, and more — from an external configuration source instead of hardcoding them as Swift literals.
+
+## Overview
+
+``RequestDL/Configured`` reads from a swift-configuration `ConfigReader` — backed by environment variables, a JSON file, in-memory defaults, or any other `ConfigProvider` — and composes the same properties you'd otherwise write by hand (``RequestDL/BaseURL``, ``RequestDL/Authorization``, ``RequestDL/Proxy``, ``RequestDL/SecureConnection``, ...). Nothing about the resulting request is special-cased: a config-driven property and a literal one resolve exactly the same way, and the two compose freely in the same `@PropertyBuilder` block.
+
+```swift
+DataTask {
+    Configured(appConfig)
+}
+```
+
+> Important: `Configured` is gated to `macOS 15`, `iOS 18`, `watchOS 11`, `tvOS 18`, and `visionOS 2` — every symbol in swift-configuration's `Configuration` module carries that same availability. This is a per-symbol gate, not a change to the package's own platform floor: every other RequestDL property keeps working on its existing, older minimums.
+
+`ConfigReader.scoped(to:)` lets multiple endpoints share one reader under different key prefixes, so a single configuration source can back several distinct `Configured` declarations:
+
+```swift
+DataTask {
+    Configured(appConfig.scoped(to: "usersAPI"))
+}
+```
+
+### A basic setup
+
+The simplest case reads a host, an HTTP method, a timeout, and a handful of headers and query parameters:
+
+```swift
+let provider = InMemoryProvider(values: [
+    "baseURL": "https://api.example.com",
+    "method": "post",
+    "timeout": 30,
+    "headers": .init(.stringArray(["X-Api-Version: 2"]), isSecret: false),
+    "queries": .init(.stringArray(["locale=en_US"]), isSecret: false),
+])
+
+DataTask {
+    Configured(ConfigReader(provider: provider))
+}
+```
+
+Every key is read independently and is entirely optional — a missing key contributes nothing, the same as any other absent property. `baseURL` is passed to ``RequestDL/FlexibleURL``, not ``RequestDL/BaseURL``, since it also accepts a relative path (`"/users/123"`, appended to whatever base URL is otherwise in effect) or a complete URL that overrides it outright — see ``RequestDL/Configured`` for the full key-by-key reference.
+
+### Authentication and proxying
+
+`authorization` and `proxy` are scoped keys: each reads a handful of related sub-keys together, rather than a single flat value.
+
+```swift
+let provider = InMemoryProvider(values: [
+    "authorization.scheme": "bearer",
+    "authorization.token": apiToken,
+
+    "proxy.enabled": true,
+    "proxy.host": "proxy.example.com",
+    "proxy.port": 8080,
+])
+
+DataTask {
+    BaseURL("api.example.com")
+    Configured(ConfigReader(provider: provider))
+}
+```
+
+Unlike the properties in the basic setup above, these two — along with `secureConnection.privateKey` and `redirect` — validate what they read: an unrecognized `authorization.scheme`, a `proxy.enabled` without a `proxy.host`, and similar genuinely-invalid combinations throw ``RequestDL/ConfiguredError`` rather than silently doing nothing.
+
+### Secure connection
+
+`secureConnection.trustRoots`, `.additionalTrustRoots`, and `.certificates` each take a path to a `PEM` file and delegate straight to ``RequestDL/TrustRoots``, ``RequestDL/AdditionalTrustRoots``, and ``RequestDL/Certificates`` — none of which require nesting inside a ``RequestDL/SecureConnection`` wrapper. `secureConnection.tlsMinimumVersion`/`.tlsMaximumVersion` are the exception: configuring `SecureConnection` itself, rather than a certificate, does need that wrapper.
+
+```swift
+let provider = InMemoryProvider(values: [
+    "secureConnection.certificates": "/path/to/client.pem",
+    "secureConnection.privateKey.file": "/path/to/key.pem",
+    "secureConnection.tlsMinimumVersion": "1.2",
+])
+
+DataTask {
+    BaseURL("api.example.com")
+    Configured(ConfigReader(provider: provider))
+}
+```
+
+### Overriding a config-driven value
+
+An explicit property declared after `Configured` in the same `@PropertyBuilder` block still wins — the same "last one wins" precedent ``RequestDL/BaseURL`` and ``RequestDL/DNSOverride`` already establish for repeated declarations:
+
+```swift
+DataTask {
+    Configured(appConfig)
+    Timeout(.seconds(5))  // overrides whatever "timeout" the config specified
+}
+```
+
+## Topics
+
+### Reading configuration
+
+- ``RequestDL/Configured``
+- ``RequestDL/ConfiguredError``

--- a/Sources/RequestDL/Documentation.docc/RequestDL.md
+++ b/Sources/RequestDL/Documentation.docc/RequestDL.md
@@ -79,6 +79,7 @@ try await DataTask {
 - [x] [Combine support](<doc:Exploring-combine>) (Apple platforms only);
 - [x] [Image loading for SwiftUI, UIKit, AppKit and watchOS](<doc:Loading-images>) (Apple platforms only);
 - [x] [Distributed tracing](<doc:Distributed-tracing>);
+- [x] [Configuration-driven requests](<doc:Configuration-driven-requests>) (via swift-configuration);
 
 We are excited to expand this list with many other features. Start by making your contribution in [Discussions](https://github.com/orgs/request-dl/discussions) or by opening a PR (Pull Request).
 

--- a/Sources/RequestDL/Properties/Sources/Extra Properties/Configured/Configured.swift
+++ b/Sources/RequestDL/Properties/Sources/Extra Properties/Configured/Configured.swift
@@ -3,6 +3,7 @@
 //
 
 import Configuration
+import NIOSSL
 
 /// A property that derives declarative request properties from an external configuration source.
 ///
@@ -24,7 +25,14 @@ import Configuration
 ///
 /// ## Configuration keys
 ///
-/// - `baseURL` (string, optional): passed to ``BaseURL/init(_:)``.
+/// - `baseURL` (string, optional): passed to ``FlexibleURL/init(_:)`` — not ``BaseURL``, since
+///   `FlexibleURL` already covers everything a bare host would (a complete `"scheme://host/..."`
+///   value sets the base URL, same as `BaseURL`) while also accepting a relative value (e.g.
+///   `"/users/123"`, appended to whatever base URL is otherwise in effect) or a query-only value
+///   (e.g. `"?active=true"`) in the same field, the same trade-offs `FlexibleURL` documents on its
+///   own. A bare host with no scheme (e.g. `"example.com"`) is **not** recognized as a host here —
+///   it has no `://`, so `FlexibleURL` reads it as a relative path instead; write
+///   `"https://example.com"` for the base URL case.
 /// - `method` (string, optional): uppercased and passed to ``RequestMethod/init(_:)``.
 /// - `timeout` (int, optional): interpreted as seconds and passed to ``Timeout/init(_:for:)``.
 /// - `headers` (string array, optional): each entry is a colon-separated `"Name: Value"` pair,
@@ -37,6 +45,9 @@ import Configuration
 ///   `"bearer"` reads `authorization.token`.
 /// - `dnsOverrides` (string array, optional): each entry is a colon-separated `"host:IP"` pair,
 ///   one ``DNSOverride`` per entry.
+/// - `urlOverrides` (string array, optional): each entry is a `"origin|destination"` pair — both
+///   full `"scheme://host[/path]"` strings, so `:`/`/` couldn't serve as the separator the way
+///   they do for `dnsOverrides`/`headers` — collected into a single ``URLOverride``.
 /// - `systemProxy` (bool, optional, default: `false`): includes ``SystemProxy`` when `true`.
 /// - `proxy` (scoped, optional): passed to ``Proxy``. Reads `proxy.enabled` (default `false`;
 ///   skipped entirely when not `true`), `proxy.host` (required), `proxy.port` (required for
@@ -44,6 +55,34 @@ import Configuration
 ///   `"http"`). For `"http"` proxies only, also reads `proxy.authorization` (same shape as the
 ///   top-level `authorization` key) and `proxy.connectHeaders` (string array, colon-separated
 ///   pairs, sent only on the proxy's `CONNECT` request).
+/// - `cachePolicy` (string, optional): `"memory"`, `"disk"`, or `"all"`, passed to
+///   ``Property/cachePolicy(_:)``.
+/// - `cacheStrategy` (string, optional): `"ignoreCachedData"`, `"reloadAndValidateCachedData"`,
+///   `"returnCachedDataElseLoad"`, or `"useCachedDataOnly"` — the ``CacheStrategy`` case names
+///   verbatim — passed to ``Property/cacheStrategy(_:)``.
+/// - `secureConnection` (scoped, optional): reads `secureConnection.trustRoots`,
+///   `secureConnection.additionalTrustRoots`, and `secureConnection.certificates` (each a string
+///   path to a `PEM` file, passed to ``TrustRoots``, ``AdditionalTrustRoots``, and ``Certificates``
+///   respectively — none of these require nesting inside a `SecureConnection`, so each is included
+///   independently); `secureConnection.privateKey` (scoped: `.file` required, `.format`
+///   (`"pem"`/`"der"`, default `"pem"`), `.password` optional, treated as secret) passed to
+///   ``PrivateKey``; and `secureConnection.tlsMinimumVersion`/`secureConnection.tlsMaximumVersion`
+///   (`"1.0"`/`"1.1"`/`"1.2"`/`"1.3"`), passed to ``SecureConnection/version(minimum:)``/
+///   ``SecureConnection/version(maximum:)`` — these two, unlike the rest, do require a
+///   `SecureConnection` wrapper, since they configure `SecureConnection` itself rather than a
+///   certificate.
+/// - `redirect` (scoped, optional): passed to ``Session``. Reads `redirect.mode` (`"follow"` or
+///   `"disallow"`; absent entirely, the key contributes nothing rather than assuming either).
+///   `"follow"` additionally reads `redirect.maxRedirects` (int, default `5`) and
+///   `redirect.allowCycles` (bool, default `false`), passed to
+///   ``Session/enableRedirectFollow(max:allowCycles:)``; `"disallow"` is passed to
+///   ``Session/disableRedirect()``.
+/// - `maximumConnectionsPerHost` (int, optional): passed to
+///   ``Session/maximumConnectionsPerHost(_:)``.
+/// - `maximumConcurrentConnections` (int, optional): passed to
+///   ``Session/maximumConcurrentConnections(_:)``. Both are read independently and, when either
+///   is present, chained onto the same ``Session`` value — same as declaring
+///   `Session().maximumConnectionsPerHost(x).maximumConcurrentConnections(y)` directly.
 ///
 /// Every key is read independently and is optional: a missing key simply contributes nothing, the
 /// same as any other absent property. An explicit property declared after `Configured` in the same
@@ -51,10 +90,15 @@ import Configuration
 /// established by ``BaseURL`` and ``DNSOverride``.
 ///
 /// - Throws: ``ConfiguredError`` if `authorization.scheme` or `proxy.authorization.scheme` is
-///   specified but invalid, if the fields either requires are missing, if `proxy.enabled` is `true`
+///   specified but invalid, if the fields the specified scheme requires are missing, if
+///   `proxy.enabled` is `true`
 ///   but `proxy.host` is missing or `proxy.type` is unknown, if `proxy.port` is missing for an
-///   `"http"` proxy, or if `proxy.authorization`/`proxy.connectHeaders` is specified for a `"socks"`
-///   proxy.
+///   `"http"` proxy, if `proxy.authorization`/`proxy.connectHeaders` is specified for a `"socks"`
+///   proxy, if `cachePolicy`/`cacheStrategy` is specified but is none of the recognized values, if
+///   `secureConnection.privateKey.format` is specified but is neither `"pem"` nor `"der"`, if
+///   `secureConnection.tlsMinimumVersion`/`secureConnection.tlsMaximumVersion` is specified but is
+///   none of the recognized values, or if `redirect.mode` is specified but is neither `"follow"`
+///   nor `"disallow"`.
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 public struct Configured: Property {
 
@@ -80,7 +124,7 @@ public struct Configured: Property {
 
         return AsyncProperty {
             if let baseURL = reader.string(forKey: "baseURL") {
-                BaseURL(baseURL)
+                FlexibleURL(baseURL)
             }
 
             if let method = reader.string(forKey: "method") {
@@ -109,15 +153,187 @@ public struct Configured: Property {
                 }
             }
 
+            if let urlOverridePairs = reader.stringArray(forKey: "urlOverrides") {
+                URLOverride(Self.pairs(urlOverridePairs, separatedBy: "|"))
+            }
+
             if reader.bool(forKey: "systemProxy", default: false) {
                 SystemProxy()
             }
 
             try Self.proxy(reader.scoped(to: "proxy"))
+
+            if let cachePolicy = reader.string(forKey: "cachePolicy") {
+                EmptyProperty().cachePolicy(try Self.cachePolicy(cachePolicy))
+            }
+
+            if let cacheStrategy = reader.string(forKey: "cacheStrategy") {
+                EmptyProperty().cacheStrategy(try Self.cacheStrategy(cacheStrategy))
+            }
+
+            let secureConnectionReader = reader.scoped(to: "secureConnection")
+
+            if let trustRootsFile = secureConnectionReader.string(forKey: "trustRoots") {
+                TrustRoots(trustRootsFile)
+            }
+
+            if let additionalTrustRootsFile = secureConnectionReader.string(forKey: "additionalTrustRoots") {
+                AdditionalTrustRoots(additionalTrustRootsFile)
+            }
+
+            if let certificatesFile = secureConnectionReader.string(forKey: "certificates") {
+                Certificates(certificatesFile)
+            }
+
+            if let privateKey = try Self.privateKey(secureConnectionReader.scoped(to: "privateKey")) {
+                privateKey
+            }
+
+            if let secureConnection = try Self.secureConnectionVersion(secureConnectionReader) {
+                secureConnection
+            }
+
+            if let redirect = try Self.redirect(reader.scoped(to: "redirect")) {
+                redirect
+            }
+
+            if let connectionLimits = Self.connectionLimits(reader) {
+                connectionLimits
+            }
         }
     }
 
     // MARK: - Private static methods
+
+    private static func connectionLimits(_ reader: ConfigReader) -> Session? {
+        let maximumConnectionsPerHost = reader.int(forKey: "maximumConnectionsPerHost")
+        let maximumConcurrentConnections = reader.int(forKey: "maximumConcurrentConnections")
+
+        guard maximumConnectionsPerHost != nil || maximumConcurrentConnections != nil else {
+            return nil
+        }
+
+        var session = Session()
+
+        if let maximumConnectionsPerHost {
+            session = session.maximumConnectionsPerHost(maximumConnectionsPerHost)
+        }
+
+        if let maximumConcurrentConnections {
+            session = session.maximumConcurrentConnections(maximumConcurrentConnections)
+        }
+
+        return session
+    }
+
+    private static func redirect(_ reader: ConfigReader) throws -> Session? {
+        guard let mode = reader.string(forKey: "mode") else {
+            return nil
+        }
+
+        switch mode {
+        case "follow":
+            return Session().enableRedirectFollow(
+                max: reader.int(forKey: "maxRedirects", default: 5),
+                allowCycles: reader.bool(forKey: "allowCycles", default: false)
+            )
+        case "disallow":
+            return Session().disableRedirect()
+        default:
+            throw ConfiguredError(context: .invalidRedirectConfiguration)
+        }
+    }
+
+    private static func privateKey(_ reader: ConfigReader) throws -> PrivateKey? {
+        guard let file = reader.string(forKey: "file") else {
+            return nil
+        }
+
+        let format = try Self.certificateFormat(reader.string(forKey: "format", default: "pem"))
+
+        if let password = reader.string(forKey: "password", isSecret: true) {
+            return PrivateKey(file, format: format, password: NIOSSLSecureBytes(password.utf8))
+        }
+
+        return PrivateKey(file, format: format)
+    }
+
+    private static func secureConnectionVersion(
+        _ reader: ConfigReader
+    ) throws -> SecureConnection<EmptyProperty>? {
+        let minimum = try reader.string(forKey: "tlsMinimumVersion").map(Self.tlsVersion)
+        let maximum = try reader.string(forKey: "tlsMaximumVersion").map(Self.tlsVersion)
+
+        guard minimum != nil || maximum != nil else {
+            return nil
+        }
+
+        var secureConnection = SecureConnection()
+
+        if let minimum {
+            secureConnection = secureConnection.version(minimum: minimum)
+        }
+
+        if let maximum {
+            secureConnection = secureConnection.version(maximum: maximum)
+        }
+
+        return secureConnection
+    }
+
+    private static func certificateFormat(_ value: String) throws -> Certificate.Format {
+        switch value {
+        case "pem":
+            return .pem
+        case "der":
+            return .der
+        default:
+            throw ConfiguredError(context: .invalidSecureConnectionConfiguration)
+        }
+    }
+
+    private static func tlsVersion(_ value: String) throws -> TLSVersion {
+        switch value {
+        case "1.0":
+            return .v1
+        case "1.1":
+            return .v1_1
+        case "1.2":
+            return .v1_2
+        case "1.3":
+            return .v1_3
+        default:
+            throw ConfiguredError(context: .invalidSecureConnectionConfiguration)
+        }
+    }
+
+    private static func cacheStrategy(_ value: String) throws -> CacheStrategy {
+        switch value {
+        case "ignoreCachedData":
+            return .ignoreCachedData
+        case "reloadAndValidateCachedData":
+            return .reloadAndValidateCachedData
+        case "returnCachedDataElseLoad":
+            return .returnCachedDataElseLoad
+        case "useCachedDataOnly":
+            return .useCachedDataOnly
+        default:
+            throw ConfiguredError(context: .invalidCacheStrategy)
+        }
+    }
+
+    private static func cachePolicy(_ value: String) throws -> DataCache.Policy.Set {
+        switch value {
+        case "memory":
+            return .memory
+        case "disk":
+            return .disk
+        case "all":
+            return .all
+        default:
+            throw ConfiguredError(context: .invalidCachePolicy)
+        }
+    }
 
     // Returns a type-erased `AnyProperty` rather than `some Property`: the "http" and "socks"
     // branches each resolve to a different specialization of the generic `Proxy<Headers>`, and
@@ -174,15 +390,11 @@ public struct Configured: Property {
         }
     }
 
-    // Matches the `Headers` specialization `proxy(_:)` always builds its `connectHeaders` closure
-    // with below (a `PropertyForEach` over the parsed pairs, empty when none are configured), so
-    // `Proxy<ProxyConnectHeaders>.Authorization` is the same specialization the compiler infers
-    // for the call in `proxy(_:)` — keeping `proxyAuthorization`'s return type generic-free.
     private typealias ProxyConnectHeaders = PropertyForEach<[String: String], String, CustomHeader>
 
     private static func proxyAuthorization(
         _ reader: ConfigReader
-    ) throws -> Proxy<ProxyConnectHeaders>.Authorization? {
+    ) throws -> ProxyAuthorization? {
         guard let scheme = reader.string(forKey: "scheme") else {
             return nil
         }

--- a/Sources/RequestDL/Properties/Sources/Extra Properties/Configured/Configured.swift
+++ b/Sources/RequestDL/Properties/Sources/Extra Properties/Configured/Configured.swift
@@ -1,0 +1,275 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+import Configuration
+
+/// A property that derives declarative request properties from an external configuration source.
+///
+/// Use `Configured` to drive a request's `BaseURL`, `RequestMethod`, `Timeout`, headers and query
+/// parameters from a `ConfigReader` — backed by environment variables, a JSON file, in-memory
+/// defaults, or any other `ConfigProvider` — instead of hardcoding them as Swift literals.
+///
+/// ```swift
+/// DataTask {
+///     Configured(appConfig)
+/// }
+/// ```
+///
+/// `ConfigReader.scoped(to:)` lets multiple endpoints share one reader under different key prefixes:
+///
+/// ```swift
+/// Configured(appConfig.scoped(to: "myAPI"))
+/// ```
+///
+/// ## Configuration keys
+///
+/// - `baseURL` (string, optional): passed to ``BaseURL/init(_:)``.
+/// - `method` (string, optional): uppercased and passed to ``RequestMethod/init(_:)``.
+/// - `timeout` (int, optional): interpreted as seconds and passed to ``Timeout/init(_:for:)``.
+/// - `headers` (string array, optional): each entry is a colon-separated `"Name: Value"` pair,
+///   collected into a ``HeaderGroup``.
+/// - `queries` (string array, optional): each entry is an equals-separated `"name=value"` pair,
+///   collected into a ``QueryGroup``.
+/// - `authorization` (scoped, optional): passed to ``Authorization``. Reads `authorization.scheme`
+///   (`"basic"` or `"bearer"`); `"basic"` additionally reads `authorization.username` and
+///   `authorization.password` (or, absent those, a pre-encoded `authorization.credentials`), while
+///   `"bearer"` reads `authorization.token`.
+/// - `dnsOverrides` (string array, optional): each entry is a colon-separated `"host:IP"` pair,
+///   one ``DNSOverride`` per entry.
+/// - `systemProxy` (bool, optional, default: `false`): includes ``SystemProxy`` when `true`.
+/// - `proxy` (scoped, optional): passed to ``Proxy``. Reads `proxy.enabled` (default `false`;
+///   skipped entirely when not `true`), `proxy.host` (required), `proxy.port` (required for
+///   `"http"`, defaults to `1080` for `"socks"`), and `proxy.type` (`"http"` or `"socks"`, default
+///   `"http"`). For `"http"` proxies only, also reads `proxy.authorization` (same shape as the
+///   top-level `authorization` key) and `proxy.connectHeaders` (string array, colon-separated
+///   pairs, sent only on the proxy's `CONNECT` request).
+///
+/// Every key is read independently and is optional: a missing key simply contributes nothing, the
+/// same as any other absent property. An explicit property declared after `Configured` in the same
+/// `@PropertyBuilder` block still wins, following the same "last one wins" precedent already
+/// established by ``BaseURL`` and ``DNSOverride``.
+///
+/// - Throws: ``ConfiguredError`` if `authorization.scheme` or `proxy.authorization.scheme` is
+///   specified but invalid, if the fields either requires are missing, if `proxy.enabled` is `true`
+///   but `proxy.host` is missing or `proxy.type` is unknown, if `proxy.port` is missing for an
+///   `"http"` proxy, or if `proxy.authorization`/`proxy.connectHeaders` is specified for a `"socks"`
+///   proxy.
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+public struct Configured: Property {
+
+    // MARK: - Internal properties
+
+    let reader: ConfigReader
+
+    // MARK: - Inits
+
+    ///
+    /// Creates a new `Configured` property backed by the given configuration reader.
+    ///
+    /// - Parameter reader: The `ConfigReader` used to resolve request properties.
+    ///
+    public init(_ reader: ConfigReader) {
+        self.reader = reader
+    }
+
+    // MARK: - Public properties
+
+    public var body: some Property {
+        let reader = reader
+
+        return AsyncProperty {
+            if let baseURL = reader.string(forKey: "baseURL") {
+                BaseURL(baseURL)
+            }
+
+            if let method = reader.string(forKey: "method") {
+                RequestMethod(HTTPMethod(method.uppercased()))
+            }
+
+            if let timeout = reader.int(forKey: "timeout") {
+                Timeout(.seconds(Int64(timeout)))
+            }
+
+            if let headerPairs = reader.stringArray(forKey: "headers") {
+                HeaderGroup(Self.pairs(headerPairs, separatedBy: ":"))
+            }
+
+            if let queryPairs = reader.stringArray(forKey: "queries") {
+                QueryGroup(Self.pairs(queryPairs, separatedBy: "="))
+            }
+
+            if let authorization = try Self.authorization(reader.scoped(to: "authorization")) {
+                authorization
+            }
+
+            if let dnsOverridePairs = reader.stringArray(forKey: "dnsOverrides") {
+                PropertyForEach(Self.pairs(dnsOverridePairs, separatedBy: ":"), id: \.key) {
+                    DNSOverride($0.value, from: $0.key)
+                }
+            }
+
+            if reader.bool(forKey: "systemProxy", default: false) {
+                SystemProxy()
+            }
+
+            try Self.proxy(reader.scoped(to: "proxy"))
+        }
+    }
+
+    // MARK: - Private static methods
+
+    // Returns a type-erased `AnyProperty` rather than `some Property`: the "http" and "socks"
+    // branches each resolve to a different specialization of the generic `Proxy<Headers>`, and
+    // asking the compiler to unify those through nested result-builder inference (`some Property`
+    // over an `if`/`switch` mixing several `Proxy<Headers>` specializations) runs into a type
+    // checker limitation. A plain throwing function returning one concrete type sidesteps it.
+    private static func proxy(_ reader: ConfigReader) throws -> AnyProperty {
+        guard reader.bool(forKey: "enabled", default: false) else {
+            return AnyProperty(EmptyProperty())
+        }
+
+        guard let host = reader.string(forKey: "host") else {
+            throw ConfiguredError(context: .invalidProxyConfiguration)
+        }
+
+        let authorization = try Self.proxyAuthorization(reader.scoped(to: "authorization"))
+        let connectHeaderPairs = reader.stringArray(forKey: "connectHeaders")
+
+        switch reader.string(forKey: "type", default: "http") {
+        case "http":
+            guard let port = reader.int(forKey: "port") else {
+                throw ConfiguredError(context: .invalidProxyConfiguration)
+            }
+
+            return AnyProperty(
+                Proxy(host: host, port: port, authorization: authorization) { () -> ProxyConnectHeaders in
+                    // Built from `PropertyForEach`/`CustomHeader` rather than `HeaderGroup`:
+                    // `Proxy` discovers its `connectHeaders` content by searching for raw
+                    // `HeaderNode` leaves, but `HeaderGroup` wraps its headers into its own
+                    // opaque leaf node first, so nesting it here would silently resolve to no
+                    // headers at all.
+                    PropertyForEach(
+                        connectHeaderPairs.map { Self.pairs($0, separatedBy: ":") } ?? [:],
+                        id: \.key
+                    ) {
+                        CustomHeader(name: $0.key, value: $0.value)
+                    }
+                }
+            )
+        case "socks":
+            guard authorization == nil, connectHeaderPairs == nil else {
+                throw ConfiguredError(context: .invalidProxyConfiguration)
+            }
+
+            return AnyProperty(
+                Proxy(
+                    host: host,
+                    port: reader.int(forKey: "port", default: 1080),
+                    connection: .socks
+                )
+            )
+        default:
+            throw ConfiguredError(context: .invalidProxyConfiguration)
+        }
+    }
+
+    // Matches the `Headers` specialization `proxy(_:)` always builds its `connectHeaders` closure
+    // with below (a `PropertyForEach` over the parsed pairs, empty when none are configured), so
+    // `Proxy<ProxyConnectHeaders>.Authorization` is the same specialization the compiler infers
+    // for the call in `proxy(_:)` — keeping `proxyAuthorization`'s return type generic-free.
+    private typealias ProxyConnectHeaders = PropertyForEach<[String: String], String, CustomHeader>
+
+    private static func proxyAuthorization(
+        _ reader: ConfigReader
+    ) throws -> Proxy<ProxyConnectHeaders>.Authorization? {
+        guard let scheme = reader.string(forKey: "scheme") else {
+            return nil
+        }
+
+        switch scheme {
+        case "basic":
+            if let username = reader.string(forKey: "username"),
+                let password = reader.string(forKey: "password")
+            {
+                return .basic(username: username, password: password)
+            } else if let credentials = reader.string(forKey: "credentials") {
+                return .basic(credentials: credentials)
+            } else {
+                throw ConfiguredError(context: .invalidAuthorizationConfiguration)
+            }
+        case "bearer":
+            guard let token = reader.string(forKey: "token") else {
+                throw ConfiguredError(context: .invalidAuthorizationConfiguration)
+            }
+            return .bearer(tokens: token)
+        default:
+            throw ConfiguredError(context: .invalidAuthorizationConfiguration)
+        }
+    }
+
+    private static func authorization(_ reader: ConfigReader) throws -> Authorization? {
+        guard let scheme = reader.string(forKey: "scheme") else {
+            return nil
+        }
+
+        switch scheme {
+        case "basic":
+            if let username = reader.string(forKey: "username"),
+                let password = reader.string(forKey: "password")
+            {
+                return Authorization(username: username, password: password)
+            } else if let credentials = reader.string(forKey: "credentials") {
+                return Authorization(.basic, token: credentials)
+            } else {
+                throw ConfiguredError(context: .invalidAuthorizationConfiguration)
+            }
+        case "bearer":
+            guard let token = reader.string(forKey: "token") else {
+                throw ConfiguredError(context: .invalidAuthorizationConfiguration)
+            }
+            return Authorization(.bearer, token: token)
+        default:
+            throw ConfiguredError(context: .invalidAuthorizationConfiguration)
+        }
+    }
+
+    private static func pairs(
+        _ entries: [String],
+        separatedBy separator: Character
+    ) -> [String: String] {
+        entries.reduce(into: [String: String]()) { result, entry in
+            guard let (key, value) = entry.splitOnFirst(separator) else {
+                return
+            }
+
+            if !key.isEmpty {
+                result[key] = value
+            }
+        }
+    }
+}
+
+extension StringProtocol {
+
+    fileprivate func splitOnFirst(_ separator: Character) -> (String, String)? {
+        guard let separatorIndex = firstIndex(of: separator) else {
+            return nil
+        }
+
+        return (
+            String(self[..<separatorIndex]).trimmingASCIIWhitespace(),
+            String(self[index(after: separatorIndex)...]).trimmingASCIIWhitespace()
+        )
+    }
+
+    fileprivate func trimmingASCIIWhitespace() -> String {
+        guard let start = firstIndex(where: { $0 != " " && $0 != "\t" }),
+            let end = lastIndex(where: { $0 != " " && $0 != "\t" })
+        else {
+            return ""
+        }
+
+        return String(self[start...end])
+    }
+}

--- a/Sources/RequestDL/Properties/Sources/Extra Properties/Configured/Models/ConfiguredError.swift
+++ b/Sources/RequestDL/Properties/Sources/Extra Properties/Configured/Models/ConfiguredError.swift
@@ -22,6 +22,20 @@ public struct ConfiguredError: Error {
         /// `"http"` nor `"socks"`, `proxy.port` is missing for an `"http"` proxy, or
         /// `proxy.authorization`/`proxy.connectHeaders` is specified for a `"socks"` proxy.
         case invalidProxyConfiguration
+
+        /// `cachePolicy` was specified but is neither `"memory"`, `"disk"`, nor `"all"`.
+        case invalidCachePolicy
+
+        /// `cacheStrategy` was specified but is none of the ``CacheStrategy`` case names.
+        case invalidCacheStrategy
+
+        /// `secureConnection.privateKey.format` was specified but is neither `"pem"` nor
+        /// `"der"`, or `secureConnection.tlsMinimumVersion`/`secureConnection.tlsMaximumVersion`
+        /// was specified but is none of `"1.0"`, `"1.1"`, `"1.2"`, `"1.3"`.
+        case invalidSecureConnectionConfiguration
+
+        /// `redirect.mode` was specified but is neither `"follow"` nor `"disallow"`.
+        case invalidRedirectConfiguration
     }
 
     // MARK: - Public properties

--- a/Sources/RequestDL/Properties/Sources/Extra Properties/Configured/Models/ConfiguredError.swift
+++ b/Sources/RequestDL/Properties/Sources/Extra Properties/Configured/Models/ConfiguredError.swift
@@ -1,0 +1,42 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+/// A custom error type representing invalid `Configured` configuration.
+///
+/// ```swift
+/// throw ConfiguredError(context: .invalidAuthorizationConfiguration)
+/// ```
+public struct ConfiguredError: Error {
+
+    ///
+    /// The possible contexts for the configured error.
+    ///
+    public enum Context: Sendable {
+        /// `authorization.scheme` (or `proxy.authorization.scheme`) was specified but is neither
+        /// `"basic"` nor `"bearer"`, or the fields required by the specified scheme are missing
+        /// (`username`/`password` or `credentials` for `"basic"`, `token` for `"bearer"`).
+        case invalidAuthorizationConfiguration
+
+        /// `proxy.enabled` is `true` but `proxy.host` is missing, `proxy.type` is neither
+        /// `"http"` nor `"socks"`, `proxy.port` is missing for an `"http"` proxy, or
+        /// `proxy.authorization`/`proxy.connectHeaders` is specified for a `"socks"` proxy.
+        case invalidProxyConfiguration
+    }
+
+    // MARK: - Public properties
+
+    /// The context of the error.
+    public let context: Context
+
+    // MARK: - Initializer
+
+    ///
+    /// Initializes a `ConfiguredError` instance.
+    ///
+    /// - Parameter context: The context of the error.
+    ///
+    public init(context: Context) {
+        self.context = context
+    }
+}

--- a/Tests/RequestDLTests/Properties/Sources/Extra Properties/Configured/ConfiguredTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Extra Properties/Configured/ConfiguredTests.swift
@@ -21,9 +21,11 @@ struct ConfiguredTests {
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
     func baseURL() async throws {
         // Given
-        let reader = ConfigReader(provider: InMemoryProvider(values: [
-            "baseURL": "https://example.com"
-        ]))
+        let reader = ConfigReader(
+            provider: InMemoryProvider(values: [
+                "baseURL": "https://example.com"
+            ])
+        )
 
         // When
         let resolved = try await resolve(
@@ -40,9 +42,11 @@ struct ConfiguredTests {
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
     func method() async throws {
         // Given
-        let reader = ConfigReader(provider: InMemoryProvider(values: [
-            "method": "post"
-        ]))
+        let reader = ConfigReader(
+            provider: InMemoryProvider(values: [
+                "method": "post"
+            ])
+        )
 
         // When
         let resolved = try await resolve(
@@ -59,9 +63,11 @@ struct ConfiguredTests {
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
     func timeout() async throws {
         // Given
-        let reader = ConfigReader(provider: InMemoryProvider(values: [
-            "timeout": 75
-        ]))
+        let reader = ConfigReader(
+            provider: InMemoryProvider(values: [
+                "timeout": 75
+            ])
+        )
 
         // When
         let resolved = try await resolve(
@@ -79,9 +85,11 @@ struct ConfiguredTests {
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
     func headers() async throws {
         // Given
-        let reader = ConfigReader(provider: InMemoryProvider(values: [
-            "headers": .init(.stringArray(["Content-Type: application/json", "x-api-key: 123"]), isSecret: false)
-        ]))
+        let reader = ConfigReader(
+            provider: InMemoryProvider(values: [
+                "headers": .init(.stringArray(["Content-Type: application/json", "x-api-key: 123"]), isSecret: false)
+            ])
+        )
 
         // When
         let resolved = try await resolve(
@@ -99,9 +107,11 @@ struct ConfiguredTests {
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
     func queries() async throws {
         // Given
-        let reader = ConfigReader(provider: InMemoryProvider(values: [
-            "queries": .init(.stringArray(["number=123", "page=1"]), isSecret: false)
-        ]))
+        let reader = ConfigReader(
+            provider: InMemoryProvider(values: [
+                "queries": .init(.stringArray(["number=123", "page=1"]), isSecret: false)
+            ])
+        )
 
         // When
         let resolved = try await resolve(
@@ -127,9 +137,11 @@ struct ConfiguredTests {
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
     func baseURLRelativePathAppendsToExistingBaseURL() async throws {
         // Given
-        let reader = ConfigReader(provider: InMemoryProvider(values: [
-            "baseURL": "users/123"
-        ]))
+        let reader = ConfigReader(
+            provider: InMemoryProvider(values: [
+                "baseURL": "users/123"
+            ])
+        )
 
         // When
         let resolved = try await resolve(
@@ -147,9 +159,11 @@ struct ConfiguredTests {
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
     func baseURLCompleteURLOverridesExistingBaseURL() async throws {
         // Given
-        let reader = ConfigReader(provider: InMemoryProvider(values: [
-            "baseURL": "https://override.example.com/v2"
-        ]))
+        let reader = ConfigReader(
+            provider: InMemoryProvider(values: [
+                "baseURL": "https://override.example.com/v2"
+            ])
+        )
 
         // When
         let resolved = try await resolve(
@@ -187,9 +201,11 @@ struct ConfiguredTests {
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
     func explicitPropertyDeclaredAfterWins() async throws {
         // Given
-        let reader = ConfigReader(provider: InMemoryProvider(values: [
-            "baseURL": "https://example.com"
-        ]))
+        let reader = ConfigReader(
+            provider: InMemoryProvider(values: [
+                "baseURL": "https://example.com"
+            ])
+        )
 
         // When
         let resolved = try await resolve(
@@ -207,10 +223,12 @@ struct ConfiguredTests {
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
     func bearerAuthorization() async throws {
         // Given
-        let reader = ConfigReader(provider: InMemoryProvider(values: [
-            "authorization.scheme": "bearer",
-            "authorization.token": "abc123",
-        ]))
+        let reader = ConfigReader(
+            provider: InMemoryProvider(values: [
+                "authorization.scheme": "bearer",
+                "authorization.token": "abc123",
+            ])
+        )
 
         // When
         let resolved = try await resolve(
@@ -227,11 +245,13 @@ struct ConfiguredTests {
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
     func basicAuthorizationFromUsernameAndPassword() async throws {
         // Given
-        let reader = ConfigReader(provider: InMemoryProvider(values: [
-            "authorization.scheme": "basic",
-            "authorization.username": "user",
-            "authorization.password": "pass",
-        ]))
+        let reader = ConfigReader(
+            provider: InMemoryProvider(values: [
+                "authorization.scheme": "basic",
+                "authorization.username": "user",
+                "authorization.password": "pass",
+            ])
+        )
 
         // When
         let resolved = try await resolve(
@@ -248,10 +268,12 @@ struct ConfiguredTests {
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
     func basicAuthorizationFromCredentials() async throws {
         // Given
-        let reader = ConfigReader(provider: InMemoryProvider(values: [
-            "authorization.scheme": "basic",
-            "authorization.credentials": "dXNlcjpwYXNz",
-        ]))
+        let reader = ConfigReader(
+            provider: InMemoryProvider(values: [
+                "authorization.scheme": "basic",
+                "authorization.credentials": "dXNlcjpwYXNz",
+            ])
+        )
 
         // When
         let resolved = try await resolve(
@@ -268,9 +290,11 @@ struct ConfiguredTests {
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
     func invalidAuthorizationSchemeThrows() async throws {
         // Given
-        let reader = ConfigReader(provider: InMemoryProvider(values: [
-            "authorization.scheme": "digest"
-        ]))
+        let reader = ConfigReader(
+            provider: InMemoryProvider(values: [
+                "authorization.scheme": "digest"
+            ])
+        )
 
         // Then
         await #expect(throws: ConfiguredError.self) {
@@ -287,9 +311,11 @@ struct ConfiguredTests {
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
     func incompleteBearerAuthorizationThrows() async throws {
         // Given
-        let reader = ConfigReader(provider: InMemoryProvider(values: [
-            "authorization.scheme": "bearer"
-        ]))
+        let reader = ConfigReader(
+            provider: InMemoryProvider(values: [
+                "authorization.scheme": "bearer"
+            ])
+        )
 
         // Then
         await #expect(throws: ConfiguredError.self) {
@@ -306,12 +332,14 @@ struct ConfiguredTests {
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
     func dnsOverrides() async throws {
         // Given
-        let reader = ConfigReader(provider: InMemoryProvider(values: [
-            "dnsOverrides": .init(
-                .stringArray(["localhost:127.0.0.1", "example.com:192.168.1.1"]),
-                isSecret: false
-            )
-        ]))
+        let reader = ConfigReader(
+            provider: InMemoryProvider(values: [
+                "dnsOverrides": .init(
+                    .stringArray(["localhost:127.0.0.1", "example.com:192.168.1.1"]),
+                    isSecret: false
+                )
+            ])
+        )
 
         // When
         let resolved = try await resolve(
@@ -329,12 +357,14 @@ struct ConfiguredTests {
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
     func urlOverrides() async throws {
         // Given
-        let reader = ConfigReader(provider: InMemoryProvider(values: [
-            "urlOverrides": .init(
-                .stringArray(["https://google.com|https://apple.com"]),
-                isSecret: false
-            )
-        ]))
+        let reader = ConfigReader(
+            provider: InMemoryProvider(values: [
+                "urlOverrides": .init(
+                    .stringArray(["https://google.com|https://apple.com"]),
+                    isSecret: false
+                )
+            ])
+        )
 
         // When
         let resolved = try await resolve(
@@ -352,12 +382,14 @@ struct ConfiguredTests {
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
     func urlOverridesWithPathPrefix() async throws {
         // Given
-        let reader = ConfigReader(provider: InMemoryProvider(values: [
-            "urlOverrides": .init(
-                .stringArray(["https://google.com/api/v1|https://apple.com/v2"]),
-                isSecret: false
-            )
-        ]))
+        let reader = ConfigReader(
+            provider: InMemoryProvider(values: [
+                "urlOverrides": .init(
+                    .stringArray(["https://google.com/api/v1|https://apple.com/v2"]),
+                    isSecret: false
+                )
+            ])
+        )
 
         // When
         let resolved = try await resolve(
@@ -376,9 +408,11 @@ struct ConfiguredTests {
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
     func systemProxyEnabled() async throws {
         // Given
-        let reader = ConfigReader(provider: InMemoryProvider(values: [
-            "systemProxy": true
-        ]))
+        let reader = ConfigReader(
+            provider: InMemoryProvider(values: [
+                "systemProxy": true
+            ])
+        )
 
         // When / Then
         // No assertion on the resolved host/port: the system/environment proxy is
@@ -396,11 +430,13 @@ struct ConfiguredTests {
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
     func httpProxyWithoutAuthorization() async throws {
         // Given
-        let reader = ConfigReader(provider: InMemoryProvider(values: [
-            "proxy.enabled": true,
-            "proxy.host": "proxy.example.com",
-            "proxy.port": 8080,
-        ]))
+        let reader = ConfigReader(
+            provider: InMemoryProvider(values: [
+                "proxy.enabled": true,
+                "proxy.host": "proxy.example.com",
+                "proxy.port": 8080,
+            ])
+        )
 
         // When
         let resolved = try await resolve(
@@ -419,15 +455,17 @@ struct ConfiguredTests {
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
     func httpProxyWithBasicAuthorizationAndConnectHeaders() async throws {
         // Given
-        let reader = ConfigReader(provider: InMemoryProvider(values: [
-            "proxy.enabled": true,
-            "proxy.host": "proxy.example.com",
-            "proxy.port": 8080,
-            "proxy.authorization.scheme": "basic",
-            "proxy.authorization.username": "user",
-            "proxy.authorization.password": "pass",
-            "proxy.connectHeaders": .init(.stringArray(["X-Proxy-Token: abc123"]), isSecret: false),
-        ]))
+        let reader = ConfigReader(
+            provider: InMemoryProvider(values: [
+                "proxy.enabled": true,
+                "proxy.host": "proxy.example.com",
+                "proxy.port": 8080,
+                "proxy.authorization.scheme": "basic",
+                "proxy.authorization.username": "user",
+                "proxy.authorization.password": "pass",
+                "proxy.connectHeaders": .init(.stringArray(["X-Proxy-Token: abc123"]), isSecret: false),
+            ])
+        )
 
         // When
         let resolved = try await resolve(
@@ -450,11 +488,13 @@ struct ConfiguredTests {
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
     func socksProxy() async throws {
         // Given
-        let reader = ConfigReader(provider: InMemoryProvider(values: [
-            "proxy.enabled": true,
-            "proxy.host": "socks-proxy.example.com",
-            "proxy.type": "socks",
-        ]))
+        let reader = ConfigReader(
+            provider: InMemoryProvider(values: [
+                "proxy.enabled": true,
+                "proxy.host": "socks-proxy.example.com",
+                "proxy.type": "socks",
+            ])
+        )
 
         // When
         let resolved = try await resolve(
@@ -472,10 +512,12 @@ struct ConfiguredTests {
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
     func proxyDisabledContributesNothing() async throws {
         // Given
-        let reader = ConfigReader(provider: InMemoryProvider(values: [
-            "proxy.host": "proxy.example.com",
-            "proxy.port": 8080,
-        ]))
+        let reader = ConfigReader(
+            provider: InMemoryProvider(values: [
+                "proxy.host": "proxy.example.com",
+                "proxy.port": 8080,
+            ])
+        )
 
         // When
         let resolved = try await resolve(
@@ -492,9 +534,11 @@ struct ConfiguredTests {
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
     func proxyEnabledWithoutHostThrows() async throws {
         // Given
-        let reader = ConfigReader(provider: InMemoryProvider(values: [
-            "proxy.enabled": true
-        ]))
+        let reader = ConfigReader(
+            provider: InMemoryProvider(values: [
+                "proxy.enabled": true
+            ])
+        )
 
         // Then
         await #expect(throws: ConfiguredError.self) {
@@ -511,10 +555,12 @@ struct ConfiguredTests {
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
     func httpProxyWithoutPortThrows() async throws {
         // Given
-        let reader = ConfigReader(provider: InMemoryProvider(values: [
-            "proxy.enabled": true,
-            "proxy.host": "proxy.example.com",
-        ]))
+        let reader = ConfigReader(
+            provider: InMemoryProvider(values: [
+                "proxy.enabled": true,
+                "proxy.host": "proxy.example.com",
+            ])
+        )
 
         // Then
         await #expect(throws: ConfiguredError.self) {
@@ -531,13 +577,15 @@ struct ConfiguredTests {
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
     func socksProxyWithAuthorizationThrows() async throws {
         // Given
-        let reader = ConfigReader(provider: InMemoryProvider(values: [
-            "proxy.enabled": true,
-            "proxy.host": "socks-proxy.example.com",
-            "proxy.type": "socks",
-            "proxy.authorization.scheme": "bearer",
-            "proxy.authorization.token": "abc123",
-        ]))
+        let reader = ConfigReader(
+            provider: InMemoryProvider(values: [
+                "proxy.enabled": true,
+                "proxy.host": "socks-proxy.example.com",
+                "proxy.type": "socks",
+                "proxy.authorization.scheme": "bearer",
+                "proxy.authorization.token": "abc123",
+            ])
+        )
 
         // Then
         await #expect(throws: ConfiguredError.self) {
@@ -554,11 +602,13 @@ struct ConfiguredTests {
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
     func invalidProxyTypeThrows() async throws {
         // Given
-        let reader = ConfigReader(provider: InMemoryProvider(values: [
-            "proxy.enabled": true,
-            "proxy.host": "proxy.example.com",
-            "proxy.type": "ftp",
-        ]))
+        let reader = ConfigReader(
+            provider: InMemoryProvider(values: [
+                "proxy.enabled": true,
+                "proxy.host": "proxy.example.com",
+                "proxy.type": "ftp",
+            ])
+        )
 
         // Then
         await #expect(throws: ConfiguredError.self) {
@@ -575,9 +625,11 @@ struct ConfiguredTests {
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
     func cachePolicyMemory() async throws {
         // Given
-        let reader = ConfigReader(provider: InMemoryProvider(values: [
-            "cachePolicy": "memory"
-        ]))
+        let reader = ConfigReader(
+            provider: InMemoryProvider(values: [
+                "cachePolicy": "memory"
+            ])
+        )
 
         // When
         let resolved = try await resolve(
@@ -594,9 +646,11 @@ struct ConfiguredTests {
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
     func cachePolicyDisk() async throws {
         // Given
-        let reader = ConfigReader(provider: InMemoryProvider(values: [
-            "cachePolicy": "disk"
-        ]))
+        let reader = ConfigReader(
+            provider: InMemoryProvider(values: [
+                "cachePolicy": "disk"
+            ])
+        )
 
         // When
         let resolved = try await resolve(
@@ -613,9 +667,11 @@ struct ConfiguredTests {
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
     func cachePolicyAll() async throws {
         // Given
-        let reader = ConfigReader(provider: InMemoryProvider(values: [
-            "cachePolicy": "all"
-        ]))
+        let reader = ConfigReader(
+            provider: InMemoryProvider(values: [
+                "cachePolicy": "all"
+            ])
+        )
 
         // When
         let resolved = try await resolve(
@@ -632,9 +688,11 @@ struct ConfiguredTests {
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
     func invalidCachePolicyThrows() async throws {
         // Given
-        let reader = ConfigReader(provider: InMemoryProvider(values: [
-            "cachePolicy": "ssd"
-        ]))
+        let reader = ConfigReader(
+            provider: InMemoryProvider(values: [
+                "cachePolicy": "ssd"
+            ])
+        )
 
         // Then
         await #expect(throws: ConfiguredError.self) {
@@ -658,9 +716,11 @@ struct ConfiguredTests {
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
     func cacheStrategy(value: String, expected: CacheStrategy) async throws {
         // Given
-        let reader = ConfigReader(provider: InMemoryProvider(values: [
-            "cacheStrategy": .init(.string(value), isSecret: false)
-        ]))
+        let reader = ConfigReader(
+            provider: InMemoryProvider(values: [
+                "cacheStrategy": .init(.string(value), isSecret: false)
+            ])
+        )
 
         // When
         let resolved = try await resolve(
@@ -677,9 +737,11 @@ struct ConfiguredTests {
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
     func invalidCacheStrategyThrows() async throws {
         // Given
-        let reader = ConfigReader(provider: InMemoryProvider(values: [
-            "cacheStrategy": "ignoreEverything"
-        ]))
+        let reader = ConfigReader(
+            provider: InMemoryProvider(values: [
+                "cacheStrategy": "ignoreEverything"
+            ])
+        )
 
         // Then
         await #expect(throws: ConfiguredError.self) {
@@ -697,9 +759,11 @@ struct ConfiguredTests {
     func secureConnectionTrustRoots() async throws {
         // Given
         let file = UUID().uuidString
-        let reader = ConfigReader(provider: InMemoryProvider(values: [
-            "secureConnection.trustRoots": .init(.string(file), isSecret: false)
-        ]))
+        let reader = ConfigReader(
+            provider: InMemoryProvider(values: [
+                "secureConnection.trustRoots": .init(.string(file), isSecret: false)
+            ])
+        )
 
         // When
         let resolved = try await resolve(
@@ -718,9 +782,11 @@ struct ConfiguredTests {
     func secureConnectionAdditionalTrustRoots() async throws {
         // Given
         let file = UUID().uuidString
-        let reader = ConfigReader(provider: InMemoryProvider(values: [
-            "secureConnection.additionalTrustRoots": .init(.string(file), isSecret: false)
-        ]))
+        let reader = ConfigReader(
+            provider: InMemoryProvider(values: [
+                "secureConnection.additionalTrustRoots": .init(.string(file), isSecret: false)
+            ])
+        )
 
         // When
         let resolved = try await resolve(
@@ -741,9 +807,11 @@ struct ConfiguredTests {
     func secureConnectionCertificates() async throws {
         // Given
         let file = UUID().uuidString
-        let reader = ConfigReader(provider: InMemoryProvider(values: [
-            "secureConnection.certificates": .init(.string(file), isSecret: false)
-        ]))
+        let reader = ConfigReader(
+            provider: InMemoryProvider(values: [
+                "secureConnection.certificates": .init(.string(file), isSecret: false)
+            ])
+        )
 
         // When
         let resolved = try await resolve(
@@ -761,10 +829,12 @@ struct ConfiguredTests {
     func secureConnectionPrivateKeyWithoutPassword() async throws {
         // Given
         let file = UUID().uuidString
-        let reader = ConfigReader(provider: InMemoryProvider(values: [
-            "secureConnection.privateKey.file": .init(.string(file), isSecret: false),
-            "secureConnection.privateKey.format": "der",
-        ]))
+        let reader = ConfigReader(
+            provider: InMemoryProvider(values: [
+                "secureConnection.privateKey.file": .init(.string(file), isSecret: false),
+                "secureConnection.privateKey.format": "der",
+            ])
+        )
 
         // When
         let resolved = try await resolve(
@@ -786,10 +856,12 @@ struct ConfiguredTests {
         // Given
         let file = UUID().uuidString
         let password = UUID().uuidString
-        let reader = ConfigReader(provider: InMemoryProvider(values: [
-            "secureConnection.privateKey.file": .init(.string(file), isSecret: false),
-            "secureConnection.privateKey.password": .init(.string(password), isSecret: true),
-        ]))
+        let reader = ConfigReader(
+            provider: InMemoryProvider(values: [
+                "secureConnection.privateKey.file": .init(.string(file), isSecret: false),
+                "secureConnection.privateKey.password": .init(.string(password), isSecret: true),
+            ])
+        )
 
         // When
         let resolved = try await resolve(
@@ -811,10 +883,12 @@ struct ConfiguredTests {
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
     func invalidPrivateKeyFormatThrows() async throws {
         // Given
-        let reader = ConfigReader(provider: InMemoryProvider(values: [
-            "secureConnection.privateKey.file": "key.p12",
-            "secureConnection.privateKey.format": "p12",
-        ]))
+        let reader = ConfigReader(
+            provider: InMemoryProvider(values: [
+                "secureConnection.privateKey.file": "key.p12",
+                "secureConnection.privateKey.format": "p12",
+            ])
+        )
 
         // Then
         await #expect(throws: ConfiguredError.self) {
@@ -831,10 +905,12 @@ struct ConfiguredTests {
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
     func secureConnectionTLSVersionRange() async throws {
         // Given
-        let reader = ConfigReader(provider: InMemoryProvider(values: [
-            "secureConnection.tlsMinimumVersion": "1.2",
-            "secureConnection.tlsMaximumVersion": "1.3",
-        ]))
+        let reader = ConfigReader(
+            provider: InMemoryProvider(values: [
+                "secureConnection.tlsMinimumVersion": "1.2",
+                "secureConnection.tlsMaximumVersion": "1.3",
+            ])
+        )
 
         // When
         let resolved = try await resolve(
@@ -870,9 +946,11 @@ struct ConfiguredTests {
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
     func invalidTLSVersionThrows() async throws {
         // Given
-        let reader = ConfigReader(provider: InMemoryProvider(values: [
-            "secureConnection.tlsMinimumVersion": "1.4"
-        ]))
+        let reader = ConfigReader(
+            provider: InMemoryProvider(values: [
+                "secureConnection.tlsMinimumVersion": "1.4"
+            ])
+        )
 
         // Then
         await #expect(throws: ConfiguredError.self) {
@@ -889,11 +967,13 @@ struct ConfiguredTests {
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
     func redirectFollow() async throws {
         // Given
-        let reader = ConfigReader(provider: InMemoryProvider(values: [
-            "redirect.mode": "follow",
-            "redirect.maxRedirects": 10,
-            "redirect.allowCycles": true,
-        ]))
+        let reader = ConfigReader(
+            provider: InMemoryProvider(values: [
+                "redirect.mode": "follow",
+                "redirect.maxRedirects": 10,
+                "redirect.allowCycles": true,
+            ])
+        )
 
         // When
         let resolved = try await resolve(
@@ -910,9 +990,11 @@ struct ConfiguredTests {
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
     func redirectFollowDefaults() async throws {
         // Given
-        let reader = ConfigReader(provider: InMemoryProvider(values: [
-            "redirect.mode": "follow"
-        ]))
+        let reader = ConfigReader(
+            provider: InMemoryProvider(values: [
+                "redirect.mode": "follow"
+            ])
+        )
 
         // When
         let resolved = try await resolve(
@@ -929,9 +1011,11 @@ struct ConfiguredTests {
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
     func redirectDisallow() async throws {
         // Given
-        let reader = ConfigReader(provider: InMemoryProvider(values: [
-            "redirect.mode": "disallow"
-        ]))
+        let reader = ConfigReader(
+            provider: InMemoryProvider(values: [
+                "redirect.mode": "disallow"
+            ])
+        )
 
         // When
         let resolved = try await resolve(
@@ -965,9 +1049,11 @@ struct ConfiguredTests {
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
     func invalidRedirectModeThrows() async throws {
         // Given
-        let reader = ConfigReader(provider: InMemoryProvider(values: [
-            "redirect.mode": "bounce"
-        ]))
+        let reader = ConfigReader(
+            provider: InMemoryProvider(values: [
+                "redirect.mode": "bounce"
+            ])
+        )
 
         // Then
         await #expect(throws: ConfiguredError.self) {
@@ -984,9 +1070,11 @@ struct ConfiguredTests {
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
     func maximumConnectionsPerHost() async throws {
         // Given
-        let reader = ConfigReader(provider: InMemoryProvider(values: [
-            "maximumConnectionsPerHost": 16
-        ]))
+        let reader = ConfigReader(
+            provider: InMemoryProvider(values: [
+                "maximumConnectionsPerHost": 16
+            ])
+        )
 
         // When
         let resolved = try await resolve(
@@ -1003,9 +1091,11 @@ struct ConfiguredTests {
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
     func maximumConcurrentConnections() async throws {
         // Given
-        let reader = ConfigReader(provider: InMemoryProvider(values: [
-            "maximumConcurrentConnections": 4
-        ]))
+        let reader = ConfigReader(
+            provider: InMemoryProvider(values: [
+                "maximumConcurrentConnections": 4
+            ])
+        )
 
         // When
         let resolved = try await resolve(
@@ -1022,10 +1112,12 @@ struct ConfiguredTests {
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
     func connectionLimitsCombined() async throws {
         // Given
-        let reader = ConfigReader(provider: InMemoryProvider(values: [
-            "maximumConnectionsPerHost": 16,
-            "maximumConcurrentConnections": 4,
-        ]))
+        let reader = ConfigReader(
+            provider: InMemoryProvider(values: [
+                "maximumConnectionsPerHost": 16,
+                "maximumConcurrentConnections": 4,
+            ])
+        )
 
         // When
         let resolved = try await resolve(
@@ -1043,9 +1135,11 @@ struct ConfiguredTests {
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
     func scopedReader() async throws {
         // Given
-        let reader = ConfigReader(provider: InMemoryProvider(values: [
-            "myAPI.baseURL": "https://example.com"
-        ]))
+        let reader = ConfigReader(
+            provider: InMemoryProvider(values: [
+                "myAPI.baseURL": "https://example.com"
+            ])
+        )
 
         // When
         let resolved = try await resolve(

--- a/Tests/RequestDLTests/Properties/Sources/Extra Properties/Configured/ConfiguredTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Extra Properties/Configured/ConfiguredTests.swift
@@ -1,0 +1,497 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+import Configuration
+import Testing
+
+@testable import RequestDL
+
+struct ConfiguredTests {
+
+    @Test
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    func baseURL() async throws {
+        // Given
+        let reader = ConfigReader(provider: InMemoryProvider(values: [
+            "baseURL": "example.com"
+        ]))
+
+        // When
+        let resolved = try await resolve(
+            TestProperty {
+                Configured(reader)
+            }
+        )
+
+        // Then
+        #expect(resolved.requestConfiguration.url == "https://example.com")
+    }
+
+    @Test
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    func method() async throws {
+        // Given
+        let reader = ConfigReader(provider: InMemoryProvider(values: [
+            "method": "post"
+        ]))
+
+        // When
+        let resolved = try await resolve(
+            TestProperty {
+                Configured(reader)
+            }
+        )
+
+        // Then
+        #expect(resolved.requestConfiguration.method == "POST")
+    }
+
+    @Test
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    func timeout() async throws {
+        // Given
+        let reader = ConfigReader(provider: InMemoryProvider(values: [
+            "timeout": 75
+        ]))
+
+        // When
+        let resolved = try await resolve(
+            TestProperty {
+                Configured(reader)
+            }
+        )
+
+        // Then
+        #expect(resolved.session.configuration.timeout.connect == UnitTime.seconds(75).nanoseconds)
+        #expect(resolved.session.configuration.timeout.read == UnitTime.seconds(75).nanoseconds)
+    }
+
+    @Test
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    func headers() async throws {
+        // Given
+        let reader = ConfigReader(provider: InMemoryProvider(values: [
+            "headers": .init(.stringArray(["Content-Type: application/json", "x-api-key: 123"]), isSecret: false)
+        ]))
+
+        // When
+        let resolved = try await resolve(
+            TestProperty {
+                Configured(reader)
+            }
+        )
+
+        // Then
+        #expect(resolved.requestConfiguration.headers["Content-Type"] == ["application/json"])
+        #expect(resolved.requestConfiguration.headers["x-api-key"] == ["123"])
+    }
+
+    @Test
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    func queries() async throws {
+        // Given
+        let reader = ConfigReader(provider: InMemoryProvider(values: [
+            "queries": .init(.stringArray(["number=123", "page=1"]), isSecret: false)
+        ]))
+
+        // When
+        let resolved = try await resolve(
+            TestProperty {
+                BaseURL("127.0.0.1")
+                Configured(reader)
+            }
+        )
+
+        // `URLComponents`/`URLQueryItem` are not part of `FoundationEssentials`. A dictionary's
+        // iteration order is not guaranteed, so the query string built from it needs an
+        // order-independent comparison rather than an exact-string check.
+        let queryString = resolved.requestConfiguration.url.split(separator: "?", maxSplits: 1).last ?? ""
+        let queryItems = Set(queryString.split(separator: "&").map(String.init))
+
+        // Then
+        #expect(queryItems.count == 2)
+        #expect(queryItems.contains("number=123"))
+        #expect(queryItems.contains("page=1"))
+    }
+
+    @Test
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    func missingKeysContributeNothing() async throws {
+        // Given
+        let reader = ConfigReader(provider: InMemoryProvider(values: [:]))
+
+        // When
+        let resolved = try await resolve(
+            TestProperty {
+                BaseURL("example.com")
+                Configured(reader)
+            }
+        )
+
+        // Then
+        #expect(resolved.requestConfiguration.url == "https://example.com")
+        #expect(resolved.requestConfiguration.method == nil)
+        #expect(resolved.requestConfiguration.headers.isEmpty)
+    }
+
+    @Test
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    func explicitPropertyDeclaredAfterWins() async throws {
+        // Given
+        let reader = ConfigReader(provider: InMemoryProvider(values: [
+            "baseURL": "example.com"
+        ]))
+
+        // When
+        let resolved = try await resolve(
+            TestProperty {
+                Configured(reader)
+                BaseURL("override.com")
+            }
+        )
+
+        // Then
+        #expect(resolved.requestConfiguration.url == "https://override.com")
+    }
+
+    @Test
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    func bearerAuthorization() async throws {
+        // Given
+        let reader = ConfigReader(provider: InMemoryProvider(values: [
+            "authorization.scheme": "bearer",
+            "authorization.token": "abc123",
+        ]))
+
+        // When
+        let resolved = try await resolve(
+            TestProperty {
+                Configured(reader)
+            }
+        )
+
+        // Then
+        #expect(resolved.requestConfiguration.headers["Authorization"] == ["Bearer abc123"])
+    }
+
+    @Test
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    func basicAuthorizationFromUsernameAndPassword() async throws {
+        // Given
+        let reader = ConfigReader(provider: InMemoryProvider(values: [
+            "authorization.scheme": "basic",
+            "authorization.username": "user",
+            "authorization.password": "pass",
+        ]))
+
+        // When
+        let resolved = try await resolve(
+            TestProperty {
+                Configured(reader)
+            }
+        )
+
+        // Then
+        #expect(resolved.requestConfiguration.headers["Authorization"] == ["Basic dXNlcjpwYXNz"])
+    }
+
+    @Test
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    func basicAuthorizationFromCredentials() async throws {
+        // Given
+        let reader = ConfigReader(provider: InMemoryProvider(values: [
+            "authorization.scheme": "basic",
+            "authorization.credentials": "dXNlcjpwYXNz",
+        ]))
+
+        // When
+        let resolved = try await resolve(
+            TestProperty {
+                Configured(reader)
+            }
+        )
+
+        // Then
+        #expect(resolved.requestConfiguration.headers["Authorization"] == ["Basic dXNlcjpwYXNz"])
+    }
+
+    @Test
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    func invalidAuthorizationSchemeThrows() async throws {
+        // Given
+        let reader = ConfigReader(provider: InMemoryProvider(values: [
+            "authorization.scheme": "digest"
+        ]))
+
+        // Then
+        await #expect(throws: ConfiguredError.self) {
+            // When
+            try await resolve(
+                TestProperty {
+                    Configured(reader)
+                }
+            )
+        }
+    }
+
+    @Test
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    func incompleteBearerAuthorizationThrows() async throws {
+        // Given
+        let reader = ConfigReader(provider: InMemoryProvider(values: [
+            "authorization.scheme": "bearer"
+        ]))
+
+        // Then
+        await #expect(throws: ConfiguredError.self) {
+            // When
+            try await resolve(
+                TestProperty {
+                    Configured(reader)
+                }
+            )
+        }
+    }
+
+    @Test
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    func dnsOverrides() async throws {
+        // Given
+        let reader = ConfigReader(provider: InMemoryProvider(values: [
+            "dnsOverrides": .init(
+                .stringArray(["localhost:127.0.0.1", "example.com:192.168.1.1"]),
+                isSecret: false
+            )
+        ]))
+
+        // When
+        let resolved = try await resolve(
+            TestProperty {
+                Configured(reader)
+            }
+        )
+
+        // Then
+        #expect(resolved.session.configuration.dnsOverride["localhost"] == "127.0.0.1")
+        #expect(resolved.session.configuration.dnsOverride["example.com"] == "192.168.1.1")
+    }
+
+    @Test
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    func systemProxyEnabled() async throws {
+        // Given
+        let reader = ConfigReader(provider: InMemoryProvider(values: [
+            "systemProxy": true
+        ]))
+
+        // When / Then
+        // No assertion on the resolved host/port: the system/environment proxy is
+        // whatever the CI machine happens to have configured. Reaching here without
+        // throwing confirms `systemProxy` wired `SystemProxy()` through.
+        let resolved = try await resolve(
+            TestProperty {
+                Configured(reader)
+            }
+        )
+        _ = resolved.session.configuration.proxy
+    }
+
+    @Test
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    func httpProxyWithoutAuthorization() async throws {
+        // Given
+        let reader = ConfigReader(provider: InMemoryProvider(values: [
+            "proxy.enabled": true,
+            "proxy.host": "proxy.example.com",
+            "proxy.port": 8080,
+        ]))
+
+        // When
+        let resolved = try await resolve(
+            TestProperty {
+                Configured(reader)
+            }
+        )
+
+        // Then
+        #expect(resolved.session.configuration.proxy?.host == "proxy.example.com")
+        #expect(resolved.session.configuration.proxy?.port == 8080)
+        #expect(resolved.session.configuration.proxy?.authorization == nil)
+    }
+
+    @Test
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    func httpProxyWithBasicAuthorizationAndConnectHeaders() async throws {
+        // Given
+        let reader = ConfigReader(provider: InMemoryProvider(values: [
+            "proxy.enabled": true,
+            "proxy.host": "proxy.example.com",
+            "proxy.port": 8080,
+            "proxy.authorization.scheme": "basic",
+            "proxy.authorization.username": "user",
+            "proxy.authorization.password": "pass",
+            "proxy.connectHeaders": .init(.stringArray(["X-Proxy-Token: abc123"]), isSecret: false),
+        ]))
+
+        // When
+        let resolved = try await resolve(
+            TestProperty {
+                Configured(reader)
+            }
+        )
+
+        // Then
+        #expect(resolved.session.configuration.proxy?.host == "proxy.example.com")
+        #expect(resolved.session.configuration.proxy?.port == 8080)
+        #expect(
+            resolved.session.configuration.proxy?.authorization
+                == .basic(username: "user", password: "pass")
+        )
+        #expect(resolved.session.configuration.proxy?.connectHeaders.first(name: "X-Proxy-Token") == "abc123")
+    }
+
+    @Test
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    func socksProxy() async throws {
+        // Given
+        let reader = ConfigReader(provider: InMemoryProvider(values: [
+            "proxy.enabled": true,
+            "proxy.host": "socks-proxy.example.com",
+            "proxy.type": "socks",
+        ]))
+
+        // When
+        let resolved = try await resolve(
+            TestProperty {
+                Configured(reader)
+            }
+        )
+
+        // Then
+        #expect(resolved.session.configuration.proxy?.host == "socks-proxy.example.com")
+        #expect(resolved.session.configuration.proxy?.port == 1080)
+    }
+
+    @Test
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    func proxyDisabledContributesNothing() async throws {
+        // Given
+        let reader = ConfigReader(provider: InMemoryProvider(values: [
+            "proxy.host": "proxy.example.com",
+            "proxy.port": 8080,
+        ]))
+
+        // When
+        let resolved = try await resolve(
+            TestProperty {
+                Configured(reader)
+            }
+        )
+
+        // Then
+        #expect(resolved.session.configuration.proxy == nil)
+    }
+
+    @Test
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    func proxyEnabledWithoutHostThrows() async throws {
+        // Given
+        let reader = ConfigReader(provider: InMemoryProvider(values: [
+            "proxy.enabled": true
+        ]))
+
+        // Then
+        await #expect(throws: ConfiguredError.self) {
+            // When
+            try await resolve(
+                TestProperty {
+                    Configured(reader)
+                }
+            )
+        }
+    }
+
+    @Test
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    func httpProxyWithoutPortThrows() async throws {
+        // Given
+        let reader = ConfigReader(provider: InMemoryProvider(values: [
+            "proxy.enabled": true,
+            "proxy.host": "proxy.example.com",
+        ]))
+
+        // Then
+        await #expect(throws: ConfiguredError.self) {
+            // When
+            try await resolve(
+                TestProperty {
+                    Configured(reader)
+                }
+            )
+        }
+    }
+
+    @Test
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    func socksProxyWithAuthorizationThrows() async throws {
+        // Given
+        let reader = ConfigReader(provider: InMemoryProvider(values: [
+            "proxy.enabled": true,
+            "proxy.host": "socks-proxy.example.com",
+            "proxy.type": "socks",
+            "proxy.authorization.scheme": "bearer",
+            "proxy.authorization.token": "abc123",
+        ]))
+
+        // Then
+        await #expect(throws: ConfiguredError.self) {
+            // When
+            try await resolve(
+                TestProperty {
+                    Configured(reader)
+                }
+            )
+        }
+    }
+
+    @Test
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    func invalidProxyTypeThrows() async throws {
+        // Given
+        let reader = ConfigReader(provider: InMemoryProvider(values: [
+            "proxy.enabled": true,
+            "proxy.host": "proxy.example.com",
+            "proxy.type": "ftp",
+        ]))
+
+        // Then
+        await #expect(throws: ConfiguredError.self) {
+            // When
+            try await resolve(
+                TestProperty {
+                    Configured(reader)
+                }
+            )
+        }
+    }
+
+    @Test
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    func scopedReader() async throws {
+        // Given
+        let reader = ConfigReader(provider: InMemoryProvider(values: [
+            "myAPI.baseURL": "example.com"
+        ]))
+
+        // When
+        let resolved = try await resolve(
+            TestProperty {
+                Configured(reader.scoped(to: "myAPI"))
+            }
+        )
+
+        // Then
+        #expect(resolved.requestConfiguration.url == "https://example.com")
+    }
+}

--- a/Tests/RequestDLTests/Properties/Sources/Extra Properties/Configured/ConfiguredTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Extra Properties/Configured/ConfiguredTests.swift
@@ -3,9 +3,17 @@
 //
 
 import Configuration
+import NIOSSL
+import RequestDLInternals
 import Testing
 
 @testable import RequestDL
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import struct Foundation.UUID
+#endif
 
 struct ConfiguredTests {
 
@@ -14,7 +22,7 @@ struct ConfiguredTests {
     func baseURL() async throws {
         // Given
         let reader = ConfigReader(provider: InMemoryProvider(values: [
-            "baseURL": "example.com"
+            "baseURL": "https://example.com"
         ]))
 
         // When
@@ -117,6 +125,46 @@ struct ConfiguredTests {
 
     @Test
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    func baseURLRelativePathAppendsToExistingBaseURL() async throws {
+        // Given
+        let reader = ConfigReader(provider: InMemoryProvider(values: [
+            "baseURL": "users/123"
+        ]))
+
+        // When
+        let resolved = try await resolve(
+            TestProperty {
+                BaseURL("api.example.com")
+                Configured(reader)
+            }
+        )
+
+        // Then
+        #expect(resolved.requestConfiguration.url == "https://api.example.com/users/123")
+    }
+
+    @Test
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    func baseURLCompleteURLOverridesExistingBaseURL() async throws {
+        // Given
+        let reader = ConfigReader(provider: InMemoryProvider(values: [
+            "baseURL": "https://override.example.com/v2"
+        ]))
+
+        // When
+        let resolved = try await resolve(
+            TestProperty {
+                BaseURL("api.example.com")
+                Configured(reader)
+            }
+        )
+
+        // Then
+        #expect(resolved.requestConfiguration.url == "https://override.example.com/v2")
+    }
+
+    @Test
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
     func missingKeysContributeNothing() async throws {
         // Given
         let reader = ConfigReader(provider: InMemoryProvider(values: [:]))
@@ -140,7 +188,7 @@ struct ConfiguredTests {
     func explicitPropertyDeclaredAfterWins() async throws {
         // Given
         let reader = ConfigReader(provider: InMemoryProvider(values: [
-            "baseURL": "example.com"
+            "baseURL": "https://example.com"
         ]))
 
         // When
@@ -275,6 +323,53 @@ struct ConfiguredTests {
         // Then
         #expect(resolved.session.configuration.dnsOverride["localhost"] == "127.0.0.1")
         #expect(resolved.session.configuration.dnsOverride["example.com"] == "192.168.1.1")
+    }
+
+    @Test
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    func urlOverrides() async throws {
+        // Given
+        let reader = ConfigReader(provider: InMemoryProvider(values: [
+            "urlOverrides": .init(
+                .stringArray(["https://google.com|https://apple.com"]),
+                isSecret: false
+            )
+        ]))
+
+        // When
+        let resolved = try await resolve(
+            TestProperty {
+                BaseURL("google.com")
+                Configured(reader)
+            }
+        )
+
+        // Then
+        #expect(resolved.requestConfiguration.url == "https://apple.com")
+    }
+
+    @Test
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    func urlOverridesWithPathPrefix() async throws {
+        // Given
+        let reader = ConfigReader(provider: InMemoryProvider(values: [
+            "urlOverrides": .init(
+                .stringArray(["https://google.com/api/v1|https://apple.com/v2"]),
+                isSecret: false
+            )
+        ]))
+
+        // When
+        let resolved = try await resolve(
+            TestProperty {
+                BaseURL("google.com")
+                Path("api/v1/users")
+                Configured(reader)
+            }
+        )
+
+        // Then
+        #expect(resolved.requestConfiguration.url == "https://apple.com/v2/users")
     }
 
     @Test
@@ -478,10 +573,478 @@ struct ConfiguredTests {
 
     @Test
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    func cachePolicyMemory() async throws {
+        // Given
+        let reader = ConfigReader(provider: InMemoryProvider(values: [
+            "cachePolicy": "memory"
+        ]))
+
+        // When
+        let resolved = try await resolve(
+            TestProperty {
+                Configured(reader)
+            }
+        )
+
+        // Then
+        #expect(resolved.requestConfiguration.cachePolicy == .memory)
+    }
+
+    @Test
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    func cachePolicyDisk() async throws {
+        // Given
+        let reader = ConfigReader(provider: InMemoryProvider(values: [
+            "cachePolicy": "disk"
+        ]))
+
+        // When
+        let resolved = try await resolve(
+            TestProperty {
+                Configured(reader)
+            }
+        )
+
+        // Then
+        #expect(resolved.requestConfiguration.cachePolicy == .disk)
+    }
+
+    @Test
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    func cachePolicyAll() async throws {
+        // Given
+        let reader = ConfigReader(provider: InMemoryProvider(values: [
+            "cachePolicy": "all"
+        ]))
+
+        // When
+        let resolved = try await resolve(
+            TestProperty {
+                Configured(reader)
+            }
+        )
+
+        // Then
+        #expect(resolved.requestConfiguration.cachePolicy == .all)
+    }
+
+    @Test
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    func invalidCachePolicyThrows() async throws {
+        // Given
+        let reader = ConfigReader(provider: InMemoryProvider(values: [
+            "cachePolicy": "ssd"
+        ]))
+
+        // Then
+        await #expect(throws: ConfiguredError.self) {
+            // When
+            try await resolve(
+                TestProperty {
+                    Configured(reader)
+                }
+            )
+        }
+    }
+
+    @Test(
+        arguments: [
+            ("ignoreCachedData", CacheStrategy.ignoreCachedData),
+            ("reloadAndValidateCachedData", CacheStrategy.reloadAndValidateCachedData),
+            ("returnCachedDataElseLoad", CacheStrategy.returnCachedDataElseLoad),
+            ("useCachedDataOnly", CacheStrategy.useCachedDataOnly),
+        ]
+    )
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    func cacheStrategy(value: String, expected: CacheStrategy) async throws {
+        // Given
+        let reader = ConfigReader(provider: InMemoryProvider(values: [
+            "cacheStrategy": .init(.string(value), isSecret: false)
+        ]))
+
+        // When
+        let resolved = try await resolve(
+            TestProperty {
+                Configured(reader)
+            }
+        )
+
+        // Then
+        #expect(resolved.requestConfiguration.cacheStrategy == expected)
+    }
+
+    @Test
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    func invalidCacheStrategyThrows() async throws {
+        // Given
+        let reader = ConfigReader(provider: InMemoryProvider(values: [
+            "cacheStrategy": "ignoreEverything"
+        ]))
+
+        // Then
+        await #expect(throws: ConfiguredError.self) {
+            // When
+            try await resolve(
+                TestProperty {
+                    Configured(reader)
+                }
+            )
+        }
+    }
+
+    @Test
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    func secureConnectionTrustRoots() async throws {
+        // Given
+        let file = UUID().uuidString
+        let reader = ConfigReader(provider: InMemoryProvider(values: [
+            "secureConnection.trustRoots": .init(.string(file), isSecret: false)
+        ]))
+
+        // When
+        let resolved = try await resolve(
+            TestProperty {
+                Configured(reader)
+            }
+        )
+
+        // Then
+        #expect(!(resolved.session.configuration.secureConnection?.useDefaultTrustRoots ?? true))
+        #expect(resolved.session.configuration.secureConnection?.trustRoots == .file(file))
+    }
+
+    @Test
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    func secureConnectionAdditionalTrustRoots() async throws {
+        // Given
+        let file = UUID().uuidString
+        let reader = ConfigReader(provider: InMemoryProvider(values: [
+            "secureConnection.additionalTrustRoots": .init(.string(file), isSecret: false)
+        ]))
+
+        // When
+        let resolved = try await resolve(
+            TestProperty {
+                Configured(reader)
+            }
+        )
+
+        // Then
+        #expect(
+            resolved.session.configuration.secureConnection?.additionalTrustRoots
+                == .init([.file(file)])
+        )
+    }
+
+    @Test
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    func secureConnectionCertificates() async throws {
+        // Given
+        let file = UUID().uuidString
+        let reader = ConfigReader(provider: InMemoryProvider(values: [
+            "secureConnection.certificates": .init(.string(file), isSecret: false)
+        ]))
+
+        // When
+        let resolved = try await resolve(
+            TestProperty {
+                Configured(reader)
+            }
+        )
+
+        // Then
+        #expect(resolved.session.configuration.secureConnection?.certificateChain == .file(file))
+    }
+
+    @Test
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    func secureConnectionPrivateKeyWithoutPassword() async throws {
+        // Given
+        let file = UUID().uuidString
+        let reader = ConfigReader(provider: InMemoryProvider(values: [
+            "secureConnection.privateKey.file": .init(.string(file), isSecret: false),
+            "secureConnection.privateKey.format": "der",
+        ]))
+
+        // When
+        let resolved = try await resolve(
+            TestProperty {
+                Configured(reader)
+            }
+        )
+
+        // Then
+        #expect(
+            resolved.session.configuration.secureConnection?.privateKey
+                == .privateKey(.init(file, format: .der))
+        )
+    }
+
+    @Test
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    func secureConnectionPrivateKeyWithPassword() async throws {
+        // Given
+        let file = UUID().uuidString
+        let password = UUID().uuidString
+        let reader = ConfigReader(provider: InMemoryProvider(values: [
+            "secureConnection.privateKey.file": .init(.string(file), isSecret: false),
+            "secureConnection.privateKey.password": .init(.string(password), isSecret: true),
+        ]))
+
+        // When
+        let resolved = try await resolve(
+            TestProperty {
+                Configured(reader)
+            }
+        )
+
+        // Then
+        #expect(
+            resolved.session.configuration.secureConnection?.privateKey
+                == .privateKey(
+                    .init(file, format: .pem, password: NIOSSLSecureBytes(password.utf8))
+                )
+        )
+    }
+
+    @Test
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    func invalidPrivateKeyFormatThrows() async throws {
+        // Given
+        let reader = ConfigReader(provider: InMemoryProvider(values: [
+            "secureConnection.privateKey.file": "key.p12",
+            "secureConnection.privateKey.format": "p12",
+        ]))
+
+        // Then
+        await #expect(throws: ConfiguredError.self) {
+            // When
+            try await resolve(
+                TestProperty {
+                    Configured(reader)
+                }
+            )
+        }
+    }
+
+    @Test
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    func secureConnectionTLSVersionRange() async throws {
+        // Given
+        let reader = ConfigReader(provider: InMemoryProvider(values: [
+            "secureConnection.tlsMinimumVersion": "1.2",
+            "secureConnection.tlsMaximumVersion": "1.3",
+        ]))
+
+        // When
+        let resolved = try await resolve(
+            TestProperty {
+                Configured(reader)
+            }
+        )
+
+        // Then
+        #expect(resolved.session.configuration.secureConnection?.minimumTLSVersion == TLSVersion.v1_2.build())
+        #expect(resolved.session.configuration.secureConnection?.maximumTLSVersion == TLSVersion.v1_3.build())
+    }
+
+    @Test
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    func secureConnectionMissingKeysContributeNothing() async throws {
+        // Given
+        let reader = ConfigReader(provider: InMemoryProvider(values: [:]))
+
+        // When
+        let resolved = try await resolve(
+            TestProperty {
+                BaseURL("example.com")
+                Configured(reader)
+            }
+        )
+
+        // Then
+        #expect(resolved.session.configuration.secureConnection == nil)
+    }
+
+    @Test
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    func invalidTLSVersionThrows() async throws {
+        // Given
+        let reader = ConfigReader(provider: InMemoryProvider(values: [
+            "secureConnection.tlsMinimumVersion": "1.4"
+        ]))
+
+        // Then
+        await #expect(throws: ConfiguredError.self) {
+            // When
+            try await resolve(
+                TestProperty {
+                    Configured(reader)
+                }
+            )
+        }
+    }
+
+    @Test
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    func redirectFollow() async throws {
+        // Given
+        let reader = ConfigReader(provider: InMemoryProvider(values: [
+            "redirect.mode": "follow",
+            "redirect.maxRedirects": 10,
+            "redirect.allowCycles": true,
+        ]))
+
+        // When
+        let resolved = try await resolve(
+            TestProperty {
+                Configured(reader)
+            }
+        )
+
+        // Then
+        #expect(resolved.session.configuration.redirectConfiguration == .follow(max: 10, allowCycles: true))
+    }
+
+    @Test
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    func redirectFollowDefaults() async throws {
+        // Given
+        let reader = ConfigReader(provider: InMemoryProvider(values: [
+            "redirect.mode": "follow"
+        ]))
+
+        // When
+        let resolved = try await resolve(
+            TestProperty {
+                Configured(reader)
+            }
+        )
+
+        // Then
+        #expect(resolved.session.configuration.redirectConfiguration == .follow(max: 5, allowCycles: false))
+    }
+
+    @Test
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    func redirectDisallow() async throws {
+        // Given
+        let reader = ConfigReader(provider: InMemoryProvider(values: [
+            "redirect.mode": "disallow"
+        ]))
+
+        // When
+        let resolved = try await resolve(
+            TestProperty {
+                Configured(reader)
+            }
+        )
+
+        // Then
+        #expect(resolved.session.configuration.redirectConfiguration == .disallow)
+    }
+
+    @Test
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    func redirectMissingModeContributesNothing() async throws {
+        // Given
+        let reader = ConfigReader(provider: InMemoryProvider(values: [:]))
+
+        // When
+        let resolved = try await resolve(
+            TestProperty {
+                Configured(reader)
+            }
+        )
+
+        // Then
+        #expect(resolved.session.configuration.redirectConfiguration == nil)
+    }
+
+    @Test
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    func invalidRedirectModeThrows() async throws {
+        // Given
+        let reader = ConfigReader(provider: InMemoryProvider(values: [
+            "redirect.mode": "bounce"
+        ]))
+
+        // Then
+        await #expect(throws: ConfiguredError.self) {
+            // When
+            try await resolve(
+                TestProperty {
+                    Configured(reader)
+                }
+            )
+        }
+    }
+
+    @Test
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    func maximumConnectionsPerHost() async throws {
+        // Given
+        let reader = ConfigReader(provider: InMemoryProvider(values: [
+            "maximumConnectionsPerHost": 16
+        ]))
+
+        // When
+        let resolved = try await resolve(
+            TestProperty {
+                Configured(reader)
+            }
+        )
+
+        // Then
+        #expect(resolved.session.configuration.connectionPool.concurrentHTTP1ConnectionsPerHostSoftLimit == 16)
+    }
+
+    @Test
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    func maximumConcurrentConnections() async throws {
+        // Given
+        let reader = ConfigReader(provider: InMemoryProvider(values: [
+            "maximumConcurrentConnections": 4
+        ]))
+
+        // When
+        let resolved = try await resolve(
+            TestProperty {
+                Configured(reader)
+            }
+        )
+
+        // Then
+        #expect(resolved.session.configuration.maximumConcurrentConnections == 4)
+    }
+
+    @Test
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    func connectionLimitsCombined() async throws {
+        // Given
+        let reader = ConfigReader(provider: InMemoryProvider(values: [
+            "maximumConnectionsPerHost": 16,
+            "maximumConcurrentConnections": 4,
+        ]))
+
+        // When
+        let resolved = try await resolve(
+            TestProperty {
+                Configured(reader)
+            }
+        )
+
+        // Then
+        #expect(resolved.session.configuration.connectionPool.concurrentHTTP1ConnectionsPerHostSoftLimit == 16)
+        #expect(resolved.session.configuration.maximumConcurrentConnections == 4)
+    }
+
+    @Test
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
     func scopedReader() async throws {
         // Given
         let reader = ConfigReader(provider: InMemoryProvider(values: [
-            "myAPI.baseURL": "example.com"
+            "myAPI.baseURL": "https://example.com"
         ]))
 
         // When


### PR DESCRIPTION
## Summary

Implements [discussion #249](https://github.com/orgs/request-dl/discussions/249): a `Configured` property that drives a request's declarative properties from a swift-configuration `ConfigReader` — environment variables, a JSON file, in-memory defaults, or any other `ConfigProvider` — instead of hardcoding them as Swift literals.

`Configured` is gated to `macOS 15`/`iOS 18`/`watchOS 11`/`tvOS 18`/`visionOS 2` (every symbol in swift-configuration's own `Configuration` module carries that availability) — a per-symbol gate, not a change to the package's own platform floor.

### Supported configuration keys
- `baseURL` → `FlexibleURL` (complete URL, relative path, or query-only)
- `method`, `timeout`, `headers`, `queries`
- `authorization` (basic/bearer)
- `dnsOverrides`, `urlOverrides`
- `systemProxy`, `proxy` (http/socks, with its own `authorization`/`connectHeaders`)
- `cachePolicy`, `cacheStrategy`
- `secureConnection` (trust roots, additional trust roots, client certificates, private key, TLS version range)
- `redirect` (follow/disallow)
- `maximumConnectionsPerHost`, `maximumConcurrentConnections`

Every key is read independently and is optional — a missing key contributes nothing. Fields that compose existing properties (`BaseURL`, `Authorization`, `Proxy`, `TrustRoots`, `Session`, ...) delegate validation to them rather than reimplementing it; a handful of scoped keys with genuinely invalid combinations (`authorization.scheme`, `proxy.*`, `secureConnection.privateKey.format`, TLS version strings, `cachePolicy`/`cacheStrategy`, `redirect.mode`) throw `ConfiguredError`.

Also adds a `Configuration-driven-requests.md` DocC article (linked from `Building-the-request.md` and the `RequestDL.md` features list) walking through the common cases with examples.

### Notable design decisions (documented inline)
- `baseURL` uses `FlexibleURL` rather than `BaseURL` since it already covers the relative-path and query-only cases in the same field — a bare host with no scheme is read as a relative path, not a host, matching `FlexibleURL`'s own documented behavior.
- `Configured.body` runs inside `AsyncProperty` so field parsing can throw.
- One `Configured.swift` helper works around a Swift type-checker limitation (opaque `some Property` return type across branches producing different `Proxy<Headers>` specializations) by returning the type-erased `AnyProperty` instead.
- `proxy.connectHeaders` builds headers via `PropertyForEach`/`CustomHeader` rather than `HeaderGroup` — the `HeaderGroup`/`Proxy` interaction bug this sidesteps was found and fixed separately in #299.

## Test plan
- [x] ~130 tests across all supported keys (valid cases, missing-key-contributes-nothing, invalid-value-throws, "last one wins" override, `ConfigReader.scoped(to:)`)
- [x] Full suite green: `swift test` — 882 + 347 tests passing
- [x] `xcodebuild docbuild` with a clean DerivedData: 0 DocC diagnostics

🤖 Generated with [Claude Code](https://claude.com/claude-code)