### PR TITLE
Widen streaming upload/session-task test timeouts under CI Simulator contention

### DIFF
--- a/Tests/RequestDLInternalsTests/Sources/Client/URLSession Client/InternalsURLSessionClientSessionTaskTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Client/URLSession Client/InternalsURLSessionClientSessionTaskTests.swift
@@ -228,10 +228,13 @@ struct InternalsURLSessionClientSessionTaskTests {
         continuation.finish()
 
         // Short, not the 60s default, so a real regression fails fast rather than hanging the
-        // suite -- 15s rather than 5s since CI's iOS/iPadOS/watchOS/visionOS Simulator runners are
-        // visibly slower under load than a local run or macOS's own (host-speed) job.
+        // suite -- 30s, not tighter, since CI's iOS/iPadOS/watchOS/visionOS Simulator runners are
+        // visibly slower under load than a local run or macOS's own (host-speed) job: confirmed
+        // directly, a genuine NSURLErrorTimedOut still surfaced on RequestConfigurationURLSessionClientUploadTests
+        // (the same real-upload/timeout shape as this suite) at a 15s margin under severe
+        // contention.
         var configuration = URLSessionConfiguration.ephemeral
-        configuration.timeoutIntervalForRequest = 15
+        configuration.timeoutIntervalForRequest = 30
         let client = try Internals.URLSessionClient(configuration: configuration)
 
         // When
@@ -284,10 +287,13 @@ struct InternalsURLSessionClientSessionTaskTests {
         continuation.finish()
 
         // Short, not the 60s default, so a real regression fails fast rather than hanging the
-        // suite -- 15s rather than 5s since CI's iOS/iPadOS/watchOS/visionOS Simulator runners are
-        // visibly slower under load than a local run or macOS's own (host-speed) job.
+        // suite -- 30s, not tighter, since CI's iOS/iPadOS/watchOS/visionOS Simulator runners are
+        // visibly slower under load than a local run or macOS's own (host-speed) job: confirmed
+        // directly, a genuine NSURLErrorTimedOut still surfaced on RequestConfigurationURLSessionClientUploadTests
+        // (the same real-upload/timeout shape as this suite) at a 15s margin under severe
+        // contention.
         var configuration = URLSessionConfiguration.ephemeral
-        configuration.timeoutIntervalForRequest = 15
+        configuration.timeoutIntervalForRequest = 30
         let client = try Internals.URLSessionClient(configuration: configuration)
 
         // When

--- a/Tests/RequestDLTests/Request/RequestConfigurationURLSessionClientUploadTests.swift
+++ b/Tests/RequestDLTests/Request/RequestConfigurationURLSessionClientUploadTests.swift
@@ -50,9 +50,11 @@ import Security
 ///
 /// A short `timeoutIntervalForRequest` is kept on these tests -- harmless now that they pass, and
 /// cheap insurance against a future regression hanging the suite for the default 60s instead of
-/// failing fast. 15s, not 5s: CI's iOS/iPadOS/watchOS/visionOS Simulator runners are visibly
+/// failing fast. 30s, not tighter: CI's iOS/iPadOS/watchOS/visionOS Simulator runners are visibly
 /// slower under load than a local run or macOS's own (host-speed) job in the same workflow --
-/// tight enough to still fail fast on a real regression, loose enough not to flake there.
+/// confirmed directly, a genuine `NSURLErrorTimedOut` still surfaced here at a 15s margin under
+/// severe contention across two separate platforms in the same CI run. Still tight enough to fail
+/// fast on a real regression, loose enough not to flake under normal contention.
 ///
 /// `.concurrent(watchdogAffectedPlatformConcurrencyLimit)`/`.nonFatalWatchdog`: real network I/O
 /// against a `LocalServer`, on the same simulator runners `WatchdogAffectedPlatformConcurrencyLimit.swift`
@@ -66,7 +68,7 @@ struct RequestConfigurationURLSessionClientUploadTests {
 
     private static var shortTimeoutConfiguration: URLSessionConfiguration {
         let configuration = URLSessionConfiguration.ephemeral
-        configuration.timeoutIntervalForRequest = 15
+        configuration.timeoutIntervalForRequest = 30
         return configuration
     }
 


### PR DESCRIPTION
## Summary

`RequestConfigurationURLSessionClientUploadTests`/`InternalsURLSessionClientSessionTaskTests` drive `Internals.URLSessionClient` directly with a deliberately short `timeoutIntervalForRequest`, as fail-fast insurance against a real regression hanging the suite for the default 60s. That margin was already bumped once (5s -> 15s, in the now-merged #290) after CI flaked on it -- it held for one run, then a genuine `NSURLErrorTimedOut` resurfaced on two different Simulator platforms (tvOS, watchOS) in the same CI run that also broke an unrelated branch's tests with the identical timeout shape, confirming CI's Simulator runners are under sustained, unusually severe contention right now.

- `RequestConfigurationURLSessionClientUploadTests.shortTimeoutConfiguration`: 15s -> 30s
- `InternalsURLSessionClientSessionTaskTests`' two matching inline configurations: 15s -> 30s

Still well under the 60s default, so a real regression (the client genuinely hanging) still fails fast -- just with more headroom against Simulator scheduler contention.

## Test plan
- [x] `swift build` -- clean
- [x] `swift test` -- full suite passing (1017 + 461 tests), no regressions
- [x] `swift format lint --recursive --strict Sources Tests` -- clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)