### PR TITLE
docs: document URLSession transport support in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 RequestDL is a Swift package designed to simplify the process of performing network requests. It provides a set of tools, including the `RequestTask` protocol, which supports different types of requests, including `DataTask`, `DownloadTask`, and `UploadTask`.
 
+Requests can run over Apple's `URLSession`, or over SwiftNIO -- either plain `NIO` or `NIOTransportServices` (Network.framework) -- letting you pick the transport that best fits each platform and deployment target. See [Choosing a transport](#choosing-a-transport) below.
+
 One of the key features of RequestDL is its support for specifying properties of a request, such as `Query`, `Payload`, and `Headers`, among others. You can also use `RequestTaskModifier` and `RequestTaskInterceptor` to process the response after the request is complete, allowing for actions like decoding, mapping, error handling based on status codes, and logging responses in the console.
 
 The `Property` protocol is another powerful feature that allows developers to implement custom properties to define various aspects of the request within a struct specification or using the `@PropertyBuilder`. This makes it easy to customize requests to meet specific needs.
@@ -60,6 +62,22 @@ try await DataTask {
 This code creates a `DataTask` with the `BaseURL` set to "google.com", a `HeaderGroup` containing the "Accept" set to "application/json", a "xxx-api-key" header set the API token, and a query parameter with the key "q" and the value "apple". It then sets the `logInConsole` property to true, which will print the response in the console when the request is completed. It also decodes the response into an instance of `GoogleResponse` and then ignores it.
 
 This is just a simple example of what RequestDL can do. Check out the documentation for more information on how to use it.
+
+## Choosing a transport
+
+By default, RequestDL picks the best available transport for the current platform and session configuration -- `URLSession` on Darwin platforms, falling back to SwiftNIO where needed. You can express a preference with `preferredExecutor(_:)`, which is honored whenever the rest of the session's configuration supports it, or pin a session to a specific transport with `requiredExecutor(_:)`, which fails the request instead of silently falling back if that transport can't satisfy the configuration:
+
+```swift
+try await DataTask {
+    BaseURL("api.example.com")
+
+    Session()
+        .requiredExecutor(.urlSession)
+}
+.result()
+```
+
+The available executors are `.urlSession` (Apple's `URLSession`), `.nioTransportServices` (SwiftNIO over Network.framework), and `.nio` (plain SwiftNIO, the universal fallback on every supported platform). See the [Session](https://swiftpackageindex.com/request-dl/request-dl-nio/main/documentation/requestdl/session) documentation for details.
 
 ## Versioning
 


### PR DESCRIPTION
## Summary
- Mentions `.urlSession` alongside SwiftNIO/`NIOTransportServices` in the README intro
- Adds a "Choosing a transport" section covering `preferredExecutor(_:)`/`requiredExecutor(_:)`, following up on the URLSession executor migration
- (Already applied, out of band) updated the repo description and added the `urlsession` topic on GitHub

## Test plan
- [x] Reviewed rendered Markdown for formatting/links

🤖 Generated with [Claude Code](https://claude.com/claude-code)