### PR TITLE
Expose SSLPSKIdentityResolver and SSLKeyLogger through the public RequestDL module

### DIFF
--- a/Sources/RequestDL/Properties/Sources/Secure Connection/PSK/Models/SSLPSKIdentityResolver.swift
+++ b/Sources/RequestDL/Properties/Sources/Secure Connection/PSK/Models/SSLPSKIdentityResolver.swift
@@ -1,0 +1,11 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+import RequestDLInternals
+
+/// A protocol for resolving pre-shared key client identities.
+///
+/// ``SSLPSKIdentityResolver`` defines a function that can be used to resolve
+/// a pre-shared key client identity based on a given hint.
+public typealias SSLPSKIdentityResolver = RequestDLInternals.SSLPSKIdentityResolver

--- a/Sources/RequestDL/Properties/Sources/Secure Connection/Secure Connection/Models/SSLKeyLogger.swift
+++ b/Sources/RequestDL/Properties/Sources/Secure Connection/Secure Connection/Models/SSLKeyLogger.swift
@@ -1,0 +1,11 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+import RequestDLInternals
+
+/// A protocol for implementing `SSLKEYLOGFILE` support.
+///
+/// ``SSLKeyLogger`` defines a method that can be used to log keys in the format expected by
+/// tools that support the `SSLKEYLOGFILE`.
+public typealias SSLKeyLogger = RequestDLInternals.SSLKeyLogger


### PR DESCRIPTION
## Summary

`PSKIdentity.init(_:)` and `SecureConnection.keyLogger(_:)` are public API on the `RequestDL` module, but their parameter types (`SSLPSKIdentityResolver`, `SSLKeyLogger`) are declared only in `RequestDLInternals` -- a target that isn't vended as a library product in `Package.swift` (only `RequestDL` is, per #280's "package-visibility" extraction).

Confirmed with a throwaway package depending solely on the `RequestDL` product: conforming to either protocol failed with `cannot find type ... in scope`, since `RequestDLInternals` can't be imported outside this package. In practice, **no external consumer could implement PSK identity resolution or SSL key logging**.

## Fix

Both protocols only reference already-public NIOSSL/NIOCore types in their requirements, so this re-exports them from `RequestDL` as public `typealias`es to their `RequestDLInternals` declarations:

```swift
public typealias SSLPSKIdentityResolver = RequestDLInternals.SSLPSKIdentityResolver
public typealias SSLKeyLogger = RequestDLInternals.SSLKeyLogger
```

Single source of truth for the protocol, no bridging code, and `RequestDLInternals`'s own storage (`Internals.SecureConnection.pskIdentityResolver`/`keyLogger`) keeps working unchanged since it's the same underlying type.

## Verification

- `swift build` clean, `swift test`: 358 tests / 56 suites passing.
- Built a separate package depending only on the `RequestDL` product, before and after: `cannot find type 'SSLPSKIdentityResolver'/'SSLKeyLogger' in scope` before this change, compiles and runs after -- a class can now conform to each protocol and be passed to `PSKIdentity(_:)` / `.keyLogger(_:)`.

## Test plan

- [x] `swift build`
- [x] `swift test` (358/358)
- [x] External-consumer package validated end-to-end (build + run)