### PR TITLE
Add Server-Sent Events parsing over AsyncBytes

### DIFF
--- a/Sources/RequestDL/Tasks/Sources/Raw Task/Download/Server-Sent Events/Extensions/AsyncBytes+Events.swift
+++ b/Sources/RequestDL/Tasks/Sources/Raw Task/Download/Server-Sent Events/Extensions/AsyncBytes+Events.swift
@@ -1,0 +1,25 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+extension AsyncBytes {
+
+    /// Parses the byte stream as `text/event-stream` (Server-Sent Events) framing.
+    ///
+    /// ```swift
+    /// let result = try await DownloadTask {
+    ///     BaseURL("example.com")
+    ///     Path("stream")
+    /// }
+    /// .result()
+    ///
+    /// for try await event in result.payload.events() {
+    ///     print(event.event, event.data)
+    /// }
+    /// ```
+    ///
+    /// - Returns: A ``ServerSentEvents`` sequence that yields one ``ServerSentEvent`` per frame.
+    public func events() -> ServerSentEvents {
+        .init(bytes: self)
+    }
+}

--- a/Sources/RequestDL/Tasks/Sources/Raw Task/Download/Server-Sent Events/Models/ServerSentEvent.swift
+++ b/Sources/RequestDL/Tasks/Sources/Raw Task/Download/Server-Sent Events/Models/ServerSentEvent.swift
@@ -1,0 +1,30 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+/// A single event frame parsed from a `text/event-stream` (Server-Sent Events) response body.
+///
+/// Conforms to the [WHATWG event stream interpretation](https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation):
+/// consecutive `data:` lines belonging to the same frame are joined with `"\n"`, comment lines
+/// (starting with `:`) are dropped, and a frame with no `data:` line at all produces no event.
+///
+/// - Note: Unlike the browser `EventSource` API, `retry` is exposed directly on the event instead of
+/// silently updating a reconnection timer -- this type performs no reconnection of its own, so the value
+/// is surfaced for the caller to act on if desired.
+public struct ServerSentEvent: Sendable, Hashable {
+
+    /// The event's `id:` field, or `nil` if the stream has not sent one yet.
+    ///
+    /// Once set, the value persists across subsequent events until a new `id:` line is received,
+    /// mirroring the "last event ID" behavior of the specification.
+    public let id: String?
+
+    /// The event's `event:` field, defaulting to `"message"` when the stream omits it.
+    public let event: String
+
+    /// The event's payload, formed by joining every `data:` line in the frame with `"\n"`.
+    public let data: String
+
+    /// The reconnection time, in milliseconds, from the most recently seen `retry:` line.
+    public let retry: Int?
+}

--- a/Sources/RequestDL/Tasks/Sources/Raw Task/Download/Server-Sent Events/Models/ServerSentEventParser.swift
+++ b/Sources/RequestDL/Tasks/Sources/Raw Task/Download/Server-Sent Events/Models/ServerSentEventParser.swift
@@ -1,0 +1,161 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import struct Foundation.Data
+#endif
+
+/// Incrementally decodes `text/event-stream` bytes into ``ServerSentEvent`` values.
+///
+/// Bytes are fed in arbitrary chunks via ``feed(_:)`` -- a chunk may end mid-line, and a line may even
+/// be split across a `CR`/`LF` boundary between two chunks. State is kept internally so a caller never
+/// has to reassemble lines itself.
+struct ServerSentEventParser {
+
+    // MARK: - Private properties
+
+    private var lineBuffer = Data()
+    private var sawTrailingCR = false
+
+    private var lastEventId: String?
+    private var pendingEventType: String?
+    private var pendingDataLines: [String] = []
+    private var pendingRetry: Int?
+
+    // MARK: - Internal methods
+
+    mutating func feed(_ chunk: Data) -> [ServerSentEvent] {
+        var events: [ServerSentEvent] = []
+
+        for line in extractLines(from: chunk) {
+            if let event = process(line: line) {
+                events.append(event)
+            }
+        }
+
+        return events
+    }
+
+    /// Flushes whatever the stream left buffered when it ended -- a trailing line with no `CR`/`LF`
+    /// terminator, and/or a frame that was never closed off by a final blank line. Real servers
+    /// routinely close the connection right after the last event without emitting that blank line,
+    /// so treating end-of-stream as an implicit frame boundary avoids silently dropping it.
+    mutating func finish() -> ServerSentEvent? {
+        if !lineBuffer.isEmpty {
+            let line = String(decoding: lineBuffer, as: UTF8.self)
+            lineBuffer.removeAll()
+
+            if let event = process(line: line) {
+                return event
+            }
+        }
+
+        return dispatch()
+    }
+
+    // MARK: - Private methods
+
+    private mutating func extractLines(from chunk: Data) -> [String] {
+        var chunk = chunk
+
+        if sawTrailingCR {
+            sawTrailingCR = false
+
+            if chunk.first == UInt8(ascii: "\n") {
+                chunk = chunk.dropFirst()
+            }
+        }
+
+        lineBuffer.append(chunk)
+
+        var lines: [String] = []
+        var searchIndex = lineBuffer.startIndex
+
+        while let breakIndex = lineBuffer[searchIndex...].firstIndex(where: {
+            $0 == UInt8(ascii: "\r") || $0 == UInt8(ascii: "\n")
+        }) {
+            lines.append(String(decoding: lineBuffer[searchIndex..<breakIndex], as: UTF8.self))
+
+            var nextIndex = lineBuffer.index(after: breakIndex)
+
+            if lineBuffer[breakIndex] == UInt8(ascii: "\r") {
+                if nextIndex < lineBuffer.endIndex, lineBuffer[nextIndex] == UInt8(ascii: "\n") {
+                    nextIndex = lineBuffer.index(after: nextIndex)
+                } else if nextIndex == lineBuffer.endIndex {
+                    sawTrailingCR = true
+                }
+            }
+
+            searchIndex = nextIndex
+        }
+
+        lineBuffer.removeSubrange(lineBuffer.startIndex..<searchIndex)
+        return lines
+    }
+
+    private mutating func process(line: String) -> ServerSentEvent? {
+        if line.isEmpty {
+            return dispatch()
+        }
+
+        if line.hasPrefix(":") {
+            return nil
+        }
+
+        let field: Substring
+        let value: Substring
+
+        if let colonIndex = line.firstIndex(of: ":") {
+            field = line[line.startIndex..<colonIndex]
+
+            var rawValue = line[line.index(after: colonIndex)...]
+            if rawValue.first == " " {
+                rawValue = rawValue.dropFirst()
+            }
+            value = rawValue
+        } else {
+            field = line[...]
+            value = ""
+        }
+
+        switch field {
+        case "event":
+            pendingEventType = String(value)
+        case "data":
+            pendingDataLines.append(String(value))
+        case "id":
+            if !value.contains("\u{0000}") {
+                lastEventId = String(value)
+            }
+        case "retry":
+            if !value.isEmpty, value.allSatisfy(\.isASCII), value.allSatisfy(\.isNumber) {
+                pendingRetry = Int(value)
+            }
+        default:
+            break
+        }
+
+        return nil
+    }
+
+    private mutating func dispatch() -> ServerSentEvent? {
+        defer {
+            pendingEventType = nil
+            pendingDataLines = []
+        }
+
+        guard !pendingDataLines.isEmpty else {
+            return nil
+        }
+
+        return ServerSentEvent(
+            id: lastEventId,
+            event: pendingEventType ?? "message",
+            data: pendingDataLines.joined(separator: "\n"),
+            retry: pendingRetry
+        )
+    }
+}

--- a/Sources/RequestDL/Tasks/Sources/Raw Task/Download/Server-Sent Events/Models/ServerSentEvents.swift
+++ b/Sources/RequestDL/Tasks/Sources/Raw Task/Download/Server-Sent Events/Models/ServerSentEvents.swift
@@ -1,0 +1,82 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import struct Foundation.Data
+#endif
+
+/// An `AsyncSequence` that parses `text/event-stream` framing out of ``AsyncBytes``.
+///
+/// Bytes are consumed incrementally as they arrive over the network, so the response body is never
+/// buffered in full -- only the currently in-flight event frame is kept in memory.
+public struct ServerSentEvents: Sendable, AsyncSequence {
+
+    public typealias Element = ServerSentEvent
+
+    ///
+    /// A structure that defines an async iterator for the server-sent events.
+    ///
+    public struct AsyncIterator: AsyncIteratorProtocol {
+
+        fileprivate var bytesIterator: AsyncBytes.AsyncIterator
+        fileprivate var parser = ServerSentEventParser()
+
+        fileprivate var pendingEvents: [ServerSentEvent] = []
+        fileprivate var pendingIndex = 0
+        fileprivate var isFinished = false
+
+        ///
+        /// Returns the next event in the stream, or `nil` when the underlying byte stream ends.
+        ///
+        /// - Returns: The next ``ServerSentEvent``, if any.
+        ///
+        public mutating func next() async throws -> ServerSentEvent? {
+            while true {
+                if pendingIndex < pendingEvents.count {
+                    defer { pendingIndex += 1 }
+                    return pendingEvents[pendingIndex]
+                }
+
+                guard !isFinished else {
+                    return nil
+                }
+
+                if let chunk = try await bytesIterator.next() {
+                    pendingEvents = parser.feed(chunk)
+                    pendingIndex = 0
+                } else {
+                    isFinished = true
+
+                    if let event = parser.finish() {
+                        pendingEvents = [event]
+                        pendingIndex = 0
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Private properties
+
+    private let bytes: AsyncBytes
+
+    // MARK: - Inits
+
+    init(bytes: AsyncBytes) {
+        self.bytes = bytes
+    }
+
+    // MARK: - Public methods
+
+    ///
+    /// Returns an async iterator over the parsed server-sent events.
+    ///
+    /// - Returns: An async iterator for the server-sent events.
+    ///
+    public func makeAsyncIterator() -> AsyncIterator {
+        .init(bytesIterator: bytes.makeAsyncIterator())
+    }
+}

--- a/Tests/RequestDLTests/Tasks/Sources/Raw Task/Download/Server-Sent Events/Extensions/AsyncBytesEventsTests.swift
+++ b/Tests/RequestDLTests/Tasks/Sources/Raw Task/Download/Server-Sent Events/Extensions/AsyncBytesEventsTests.swift
@@ -44,10 +44,12 @@ struct AsyncBytesEventsTests {
         }
 
         // Then
-        #expect(events == [
-            ServerSentEvent(id: "1", event: "greeting", data: "hello", retry: nil),
-            ServerSentEvent(id: "1", event: "message", data: "world", retry: 2000)
-        ])
+        #expect(
+            events == [
+                ServerSentEvent(id: "1", event: "greeting", data: "hello", retry: nil),
+                ServerSentEvent(id: "1", event: "message", data: "world", retry: 2000),
+            ]
+        )
     }
 
     @Test
@@ -75,8 +77,10 @@ struct AsyncBytesEventsTests {
         }
 
         // Then
-        #expect(events == [
-            ServerSentEvent(id: nil, event: "message", data: "hello", retry: nil)
-        ])
+        #expect(
+            events == [
+                ServerSentEvent(id: nil, event: "message", data: "hello", retry: nil)
+            ]
+        )
     }
 }

--- a/Tests/RequestDLTests/Tasks/Sources/Raw Task/Download/Server-Sent Events/Extensions/AsyncBytesEventsTests.swift
+++ b/Tests/RequestDLTests/Tasks/Sources/Raw Task/Download/Server-Sent Events/Extensions/AsyncBytesEventsTests.swift
@@ -1,0 +1,82 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+import RequestDLInternals
+import SwiftAsyncStream
+import Testing
+
+@testable import RequestDL
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import struct Foundation.Data
+#endif
+
+struct AsyncBytesEventsTests {
+
+    @Test
+    func events_whenBytesArriveSplitAcrossChunks_shouldYieldParsedEvents() async throws {
+        // Given
+        let stream = Internals.AsyncStream<Internals.DataBuffer>()
+
+        let part1 = Data("id: 1\nevent: greeting\ndata: hel".utf8)
+        let part2 = Data("lo\n\nretry: 2000\ndata: world\n\n".utf8)
+
+        let internalBytes = Internals.AsyncBytes(
+            logger: nil,
+            totalSize: part1.count + part2.count,
+            stream: stream
+        )
+
+        let bytes = AsyncBytes(seed: .withoutCancellation, bytes: internalBytes)
+
+        // When
+        await stream.append(.success(Internals.DataBuffer(part1)))
+        await stream.append(.success(Internals.DataBuffer(part2)))
+        stream.close()
+
+        var events: [ServerSentEvent] = []
+
+        for try await event in bytes.events() {
+            events.append(event)
+        }
+
+        // Then
+        #expect(events == [
+            ServerSentEvent(id: "1", event: "greeting", data: "hello", retry: nil),
+            ServerSentEvent(id: "1", event: "message", data: "world", retry: 2000)
+        ])
+    }
+
+    @Test
+    func events_whenStreamEndsWithoutTrailingBlankLine_shouldStillYieldLastEvent() async throws {
+        // Given
+        let stream = Internals.AsyncStream<Internals.DataBuffer>()
+        let part = Data("data: hello".utf8)
+
+        let internalBytes = Internals.AsyncBytes(
+            logger: nil,
+            totalSize: part.count,
+            stream: stream
+        )
+
+        let bytes = AsyncBytes(seed: .withoutCancellation, bytes: internalBytes)
+
+        // When
+        await stream.append(.success(Internals.DataBuffer(part)))
+        stream.close()
+
+        var events: [ServerSentEvent] = []
+
+        for try await event in bytes.events() {
+            events.append(event)
+        }
+
+        // Then
+        #expect(events == [
+            ServerSentEvent(id: nil, event: "message", data: "hello", retry: nil)
+        ])
+    }
+}

--- a/Tests/RequestDLTests/Tasks/Sources/Raw Task/Download/Server-Sent Events/Models/ServerSentEventParserTests.swift
+++ b/Tests/RequestDLTests/Tasks/Sources/Raw Task/Download/Server-Sent Events/Models/ServerSentEventParserTests.swift
@@ -1,0 +1,218 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+import Testing
+
+@testable import RequestDL
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import struct Foundation.Data
+#endif
+
+struct ServerSentEventParserTests {
+
+    @Test
+    func feed_whenSingleFrameSentInOneChunk_shouldEmitEvent() {
+        // Given
+        var parser = ServerSentEventParser()
+
+        // When
+        let events = parser.feed(Data("event: greeting\ndata: hello\n\n".utf8))
+
+        // Then
+        #expect(events == [
+            ServerSentEvent(id: nil, event: "greeting", data: "hello", retry: nil)
+        ])
+    }
+
+    @Test
+    func feed_whenLineIsSplitAcrossChunks_shouldStillEmitEvent() {
+        // Given
+        var parser = ServerSentEventParser()
+
+        // When
+        let first = parser.feed(Data("data: hel".utf8))
+        let second = parser.feed(Data("lo\n\n".utf8))
+
+        // Then
+        #expect(first.isEmpty)
+        #expect(second == [
+            ServerSentEvent(id: nil, event: "message", data: "hello", retry: nil)
+        ])
+    }
+
+    @Test
+    func feed_whenCRLFTerminatorIsSplitAcrossChunks_shouldNotProduceSpuriousEmptyLine() {
+        // Given
+        var parser = ServerSentEventParser()
+
+        // When
+        let first = parser.feed(Data("data: hello\r".utf8))
+        let second = parser.feed(Data("\ndata: world\r\n\r\n".utf8))
+
+        // Then
+        #expect(first.isEmpty)
+        #expect(second == [
+            ServerSentEvent(id: nil, event: "message", data: "hello\nworld", retry: nil)
+        ])
+    }
+
+    @Test
+    func feed_whenMultipleDataLines_shouldJoinWithNewline() {
+        // Given
+        var parser = ServerSentEventParser()
+
+        // When
+        let events = parser.feed(Data("data: line one\ndata: line two\n\n".utf8))
+
+        // Then
+        #expect(events == [
+            ServerSentEvent(id: nil, event: "message", data: "line one\nline two", retry: nil)
+        ])
+    }
+
+    @Test
+    func feed_whenLineIsComment_shouldBeIgnored() {
+        // Given
+        var parser = ServerSentEventParser()
+
+        // When
+        let events = parser.feed(Data(": keep-alive\ndata: hello\n\n".utf8))
+
+        // Then
+        #expect(events == [
+            ServerSentEvent(id: nil, event: "message", data: "hello", retry: nil)
+        ])
+    }
+
+    @Test
+    func feed_whenFrameHasNoDataLine_shouldNotEmitEvent() {
+        // Given
+        var parser = ServerSentEventParser()
+
+        // When
+        let events = parser.feed(Data("event: ping\n\n".utf8))
+
+        // Then
+        #expect(events.isEmpty)
+    }
+
+    @Test
+    func feed_whenIdIsSet_shouldPersistAcrossSubsequentEvents() {
+        // Given
+        var parser = ServerSentEventParser()
+
+        // When
+        let first = parser.feed(Data("id: 1\ndata: hello\n\n".utf8))
+        let second = parser.feed(Data("data: world\n\n".utf8))
+
+        // Then
+        #expect(first == [
+            ServerSentEvent(id: "1", event: "message", data: "hello", retry: nil)
+        ])
+        #expect(second == [
+            ServerSentEvent(id: "1", event: "message", data: "world", retry: nil)
+        ])
+    }
+
+    @Test
+    func feed_whenIdContainsNullCharacter_shouldBeIgnored() {
+        // Given
+        var parser = ServerSentEventParser()
+
+        // When
+        let events = parser.feed(Data("id: 1\u{0000}\ndata: hello\n\n".utf8))
+
+        // Then
+        #expect(events == [
+            ServerSentEvent(id: nil, event: "message", data: "hello", retry: nil)
+        ])
+    }
+
+    @Test
+    func feed_whenRetryIsDigitsOnly_shouldBeParsed() {
+        // Given
+        var parser = ServerSentEventParser()
+
+        // When
+        let events = parser.feed(Data("retry: 3000\ndata: hello\n\n".utf8))
+
+        // Then
+        #expect(events == [
+            ServerSentEvent(id: nil, event: "message", data: "hello", retry: 3000)
+        ])
+    }
+
+    @Test
+    func feed_whenRetryIsNotDigitsOnly_shouldBeIgnored() {
+        // Given
+        var parser = ServerSentEventParser()
+
+        // When
+        let events = parser.feed(Data("retry: soon\ndata: hello\n\n".utf8))
+
+        // Then
+        #expect(events == [
+            ServerSentEvent(id: nil, event: "message", data: "hello", retry: nil)
+        ])
+    }
+
+    @Test
+    func feed_whenFieldHasNoColon_shouldTreatItAsFieldNameWithEmptyValue()  {
+        // Given
+        var parser = ServerSentEventParser()
+
+        // When
+        let events = parser.feed(Data("data\n\n".utf8))
+
+        // Then
+        #expect(events == [
+            ServerSentEvent(id: nil, event: "message", data: "", retry: nil)
+        ])
+    }
+
+    @Test
+    func feed_whenMultipleFramesInSingleChunk_shouldEmitEventsInOrder() {
+        // Given
+        var parser = ServerSentEventParser()
+
+        // When
+        let events = parser.feed(Data("data: first\n\ndata: second\n\n".utf8))
+
+        // Then
+        #expect(events == [
+            ServerSentEvent(id: nil, event: "message", data: "first", retry: nil),
+            ServerSentEvent(id: nil, event: "message", data: "second", retry: nil)
+        ])
+    }
+
+    @Test
+    func finish_whenTrailingLineHasNoTerminator_shouldStillDispatch() {
+        // Given
+        var parser = ServerSentEventParser()
+
+        // When
+        let fed = parser.feed(Data("data: hello\n".utf8))
+        let finished = parser.finish()
+
+        // Then
+        #expect(fed.isEmpty)
+        #expect(finished == ServerSentEvent(id: nil, event: "message", data: "hello", retry: nil))
+    }
+
+    @Test
+    func finish_whenBufferIsEmpty_shouldReturnNil() {
+        // Given
+        var parser = ServerSentEventParser()
+
+        // When
+        _ = parser.feed(Data("data: hello\n\n".utf8))
+        let finished = parser.finish()
+
+        // Then
+        #expect(finished == nil)
+    }
+}

--- a/Tests/RequestDLTests/Tasks/Sources/Raw Task/Download/Server-Sent Events/Models/ServerSentEventParserTests.swift
+++ b/Tests/RequestDLTests/Tasks/Sources/Raw Task/Download/Server-Sent Events/Models/ServerSentEventParserTests.swift
@@ -23,9 +23,11 @@ struct ServerSentEventParserTests {
         let events = parser.feed(Data("event: greeting\ndata: hello\n\n".utf8))
 
         // Then
-        #expect(events == [
-            ServerSentEvent(id: nil, event: "greeting", data: "hello", retry: nil)
-        ])
+        #expect(
+            events == [
+                ServerSentEvent(id: nil, event: "greeting", data: "hello", retry: nil)
+            ]
+        )
     }
 
     @Test
@@ -39,9 +41,11 @@ struct ServerSentEventParserTests {
 
         // Then
         #expect(first.isEmpty)
-        #expect(second == [
-            ServerSentEvent(id: nil, event: "message", data: "hello", retry: nil)
-        ])
+        #expect(
+            second == [
+                ServerSentEvent(id: nil, event: "message", data: "hello", retry: nil)
+            ]
+        )
     }
 
     @Test
@@ -55,9 +59,11 @@ struct ServerSentEventParserTests {
 
         // Then
         #expect(first.isEmpty)
-        #expect(second == [
-            ServerSentEvent(id: nil, event: "message", data: "hello\nworld", retry: nil)
-        ])
+        #expect(
+            second == [
+                ServerSentEvent(id: nil, event: "message", data: "hello\nworld", retry: nil)
+            ]
+        )
     }
 
     @Test
@@ -69,9 +75,11 @@ struct ServerSentEventParserTests {
         let events = parser.feed(Data("data: line one\ndata: line two\n\n".utf8))
 
         // Then
-        #expect(events == [
-            ServerSentEvent(id: nil, event: "message", data: "line one\nline two", retry: nil)
-        ])
+        #expect(
+            events == [
+                ServerSentEvent(id: nil, event: "message", data: "line one\nline two", retry: nil)
+            ]
+        )
     }
 
     @Test
@@ -83,9 +91,11 @@ struct ServerSentEventParserTests {
         let events = parser.feed(Data(": keep-alive\ndata: hello\n\n".utf8))
 
         // Then
-        #expect(events == [
-            ServerSentEvent(id: nil, event: "message", data: "hello", retry: nil)
-        ])
+        #expect(
+            events == [
+                ServerSentEvent(id: nil, event: "message", data: "hello", retry: nil)
+            ]
+        )
     }
 
     @Test
@@ -110,12 +120,16 @@ struct ServerSentEventParserTests {
         let second = parser.feed(Data("data: world\n\n".utf8))
 
         // Then
-        #expect(first == [
-            ServerSentEvent(id: "1", event: "message", data: "hello", retry: nil)
-        ])
-        #expect(second == [
-            ServerSentEvent(id: "1", event: "message", data: "world", retry: nil)
-        ])
+        #expect(
+            first == [
+                ServerSentEvent(id: "1", event: "message", data: "hello", retry: nil)
+            ]
+        )
+        #expect(
+            second == [
+                ServerSentEvent(id: "1", event: "message", data: "world", retry: nil)
+            ]
+        )
     }
 
     @Test
@@ -127,9 +141,11 @@ struct ServerSentEventParserTests {
         let events = parser.feed(Data("id: 1\u{0000}\ndata: hello\n\n".utf8))
 
         // Then
-        #expect(events == [
-            ServerSentEvent(id: nil, event: "message", data: "hello", retry: nil)
-        ])
+        #expect(
+            events == [
+                ServerSentEvent(id: nil, event: "message", data: "hello", retry: nil)
+            ]
+        )
     }
 
     @Test
@@ -141,9 +157,11 @@ struct ServerSentEventParserTests {
         let events = parser.feed(Data("retry: 3000\ndata: hello\n\n".utf8))
 
         // Then
-        #expect(events == [
-            ServerSentEvent(id: nil, event: "message", data: "hello", retry: 3000)
-        ])
+        #expect(
+            events == [
+                ServerSentEvent(id: nil, event: "message", data: "hello", retry: 3000)
+            ]
+        )
     }
 
     @Test
@@ -155,13 +173,15 @@ struct ServerSentEventParserTests {
         let events = parser.feed(Data("retry: soon\ndata: hello\n\n".utf8))
 
         // Then
-        #expect(events == [
-            ServerSentEvent(id: nil, event: "message", data: "hello", retry: nil)
-        ])
+        #expect(
+            events == [
+                ServerSentEvent(id: nil, event: "message", data: "hello", retry: nil)
+            ]
+        )
     }
 
     @Test
-    func feed_whenFieldHasNoColon_shouldTreatItAsFieldNameWithEmptyValue()  {
+    func feed_whenFieldHasNoColon_shouldTreatItAsFieldNameWithEmptyValue() {
         // Given
         var parser = ServerSentEventParser()
 
@@ -169,9 +189,11 @@ struct ServerSentEventParserTests {
         let events = parser.feed(Data("data\n\n".utf8))
 
         // Then
-        #expect(events == [
-            ServerSentEvent(id: nil, event: "message", data: "", retry: nil)
-        ])
+        #expect(
+            events == [
+                ServerSentEvent(id: nil, event: "message", data: "", retry: nil)
+            ]
+        )
     }
 
     @Test
@@ -183,10 +205,12 @@ struct ServerSentEventParserTests {
         let events = parser.feed(Data("data: first\n\ndata: second\n\n".utf8))
 
         // Then
-        #expect(events == [
-            ServerSentEvent(id: nil, event: "message", data: "first", retry: nil),
-            ServerSentEvent(id: nil, event: "message", data: "second", retry: nil)
-        ])
+        #expect(
+            events == [
+                ServerSentEvent(id: nil, event: "message", data: "first", retry: nil),
+                ServerSentEvent(id: nil, event: "message", data: "second", retry: nil),
+            ]
+        )
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Adds `ServerSentEvent` (`id`/`event`/`data`/`retry`) and `AsyncBytes.events()`, an `AsyncSequence` that parses `text/event-stream` framing incrementally on top of the already-public `AsyncBytes` byte stream.
- Handles the parts that are easy to get subtly wrong: a line split across two network chunks, a `CR`/`LF` terminator split across two chunks, multiple `data:` lines joined with `\n` into a single frame, `:`-prefixed comment lines, and a sticky `id`/reconnection `retry` across frames. The response body is never buffered in full.

This came out of a `feature-scout` pass over the repo (see the "Parser de Server-Sent Events sobre `AsyncBytes`" recommendation) that found `AsyncBytes` already does the hard streaming work, but no consumer-facing SSE framing existed, and every app would otherwise reimplement it (with subtly different bugs).

## Test plan
- [x] `ServerSentEventParserTests` -- 14 unit tests on the incremental parser directly (chunk-split lines, CRLF split across chunks, multi-line `data:` joins, comments, `id` persistence/reset via NUL byte, `retry` validation, no-`data:` frames don't dispatch, end-of-stream flush without a trailing blank line).
- [x] `AsyncBytesEventsTests` -- 2 tests wiring a real `AsyncBytes` (via `Internals.AsyncStream`, the same pattern used by existing `AsyncResponseCollectTests`) through `.events()` end to end.
- [x] `swift build` (all targets) and `swift test --filter "ServerSentEventParserTests|AsyncBytesEventsTests"` pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)