### PR TITLE
Fix never-mutated variable warnings

### DIFF
--- a/Sources/RequestDLInternals/Sources/Client/URLSession Client/Internals.URLSessionClient.swift
+++ b/Sources/RequestDLInternals/Sources/Client/URLSession Client/Internals.URLSessionClient.swift
@@ -73,7 +73,7 @@ extension Internals {
             proxy: Internals.Proxy? = nil,
             maximumConcurrentConnections: Int? = nil
         ) throws {
-            var configuration = configuration
+            let configuration = configuration
             // Explicitly `[:]`, not left untouched, when `proxy` is `nil` -- `URLSession` treats an
             // unset `connectionProxyDictionary` as "inherit whatever macOS's Network preferences
             // (or a device's Wi-Fi proxy config) currently say," unlike AsyncHTTPClient, which has

--- a/Tests/RequestDLInternalsTests/Sources/Client/URLSession Client/InternalsURLSessionClientSessionTaskTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Client/URLSession Client/InternalsURLSessionClientSessionTaskTests.swift
@@ -233,7 +233,7 @@ struct InternalsURLSessionClientSessionTaskTests {
         // directly, a genuine NSURLErrorTimedOut still surfaced on RequestConfigurationURLSessionClientUploadTests
         // (the same real-upload/timeout shape as this suite) at a 15s margin under severe
         // contention.
-        var configuration = URLSessionConfiguration.ephemeral
+        let configuration = URLSessionConfiguration.ephemeral
         configuration.timeoutIntervalForRequest = 30
         let client = try Internals.URLSessionClient(configuration: configuration)
 
@@ -292,7 +292,7 @@ struct InternalsURLSessionClientSessionTaskTests {
         // directly, a genuine NSURLErrorTimedOut still surfaced on RequestConfigurationURLSessionClientUploadTests
         // (the same real-upload/timeout shape as this suite) at a 15s margin under severe
         // contention.
-        var configuration = URLSessionConfiguration.ephemeral
+        let configuration = URLSessionConfiguration.ephemeral
         configuration.timeoutIntervalForRequest = 30
         let client = try Internals.URLSessionClient(configuration: configuration)
 

--- a/Tests/RequestDLInternalsTests/Sources/Session/Session Configuration/InternalsSessionConfigurationExecutorTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Session/Session Configuration/InternalsSessionConfigurationExecutorTests.swift
@@ -562,7 +562,7 @@ struct InternalsSessionConfigurationExecutorTests {
     @Test
     func requireExecutor_whenNIOTransportServicesPinnedAndCompatible_doesNotThrow() async throws {
         // Given
-        var configuration = Internals.Session.Configuration()
+        let configuration = Internals.Session.Configuration()
 
         // When / Then
         try configuration.requireExecutor(.nioTransportServices)


### PR DESCRIPTION
## Summary
- CI's log showed the "variable 'configuration' was never mutated; consider changing to 'let' constant" warning repeated after many different "Compiling X.swift" lines, which looked like dozens of instances -- but that's an artifact of how SwiftPM interleaves whole-module diagnostics with per-file progress output; the file name it just announced isn't necessarily where the warning is.
- A clean local build (`rm -rf .build && swift build --build-tests`) confirmed there are only **4 real occurrences**, all `var` locals that either never mutate at all, or only mutate properties of a reference-type value (`URLSessionConfiguration` is a class, so property sets go through the reference rather than rebinding the local) -- Swift only tracks rebinding of the `var` itself, so each becomes `let`.

## Test plan
- [x] `rm -rf .build && swift build --build-tests` -- 0 "never mutated" warnings remaining (was 4)
- [x] `swift test --filter "InternalsURLSessionClientSessionTaskTests|InternalsSessionConfigurationExecutorTests"` -- 36/36 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)