### PR TITLE
Add declarative retry/backoff modifier for RequestTask

### DIFF
--- a/Sources/RequestDL/Tasks/Sources/Modifiers/Retry/Models/RetryPolicy.swift
+++ b/Sources/RequestDL/Tasks/Sources/Modifiers/Retry/Models/RetryPolicy.swift
@@ -1,0 +1,113 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+/// A policy describing how a failed ``RequestTask`` should be retried by
+/// ``RequestTask/retry(_:)``.
+///
+/// Retrying re-executes the whole request from scratch: the ``Property`` content behind the task
+/// is resolved and sent again as if it were a brand-new call, not a resumption of the failed one.
+/// That is safe for requests that are safe to repeat -- `GET`/`HEAD`, or any request whose body is
+/// described declaratively (``Payload``'s `data`/`url`/`json` initializers, for instance) rather
+/// than consumed from a caller-owned, single-use stream that can't be read a second time.
+///
+/// It is **not** safe by default for requests with side effects that aren't idempotent (a `POST`
+/// that creates a resource, for example): if the original request actually reached the server but
+/// its response was lost -- a timeout, a dropped connection -- retrying it can duplicate that side
+/// effect. `RetryPolicy` has no visibility into the request it is applied to, so it cannot enforce
+/// this on its own; scope `shouldRetry` and where `.retry(_:)` is applied in the call graph
+/// accordingly.
+///
+/// ```swift
+/// try await DataTask {
+///     BaseURL("example.com")
+/// }
+/// .retry(.exponentialBackoff(3))
+/// .result()
+/// ```
+public struct RetryPolicy: Sendable {
+
+    // MARK: - Internal properties
+
+    let maxAttempts: Int
+    let shouldRetry: @Sendable (Error) -> Bool
+    let delay: @Sendable (_ attempt: Int) -> UnitTime
+
+    // MARK: - Inits
+
+    ///
+    /// Creates a policy with full control over the delay between attempts.
+    ///
+    /// - Parameters:
+    ///   - maxAttempts: The maximum number of times the request is executed in total, including
+    ///     the first attempt. Values below `1` are treated as `1`, i.e. no retry.
+    ///   - shouldRetry: Called with each thrown error to decide whether it is worth retrying.
+    ///     Returning `false` stops retrying and rethrows that error immediately. Defaults to
+    ///     retrying every error except cancellation, which is never retried.
+    ///   - delay: Called with the retry attempt number -- `1` for the delay before the second
+    ///     overall attempt, `2` before the third, and so on -- to compute how long to wait
+    ///     before it.
+    ///
+    public init(
+        maxAttempts: Int,
+        shouldRetry: @escaping @Sendable (Error) -> Bool = { _ in true },
+        delay: @escaping @Sendable (_ attempt: Int) -> UnitTime
+    ) {
+        self.maxAttempts = max(1, maxAttempts)
+        self.shouldRetry = shouldRetry
+        self.delay = delay
+    }
+
+    // MARK: - Public static methods
+
+    ///
+    /// A policy that waits the same fixed interval before every retry.
+    ///
+    /// - Parameters:
+    ///   - maxAttempts: The maximum number of times the request is executed in total.
+    ///   - delay: The fixed interval to wait before every retry. Default is `.seconds(1)`.
+    ///   - shouldRetry: Called with each thrown error to decide whether it is worth retrying.
+    ///
+    /// - Returns: A `RetryPolicy` with a fixed delay between attempts.
+    ///
+    public static func fixed(
+        _ maxAttempts: Int,
+        delay: UnitTime = .seconds(1),
+        shouldRetry: @escaping @Sendable (Error) -> Bool = { _ in true }
+    ) -> RetryPolicy {
+        .init(maxAttempts: maxAttempts, shouldRetry: shouldRetry) { _ in delay }
+    }
+
+    ///
+    /// A policy that grows the wait between attempts geometrically, up to a ceiling.
+    ///
+    /// - Parameters:
+    ///   - maxAttempts: The maximum number of times the request is executed in total.
+    ///   - baseDelay: How long to wait before the first retry. Default is `.seconds(1)`.
+    ///   - multiplier: How much the delay grows after each attempt. Default is `2`.
+    ///   - maxDelay: The longest delay allowed between attempts, regardless of how many have
+    ///     already happened. Default is `.seconds(30)`.
+    ///   - shouldRetry: Called with each thrown error to decide whether it is worth retrying.
+    ///
+    /// - Returns: A `RetryPolicy` with an exponentially growing delay between attempts.
+    ///
+    public static func exponentialBackoff(
+        _ maxAttempts: Int,
+        baseDelay: UnitTime = .seconds(1),
+        multiplier: Int = 2,
+        maxDelay: UnitTime = .seconds(30),
+        shouldRetry: @escaping @Sendable (Error) -> Bool = { _ in true }
+    ) -> RetryPolicy {
+        .init(maxAttempts: maxAttempts, shouldRetry: shouldRetry) { attempt in
+            var delay = baseDelay
+            var remainingDoublings = attempt - 1
+
+            while remainingDoublings > 0, delay < maxDelay {
+                delay = delay * multiplier
+                remainingDoublings -= 1
+            }
+
+            return min(delay, maxDelay)
+        }
+    }
+}

--- a/Sources/RequestDL/Tasks/Sources/Modifiers/Retry/Modifiers.Retry.swift
+++ b/Sources/RequestDL/Tasks/Sources/Modifiers/Retry/Modifiers.Retry.swift
@@ -1,0 +1,90 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+extension Modifiers {
+
+    ///
+    /// A `RequestTaskModifier` that retries the wrapped `RequestTask` according to a
+    /// ``RetryPolicy`` while it keeps throwing.
+    ///
+    /// Each retry calls the original task's `result()` again, which re-resolves and re-sends the
+    /// whole request from scratch -- see ``RetryPolicy`` for when that is, and isn't, safe to do.
+    /// A `CancellationError` is never retried, regardless of `policy`.
+    ///
+    public struct Retry<Input: Sendable>: RequestTaskModifier {
+
+        // MARK: - Internal properties
+
+        let policy: RetryPolicy
+
+        // MARK: - Public methods
+
+        ///
+        /// Executes `task`, retrying it according to `policy` while it keeps throwing.
+        ///
+        /// - Parameter task: The original `RequestTask`.
+        /// - Throws: The last error thrown by `task`, once retries are exhausted or `policy`
+        /// declines to retry it.
+        /// - Returns: The result of the first successful attempt.
+        ///
+        public func body(_ task: Content) async throws -> Input {
+            var attempt = 1
+
+            while true {
+                do {
+                    return try await task.result()
+                } catch {
+                    guard
+                        !(error is CancellationError),
+                        attempt < policy.maxAttempts,
+                        policy.shouldRetry(error)
+                    else {
+                        throw error
+                    }
+
+                    let delay = policy.delay(attempt)
+
+                    if delay > .zero {
+                        try await Task.sleep(nanoseconds: UInt64(delay.nanoseconds))
+                    }
+
+                    attempt += 1
+                }
+            }
+        }
+    }
+}
+
+// MARK: - RequestTask extension
+
+extension RequestTask {
+
+    ///
+    /// Retries the task according to `policy` when it throws.
+    ///
+    /// Use this to smooth over transient failures -- a dropped connection, a momentary `5xx`
+    /// surfaced by a modifier like ``RequestTask/acceptOnlyStatusCode(_:)`` further down the
+    /// chain -- without hand-rolling a retry loop around `result()`. Because each retry re-runs
+    /// the request from scratch, only apply it where that is safe: see ``RetryPolicy`` for the
+    /// idempotency caveat before using it on requests with side effects.
+    ///
+    /// ```swift
+    /// try await DataTask {
+    ///     BaseURL("example.com")
+    /// }
+    /// .retry(.exponentialBackoff(3))
+    /// .result()
+    /// ```
+    ///
+    /// - Parameter policy: The ``RetryPolicy`` describing how many times to retry, the delay
+    /// between attempts, and which errors are worth retrying.
+    ///
+    /// - Returns: A `ModifiedRequestTask` that retries the original task per `policy`.
+    ///
+    public func retry(
+        _ policy: RetryPolicy
+    ) -> ModifiedRequestTask<Modifiers.Retry<Element>> {
+        modifier(Modifiers.Retry(policy: policy))
+    }
+}

--- a/Tests/RequestDLTests/Tasks/Sources/Modifiers/Retry/Models/RetryPolicyTests.swift
+++ b/Tests/RequestDLTests/Tasks/Sources/Modifiers/Retry/Models/RetryPolicyTests.swift
@@ -1,0 +1,82 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+import Testing
+
+@testable import RequestDL
+
+struct RetryPolicyTests {
+
+    struct TestError: Error {}
+
+    @Test
+    func fixedClampsMaxAttemptsToAtLeastOne() {
+        // When
+        let policy = RetryPolicy.fixed(0)
+
+        // Then
+        #expect(policy.maxAttempts == 1)
+    }
+
+    @Test
+    func fixedUsesTheSameDelayForEveryAttempt() {
+        // When
+        let policy = RetryPolicy.fixed(5, delay: .seconds(2))
+
+        // Then
+        #expect(policy.delay(1) == .seconds(2))
+        #expect(policy.delay(2) == .seconds(2))
+        #expect(policy.delay(10) == .seconds(2))
+    }
+
+    @Test
+    func exponentialBackoffGrowsByTheMultiplier() {
+        // When
+        let policy = RetryPolicy.exponentialBackoff(
+            6,
+            baseDelay: .seconds(1),
+            multiplier: 2,
+            maxDelay: .seconds(30)
+        )
+
+        // Then
+        #expect(policy.delay(1) == .seconds(1))
+        #expect(policy.delay(2) == .seconds(2))
+        #expect(policy.delay(3) == .seconds(4))
+        #expect(policy.delay(4) == .seconds(8))
+    }
+
+    @Test
+    func exponentialBackoffCapsAtMaxDelay() {
+        // When
+        let policy = RetryPolicy.exponentialBackoff(
+            10,
+            baseDelay: .seconds(1),
+            multiplier: 2,
+            maxDelay: .seconds(10)
+        )
+
+        // Then
+        #expect(policy.delay(5) == .seconds(10))
+        #expect(policy.delay(9) == .seconds(10))
+    }
+
+    @Test
+    func shouldRetryDefaultsToTrueForAnyError() {
+        // When
+        let policy = RetryPolicy.fixed(3)
+
+        // Then
+        #expect(policy.shouldRetry(TestError()))
+    }
+
+    @Test
+    func shouldRetryCanBeCustomized() {
+        // When
+        let policy = RetryPolicy.fixed(3, shouldRetry: { _ in false })
+
+        // Then
+        #expect(!policy.shouldRetry(TestError()))
+    }
+}

--- a/Tests/RequestDLTests/Tasks/Sources/Modifiers/Retry/ModifiersRetryTests.swift
+++ b/Tests/RequestDLTests/Tasks/Sources/Modifiers/Retry/ModifiersRetryTests.swift
@@ -1,0 +1,139 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+import SwiftAsyncStream
+import Testing
+
+@testable import RequestDL
+
+struct ModifiersRetryTests {
+
+    struct TransientError: Error {}
+
+    @Test
+    func retryDoesNotRetryOnSuccess() async throws {
+        // Given
+        let attempts = InlineProperty(wrappedValue: 0)
+
+        // When
+        let result = try await MockedTask {
+            BaseURL("localhost")
+        }
+        .flatMap { _ -> Int in
+            attempts.wrappedValue += 1
+            return 42
+        }
+        .retry(.fixed(5, delay: .zero))
+        .result()
+
+        // Then
+        #expect(result == 42)
+        #expect(attempts.wrappedValue == 1)
+    }
+
+    @Test
+    func retrySucceedsAfterTransientFailures() async throws {
+        // Given
+        let attempts = InlineProperty(wrappedValue: 0)
+
+        // When
+        let result = try await MockedTask {
+            BaseURL("localhost")
+        }
+        .flatMap { _ -> Int in
+            attempts.wrappedValue += 1
+            if attempts.wrappedValue < 3 {
+                throw TransientError()
+            }
+            return attempts.wrappedValue
+        }
+        .retry(.fixed(5, delay: .zero))
+        .result()
+
+        // Then
+        #expect(result == 3)
+        #expect(attempts.wrappedValue == 3)
+    }
+
+    @Test
+    func retryExhaustsAttemptsAndRethrowsLastError() async throws {
+        // Given
+        let attempts = InlineProperty(wrappedValue: 0)
+
+        // When
+        do {
+            _ = try await MockedTask {
+                BaseURL("localhost")
+            }
+            .flatMap { _ -> Int in
+                attempts.wrappedValue += 1
+                throw TransientError()
+            }
+            .retry(.fixed(3, delay: .zero))
+            .result()
+
+            Issue.record("Expected the task to keep throwing")
+        } catch is TransientError {
+        } catch {
+            throw error
+        }
+
+        // Then
+        #expect(attempts.wrappedValue == 3)
+    }
+
+    @Test
+    func retryStopsWhenShouldRetryReturnsFalse() async throws {
+        // Given
+        let attempts = InlineProperty(wrappedValue: 0)
+
+        // When
+        do {
+            _ = try await MockedTask {
+                BaseURL("localhost")
+            }
+            .flatMap { _ -> Int in
+                attempts.wrappedValue += 1
+                throw TransientError()
+            }
+            .retry(.fixed(5, delay: .zero, shouldRetry: { _ in false }))
+            .result()
+
+            Issue.record("Expected the task to fail without retrying")
+        } catch is TransientError {
+        } catch {
+            throw error
+        }
+
+        // Then
+        #expect(attempts.wrappedValue == 1)
+    }
+
+    @Test
+    func retryNeverRetriesCancellation() async throws {
+        // Given
+        let attempts = InlineProperty(wrappedValue: 0)
+
+        // When
+        do {
+            _ = try await MockedTask {
+                BaseURL("localhost")
+            }
+            .flatMap { _ -> Int in
+                attempts.wrappedValue += 1
+                throw CancellationError()
+            }
+            .retry(.fixed(5, delay: .zero))
+            .result()
+
+            Issue.record("Expected cancellation to propagate without retrying")
+        } catch is CancellationError {
+        } catch {
+            throw error
+        }
+
+        // Then
+        #expect(attempts.wrappedValue == 1)
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `RetryPolicy` (`.fixed(_:delay:shouldRetry:)` / `.exponentialBackoff(_:baseDelay:multiplier:maxDelay:shouldRetry:)`) and `RequestTask.retry(_:)`, so a task can retry itself on failure instead of every caller hand-rolling a loop around `result()`.
- Follows the same shape as the existing `Modifiers.FlatMapError`: each retry calls `task.result()` again, which re-resolves and re-sends the whole request from scratch.
- Documents the idempotency caveat directly on `RetryPolicy` and `.retry(_:)`: since a modifier has no visibility into the request's HTTP method, it can't mechanically restrict itself to safe methods (GET/HEAD) — retrying a request whose side effect already landed on the server (e.g. a POST after a lost response) can duplicate it. Scoping `shouldRetry`/where `.retry(_:)` is applied is left to the caller, the same tradeoff Alamofire/URLSession make.
- This was flagged as opportunity "B" (retry/backoff modifier) in a feature-scout pass over the repo, where it was originally deferred for lack of demand evidence — implemented here on explicit request.

## Test plan
- [x] `swift build`
- [x] `swift test --filter RetryPolicyTests` (6 tests: delay-curve math for fixed/exponential backoff, `maxAttempts` clamping, `shouldRetry` default/override)
- [x] `swift test --filter ModifiersRetryTests` (5 tests: no-retry-on-success, recovery after transient failures, exhaustion rethrows last error, `shouldRetry` opt-out, cancellation never retried)
- [x] Full suite: `swift test --filter RequestDLTests` — 997 tests / 145 suites passed (2 pre-existing known issues, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)