### PR TITLE
Fix orphaned disk cache directory when a write is cancelled before the body starts

### DIFF
--- a/Sources/RequestDL/Properties/Sources/Cache/Data Cache/DataCache.swift
+++ b/Sources/RequestDL/Properties/Sources/Cache/Data Cache/DataCache.swift
@@ -169,12 +169,12 @@ public struct DataCache: Sendable, Equatable {
             key: String,
             cachedResponse: CachedResponse,
             contentLength: Int64
-        ) async -> Internals.AnyBuffer? {
+        ) async -> (buffer: Internals.AnyBuffer?, recordURL: URL?) {
             let (diskStorage, maximumCapacity, knownUsage) = lock.withLock {
                 (_diskStorage, _diskCapacity, _diskUsageEstimate)
             }
 
-            let (buffer, usage) = await diskStorage.allocateBuffer(
+            let (buffer, usage, recordURL) = await diskStorage.allocateBuffer(
                 key: key,
                 cachedResponse: cachedResponse,
                 contentLength: contentLength,
@@ -186,7 +186,7 @@ public struct DataCache: Sendable, Equatable {
                 lock.withLock { _diskUsageEstimate = usage }
             }
 
-            return buffer
+            return (buffer, recordURL)
         }
 
         // MARK: - Init
@@ -542,6 +542,7 @@ public struct DataCache: Sendable, Equatable {
 
         var memoryBuffer: Internals.AnyBuffer?
         var diskBuffer: Internals.AnyBuffer?
+        var diskRecordURL: URL?
 
         if cachedResponse.policy.contains(.memory) {
             // Two steps, and they have to be two.
@@ -575,7 +576,7 @@ public struct DataCache: Sendable, Equatable {
         }
 
         if cachedResponse.policy.contains(.disk) {
-            diskBuffer = await storage.allocateDiskBuffer(
+            (diskBuffer, diskRecordURL) = await storage.allocateDiskBuffer(
                 key: key,
                 cachedResponse: cachedResponse,
                 contentLength: contentLength
@@ -584,8 +585,33 @@ public struct DataCache: Sendable, Equatable {
 
         return .init(
             memoryBuffer: memoryBuffer,
-            diskBuffer: diskBuffer
+            diskBuffer: diskBuffer,
+            diskRecordURL: diskRecordURL
         )
+    }
+
+    /// Discards a cache write that started via ``allocateBuffer(key:cachedResponse:contentLength:)``
+    /// but never finished — its body stream was cancelled, errored, or otherwise gave up before
+    /// writing through `buffer` completed.
+    ///
+    /// - Important: Not the same thing as ``remove(forKey:)``. That method looks entries up by
+    /// key through `DiskStorage.record(_:)`, which requires a disk entry's `response.record`
+    /// *and* `data.record` to already both be on disk before it can even be found — exactly the
+    /// gate a write that never finished can't pass. Called there, it would silently do nothing,
+    /// leaving the half-written directory behind: invisible to every future read for the same
+    /// reason, yet still costing each of them a multi-second retry budget for `data.record`
+    /// permanently missing. This method instead targets `buffer.diskRecordURL` — the exact
+    /// directory captured at allocation time — so it finds and deletes precisely the write that
+    /// failed, without searching by key and risking an unrelated, still in-progress write to the
+    /// same key from a concurrent request.
+    func discardFailedWrite(_ buffer: Buffer, forKey key: String) async {
+        let key = base64EncodedKey(key)
+
+        storage.withMemoryStorage { $0.remove(key) }
+
+        if let diskRecordURL = buffer.diskRecordURL {
+            await storage.diskStorage.removeRecord(at: diskRecordURL)
+        }
     }
 
     /// Runs a cache write and keeps track of it, so `waitUntilIdle()` can join it later.

--- a/Sources/RequestDL/Properties/Sources/Cache/Data Cache/Models/DataCache.Buffer.swift
+++ b/Sources/RequestDL/Properties/Sources/Cache/Data Cache/Models/DataCache.Buffer.swift
@@ -4,6 +4,12 @@
 
 import RequestDLInternals
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import struct Foundation.URL
+#endif
+
 extension DataCache {
 
     struct Buffer: Sendable {
@@ -11,6 +17,14 @@ extension DataCache {
         var readableBytes: Int {
             (memoryBuffer ?? diskBuffer)?.readableBytes ?? .zero
         }
+
+        /// The exact disk record directory `diskBuffer` writes into, `nil` when there is no
+        /// disk tier (memory-only policy, or the disk write couldn't be allocated). Kept around
+        /// so a caller whose body stream never finishes writing through this buffer can hand it
+        /// straight to ``DataCache/discardFailedWrite(_:forKey:)`` — precise cleanup of exactly
+        /// this write, not a search by key that could catch an unrelated, still in-progress
+        /// write to the same key from a concurrent request.
+        let diskRecordURL: URL?
 
         // MARK: - Private properties
 
@@ -21,10 +35,12 @@ extension DataCache {
 
         init(
             memoryBuffer: Internals.AnyBuffer?,
-            diskBuffer: Internals.AnyBuffer?
+            diskBuffer: Internals.AnyBuffer?,
+            diskRecordURL: URL? = nil
         ) {
             self.memoryBuffer = memoryBuffer
             self.diskBuffer = diskBuffer
+            self.diskRecordURL = diskRecordURL
         }
 
         // MARK: - Internal methods

--- a/Sources/RequestDL/Properties/Sources/Cache/Data Cache/Models/DiskStorage.swift
+++ b/Sources/RequestDL/Properties/Sources/Cache/Data Cache/Models/DiskStorage.swift
@@ -372,32 +372,41 @@ struct DiskStorage: Sendable {
     /// decide whether `freeSpace` can skip its directory rescan below. See that method's doc
     /// for the safety argument — passing a stale or absent estimate never risks correctness,
     /// only an avoidable rescan.
-    /// - Returns: The buffer to write through, and disk usage immediately after this write
-    /// (`nil` when the write didn't happen, e.g. the entry doesn't fit at all), for the caller
-    /// to keep as its next `knownUsage`.
+    /// - Returns: The buffer to write through, disk usage immediately after this write (`nil`
+    /// when the write didn't happen, e.g. the entry doesn't fit at all) for the caller to keep
+    /// as its next `knownUsage`, and the exact directory this call created on disk (`nil`
+    /// exactly when `buffer` is), for the caller to hand back to ``removeRecord(at:)`` if the
+    /// write it's about to do through `buffer` ends up never finishing.
     func allocateBuffer(
         key: String,
         cachedResponse: CachedResponse,
         contentLength: Int64,
         maximumCapacity: Int64,
         knownUsage: Int64? = nil
-    ) async -> (buffer: Internals.AnyBuffer?, usage: Int64?) {
-        guard let response = try? JSONEncoder().encode(cachedResponse) else { return (nil, nil) }
+    ) async -> (buffer: Internals.AnyBuffer?, usage: Int64?, recordURL: URL?) {
+        guard let response = try? JSONEncoder().encode(cachedResponse) else { return (nil, nil, nil) }
 
         let writableBytes = Int64(response.count) + contentLength
-        guard writableBytes <= maximumCapacity else { return (nil, nil) }
+        guard writableBytes <= maximumCapacity else { return (nil, nil, nil) }
 
         let usageAfterEviction = await freeSpace(
             maximumCapacity - writableBytes,
             knownUsage: knownUsage
         )
 
-        guard let record = await record(key, createdAt: cachedResponse.date) else { return (nil, nil) }
+        guard let record = await record(key, createdAt: cachedResponse.date) else { return (nil, nil, nil) }
 
         do {
             try await writeAndClose(response, to: record.responseURL)
         } catch {
-            return (nil, nil)
+            // The directory itself was already created above (`Record.init(directory:key:at:)`
+            // creates it unconditionally). Left behind, it would be indistinguishable from the
+            // orphan `removeRecord(at:)` exists to clean up elsewhere — except nobody has a
+            // reason to call that for a write that never even got a buffer back. Deleting it
+            // here, while its exact URL is still in hand, is cheaper and more certain than
+            // hoping a later cleanup pass finds it by name.
+            await removeRecord(at: record.url)
+            return (nil, nil, nil)
         }
 
         #if canImport(Darwin)
@@ -405,7 +414,22 @@ struct DiskStorage: Sendable {
         #endif
 
         let buffer = await dataBuffer(for: record)
-        return (buffer, usageAfterEviction + writableBytes)
+        return (buffer, usageAfterEviction + writableBytes, record.url)
+    }
+
+    /// Deletes exactly the record directory at `url`, bypassing `record(_:)`'s completeness
+    /// gate entirely.
+    ///
+    /// That gate — both `response.record` and `data.record` present — is correct for every
+    /// read path (`subscript`, `updateCached`, eviction), which must never serve or reason
+    /// about a write that never finished. But it also means those lookups can never be used to
+    /// find and delete such a write's own leftover directory: an entry missing `data.record` is
+    /// invisible to them by design. This exists for the one caller that already knows exactly
+    /// which directory to remove without needing to look it up — the `URL` `allocateBuffer`
+    /// itself just handed back — so cleaning up a cancelled or errored cache write never has to
+    /// go searching for what it already knows.
+    func removeRecord(at url: URL) async {
+        _ = try? await Internals.fileSystem.removeItem(at: url.filePath)
     }
 
     /// Evicts the oldest entries, if any, until usage is at or under `maximumCapacity`.

--- a/Sources/RequestDL/Tasks/Sources/Raw Task/Cache Control/Internals.CacheControl.swift
+++ b/Sources/RequestDL/Tasks/Sources/Raw Task/Cache Control/Internals.CacheControl.swift
@@ -437,7 +437,7 @@ extension Internals {
                         )
                     } catch {
                         logger?.log(level: .error, "Failed to cache response: \(String(describing: error))")
-                        await dataCache.remove(forKey: requestConfiguration.url)
+                        await dataCache.discardFailedWrite(cacheBuffer, forKey: requestConfiguration.url)
                     }
                 }
 

--- a/Tests/RequestDLTests/Properties/Sources/Cache/Data Cache/DataCacheTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Cache/Data Cache/DataCacheTests.swift
@@ -3,6 +3,7 @@
 //
 
 import AsyncAlgorithms
+import NIOFileSystem
 import SwiftAsyncTesting
 import Testing
 
@@ -612,5 +613,62 @@ extension DataCacheTests {
                 }
             }
         }
+    }
+
+    /// Regression test for a cache write whose body stream is cancelled or errors before a
+    /// single byte reaches disk: `allocateBuffer` already created the record's directory and
+    /// wrote `response.record`, but `data.record` never came into being. The `catch` block in
+    /// `Internals.CacheControl.cacheIfNeeded` is supposed to clean this up by calling
+    /// `discardFailedWrite`.
+    ///
+    /// Before that method existed, cleanup went through `remove(forKey:)`, which looks entries
+    /// up via `DiskStorage.record(_:)` — and that lookup requires `response.record` *and*
+    /// `data.record` to already both be present to even recognize the entry. An entry missing
+    /// `data.record` was therefore invisible to it, `remove(forKey:)` silently did nothing, and
+    /// the half-written directory was orphaned on disk permanently — where it stayed invisible
+    /// to every future read for the same reason, while still costing each of them the full
+    /// `isReachableWithRetry` retry budget (up to ~15s) for a `data.record` that would never
+    /// appear.
+    @Test
+    func discardFailedWrite_whenBodyNeverArrives_shouldDeleteTheOrphanedCacheDirectory() async throws {
+        let dataCache = DataCache(
+            diskCapacity: 8 * 1_024 * 1_024,
+            suiteName: UUID().uuidString
+        )
+
+        let key = UUID().uuidString
+
+        // Given: a cache write that allocated its disk record but never wrote a body byte
+        // through it — the exact shape `cacheIfNeeded` leaves behind for a request that gets
+        // cancelled, errors, or is interrupted before the response body starts streaming.
+        let buffer = await dataCache.allocateBuffer(
+            key: key,
+            cachedResponse: .init(
+                response: .init(
+                    url: key,
+                    status: .init(code: 200, reason: "OK"),
+                    version: .init(minor: 0, major: 1),
+                    headers: [],
+                    isKeepAlive: true
+                ),
+                policy: .disk
+            ),
+            contentLength: 0
+        )
+
+        let allocatedBuffer = try #require(buffer)
+        #expect(allocatedBuffer.diskRecordURL != nil)
+
+        // When
+        await dataCache.discardFailedWrite(allocatedBuffer, forKey: key)
+
+        // Then: no leftover ".cached" directory under this cache's own storage directory.
+        var foundOrphan = false
+        try? await FileSystem.shared.withDirectoryHandle(atPath: dataCache.directoryURL.filePath) { dir in
+            for try await entry in dir.listContents() where entry.name.string.hasSuffix(".cached") {
+                foundOrphan = true
+            }
+        }
+        #expect(!foundOrphan)
     }
 }

--- a/Tests/RequestDLTests/Properties/Sources/Cache/Data Cache/Models/DiskStorageTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Cache/Data Cache/Models/DiskStorageTests.swift
@@ -68,7 +68,7 @@ struct DiskStorageTests {
             // Given: a first entry, written with plenty of room. The data file has to actually
             // exist on disk for the record to be discoverable later, so a byte is written and
             // the buffer closed.
-            var (firstBuffer, _) = await storage.allocateBuffer(
+            var (firstBuffer, _, _) = await storage.allocateBuffer(
                 key: "k1",
                 cachedResponse: firstResponse,
                 contentLength: 0,
@@ -81,7 +81,7 @@ struct DiskStorageTests {
 
             // When: a second entry is allocated with a capacity that only has room for itself
             // plus a sliver more — not enough to also keep the first entry around.
-            var (secondBuffer, _) = await storage.allocateBuffer(
+            var (secondBuffer, _, _) = await storage.allocateBuffer(
                 key: "k2",
                 cachedResponse: secondResponse,
                 contentLength: 0,
@@ -105,7 +105,7 @@ struct DiskStorageTests {
 
             // Given: a real entry that is already over whatever capacity `freeSpace` is about
             // to be called with — a rescan would find it and evict it.
-            var (buffer, _) = await storage.allocateBuffer(
+            var (buffer, _, _) = await storage.allocateBuffer(
                 key: "k1",
                 cachedResponse: response,
                 contentLength: 0,
@@ -132,7 +132,7 @@ struct DiskStorageTests {
             let storage = DiskStorage(directory: directoryURL)
             let response = makeCachedResponse(key: "k1")
 
-            var (buffer, _) = await storage.allocateBuffer(
+            var (buffer, _, _) = await storage.allocateBuffer(
                 key: "k1",
                 cachedResponse: response,
                 contentLength: 0,
@@ -163,7 +163,7 @@ struct DiskStorageTests {
 
             // Given/When: the first entry in an empty directory, so usage after it is exactly
             // its own size.
-            let (_, firstUsage) = await storage.allocateBuffer(
+            let (_, firstUsage, _) = await storage.allocateBuffer(
                 key: "k1",
                 cachedResponse: firstResponse,
                 contentLength: 10,
@@ -177,7 +177,7 @@ struct DiskStorageTests {
             let secondResponse = makeCachedResponse(key: "k2")
             let secondResponseSize = Int64(try JSONEncoder().encode(secondResponse).count)
 
-            let (_, secondUsage) = await storage.allocateBuffer(
+            let (_, secondUsage, _) = await storage.allocateBuffer(
                 key: "k2",
                 cachedResponse: secondResponse,
                 contentLength: 20,
@@ -282,7 +282,7 @@ struct DiskStorageTests {
             let plaintext = Data("this must never appear in cleartext on disk".utf8)
             let response = makeCachedResponse(key: "k1")
 
-            var (buffer, _) = await storage.allocateBuffer(
+            var (buffer, _, _) = await storage.allocateBuffer(
                 key: "k1",
                 cachedResponse: response,
                 contentLength: Int64(plaintext.count),
@@ -314,7 +314,7 @@ struct DiskStorageTests {
             let plaintext = Data("round trips through the encrypted disk tier".utf8)
             let response = makeCachedResponse(key: "k1")
 
-            var (buffer, _) = await storage.allocateBuffer(
+            var (buffer, _, _) = await storage.allocateBuffer(
                 key: "k1",
                 cachedResponse: response,
                 contentLength: Int64(plaintext.count),
@@ -337,7 +337,7 @@ struct DiskStorageTests {
 
             let response = makeCachedResponse(key: "k1")
 
-            var (buffer, _) = await storage.allocateBuffer(
+            var (buffer, _, _) = await storage.allocateBuffer(
                 key: "k1",
                 cachedResponse: response,
                 contentLength: 5,
@@ -366,7 +366,7 @@ struct DiskStorageTests {
 
             let response = makeCachedResponse(key: "k1")
 
-            var (buffer, _) = await storage.allocateBuffer(
+            var (buffer, _, _) = await storage.allocateBuffer(
                 key: "k1",
                 cachedResponse: response,
                 contentLength: 5,
@@ -405,7 +405,7 @@ struct DiskStorageTests {
             // What has to keep working is `Record.size`'s eviction accounting, a real stat of
             // whatever is actually on disk, so eviction still targets the oldest entry correctly
             // once that "actually on disk" is ciphertext-plus-framing rather than plaintext.
-            var (firstBuffer, _) = await storage.allocateBuffer(
+            var (firstBuffer, _, _) = await storage.allocateBuffer(
                 key: "k1",
                 cachedResponse: firstResponse,
                 contentLength: 0,
@@ -416,7 +416,7 @@ struct DiskStorageTests {
             try? await firstBuffer?.close()
             #expect(await storage["k1"] != nil)
 
-            var (secondBuffer, _) = await storage.allocateBuffer(
+            var (secondBuffer, _, _) = await storage.allocateBuffer(
                 key: "k2",
                 cachedResponse: secondResponse,
                 contentLength: 0,
@@ -452,7 +452,7 @@ struct DiskStorageTests {
             let response = makeCachedResponse(key: "k1")
 
             // Given/When: a buffer is allocated but nothing has been written into it yet.
-            let (buffer, _) = await storage.allocateBuffer(
+            let (buffer, _, _) = await storage.allocateBuffer(
                 key: "k1",
                 cachedResponse: response,
                 contentLength: 0,
@@ -498,7 +498,7 @@ struct DiskStorageTests {
 
             let response = makeCachedResponse(key: "k1")
 
-            let (buffer, _) = await storage.allocateBuffer(
+            let (buffer, _, _) = await storage.allocateBuffer(
                 key: "k1",
                 cachedResponse: response,
                 contentLength: 0,


### PR DESCRIPTION
## Summary
- A cache write that gets cancelled/interrupted before the response body's first byte arrives leaves a directory on disk with `response.record` but no `data.record`. `Internals.CacheControl.cacheIfNeeded`'s cleanup called `DataCache.remove(forKey:)`, which locates entries through `DiskStorage.Record.init?` — the same completeness gate that requires both files to already be present. It could therefore never find (and delete) the very entry it was trying to clean up.
- Left on disk, that orphan stayed invisible to every future cache read for the same reason, while still costing each of them the full `isReachableWithRetry` retry budget (up to ~15s) for a `data.record` that would never appear — surfacing as a cache that "does nothing" and requests that appear to hang.
- `DiskStorage.allocateBuffer` now hands back the exact directory it created for the caller to keep. That URL is threaded through `DataCache.Buffer` to a new `DataCache.discardFailedWrite(_:forKey:)`, which deletes precisely that directory instead of searching by key — this also avoids any risk of a by-key cleanup catching a different, still in-progress write to the same key from a concurrent request. `allocateBuffer` itself now also cleans up its own directory when writing `response.record` fails outright.
- Not a change to the encryption feature specifically — this bug exists for the plaintext disk tier too, whenever a write is interrupted before the body starts. Encryption's chunked, incremental write pattern just made the interrupted-write case easier to hit in practice.

## Test plan
- [x] New regression test (`DataCacheTests.discardFailedWrite_whenBodyNeverArrives_shouldDeleteTheOrphanedCacheDirectory`) reproducing the exact failure shape: allocate a disk buffer, never write a body byte, discard the failed write, assert no `.cached` directory survives. Confirmed this test fails (leftover directory, ~15-16s to determine that) against the old `remove(forKey:)`-based cleanup, and passes in 0.022s with the fix.
- [x] Full test suite: 893 tests / 128 suites (RequestDLTests) + 358 tests / 56 suites (RequestDLInternalsTests), zero failures.
- [x] `swift format format --in-place --recursive Sources Tests` — no changes needed.
- [x] No public API changes (`DiskStorage`, `DataCache.Buffer`, and the touched `DataCache` methods are all internal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)