### PR TITLE
Add AcceptOnlyContentType modifier for response validation

### DIFF
--- a/Sources/RequestDL/Properties/Sources/Payloads/Payload/Models/ContentType.swift
+++ b/Sources/RequestDL/Properties/Sources/Payloads/Payload/Models/ContentType.swift
@@ -150,7 +150,7 @@ extension ContentType {
     }
 
     /// The media type, without parameters, normalised for comparison.
-    private var mediaType: String {
+    var mediaType: String {
         rawValue
             .prefix { $0 != ";" }
             .filter { $0 != " " }
@@ -166,5 +166,36 @@ extension ContentType {
                     .lowercased()
                     .hasPrefix("charset=")
             }
+    }
+}
+
+// MARK: - Matching
+
+extension ContentType {
+
+    /// Whether `other`'s media type is accepted by this one, treating `self` as the accepted
+    /// side and honoring the `*/*` and `type/*` wildcards, per RFC 9110's media-range rules.
+    ///
+    /// Parameters (e.g. `charset`) are ignored on both sides, same as ``mediaType``.
+    func matches(_ other: ContentType) -> Bool {
+        let accepted = mediaType
+        let candidate = other.mediaType
+
+        if accepted == "*/*" || accepted == candidate {
+            return true
+        }
+
+        let acceptedParts = accepted.split(separator: "/", maxSplits: 1)
+        let candidateParts = candidate.split(separator: "/", maxSplits: 1)
+
+        guard
+            acceptedParts.count == 2,
+            candidateParts.count == 2,
+            acceptedParts[1] == "*"
+        else {
+            return false
+        }
+
+        return acceptedParts[0] == candidateParts[0]
     }
 }

--- a/Sources/RequestDL/Tasks/Sources/Modifiers/Accept Only Content Type/Models/UnacceptableContentTypeError.swift
+++ b/Sources/RequestDL/Tasks/Sources/Modifiers/Accept Only Content Type/Models/UnacceptableContentTypeError.swift
@@ -1,0 +1,24 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+/// A error type representing a validation error due to an unexpected or missing `Content-Type`
+/// response header.
+///
+/// ```swift
+/// do {
+///     let result = try await DataTask {
+///         BaseURL("apple.com")
+///     }
+///     .acceptOnlyContentType(.json)
+///     .result()
+///     // use validated result
+/// } catch let error as UnacceptableContentTypeError<Data> {
+///     // handle validation error
+/// }
+/// ```
+public struct UnacceptableContentTypeError<Element: Sendable>: TaskError {
+
+    /// The data that caused the validation error.
+    public let data: Element
+}

--- a/Sources/RequestDL/Tasks/Sources/Modifiers/Accept Only Content Type/Modifiers.AcceptOnlyContentType.swift
+++ b/Sources/RequestDL/Tasks/Sources/Modifiers/Accept Only Content Type/Modifiers.AcceptOnlyContentType.swift
@@ -1,0 +1,91 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+extension Modifiers {
+
+    /// A modifier that accepts only a response whose `Content-Type` header matches one of a
+    /// specific set of ``ContentType``s.
+    ///
+    /// Unlike ``AcceptOnlyStatusCode``, this inspects the response body's declared type rather
+    /// than the status line, catching cases a 2xx status code alone would miss -- for example, a
+    /// proxy or CDN returning an HTML error page with a `200 OK` status.
+    ///
+    /// Matching ignores parameters (`charset`, etc.) on both sides and honors the `*/*` and
+    /// `type/*` wildcards from RFC 9110, so `.acceptOnlyContentType(.json)` also accepts a
+    /// response declaring `application/json; charset=utf-8`.
+    public struct AcceptOnlyContentType<Input: TaskResultPrimitive>: RequestTaskModifier {
+
+        // MARK: - Internal properties
+
+        let contentTypes: [ContentType]
+
+        // MARK: - Public methods
+
+        ///
+        /// Modifies a task to accept only a response whose `Content-Type` matches one of the
+        /// specified content types.
+        ///
+        /// - Parameter task: The task to modify.
+        /// - Returns: The modified task that accepts only the specified content types.
+        /// - Throws: An `UnacceptableContentTypeError` if the response has no `Content-Type`
+        /// header, or if it does not match any of the accepted content types.
+        ///
+        public func body(_ task: Content) async throws -> Input {
+            let result = try await task.result()
+
+            guard
+                contentTypes.isEmpty || matches(result.head.headers.first(name: "Content-Type"))
+            else {
+                throw UnacceptableContentTypeError<Content.Element>(data: result)
+            }
+
+            return result
+        }
+
+        // MARK: - Private methods
+
+        private func matches(_ rawContentType: String?) -> Bool {
+            guard let rawContentType else {
+                return false
+            }
+
+            let responseContentType = ContentType(rawContentType)
+
+            return contentTypes.contains {
+                $0.matches(responseContentType)
+            }
+        }
+    }
+}
+
+// MARK: - RequestTask extension
+
+extension RequestTask where Element: TaskResultPrimitive {
+
+    ///
+    /// Returns a modified task that accepts only a response whose `Content-Type` matches one of
+    /// the specified content types.
+    ///
+    /// - Parameter contentTypes: The content types to accept. An empty list accepts any response.
+    /// - Returns: A modified task that accepts only the specified content types.
+    ///
+    public func acceptOnlyContentType(
+        _ contentTypes: ContentType...
+    ) -> ModifiedRequestTask<Modifiers.AcceptOnlyContentType<Element>> {
+        acceptOnlyContentType(contentTypes)
+    }
+
+    ///
+    /// Returns a modified task that accepts only a response whose `Content-Type` matches one of
+    /// the specified content types.
+    ///
+    /// - Parameter contentTypes: The content types to accept. An empty array accepts any response.
+    /// - Returns: A modified task that accepts only the specified content types.
+    ///
+    public func acceptOnlyContentType(
+        _ contentTypes: [ContentType]
+    ) -> ModifiedRequestTask<Modifiers.AcceptOnlyContentType<Element>> {
+        modifier(Modifiers.AcceptOnlyContentType(contentTypes: contentTypes))
+    }
+}

--- a/Sources/RequestDL/Tasks/Sources/Modifiers/Modifiers.swift
+++ b/Sources/RequestDL/Tasks/Sources/Modifiers/Modifiers.swift
@@ -11,6 +11,11 @@
 /// - ``RequestDL/Modifiers/AcceptOnlyStatusCode``
 /// - ``RequestDL/InvalidStatusCodeError``
 ///
+/// ### Validating the content type
+///
+/// - ``RequestDL/Modifiers/AcceptOnlyContentType``
+/// - ``RequestDL/UnacceptableContentTypeError``
+///
 /// ### Performing action at specific status code
 ///
 /// - ``RequestDL/Modifiers/OnStatusCode``

--- a/Tests/RequestDLTests/Tasks/Sources/Modifiers/Accept Only Content Type/ModifiersAcceptOnlyContentTypeTests.swift
+++ b/Tests/RequestDLTests/Tasks/Sources/Modifiers/Accept Only Content Type/ModifiersAcceptOnlyContentTypeTests.swift
@@ -1,0 +1,149 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+import Testing
+
+@testable import RequestDL
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import struct Foundation.Data
+#endif
+
+struct ModifiersAcceptOnlyContentTypeTests {
+
+    @Test
+    func exactMatchIsAccepted() async throws {
+        // Given / When
+        let result = try await MockedTask(
+            headers: ["Content-Type": "application/json"],
+            content: { BaseURL("localhost") }
+        )
+        .collectData()
+        .acceptOnlyContentType(.json)
+        .result()
+
+        // Then
+        #expect(result.head.headers.first(name: "Content-Type") == "application/json")
+    }
+
+    @Test
+    func charsetParameterIsIgnored() async throws {
+        // Given / When
+        let result = try await MockedTask(
+            headers: ["Content-Type": "application/json; charset=utf-8"],
+            content: { BaseURL("localhost") }
+        )
+        .collectData()
+        .acceptOnlyContentType(.json)
+        .result()
+
+        // Then
+        #expect(result.head.headers.first(name: "Content-Type") == "application/json; charset=utf-8")
+    }
+
+    @Test
+    func subtypeWildcardIsAccepted() async throws {
+        // Given / When
+        let result = try await MockedTask(
+            headers: ["Content-Type": "image/png"],
+            content: { BaseURL("localhost") }
+        )
+        .collectData()
+        .acceptOnlyContentType("image/*")
+        .result()
+
+        // Then
+        #expect(result.head.headers.first(name: "Content-Type") == "image/png")
+    }
+
+    @Test
+    func fullWildcardIsAccepted() async throws {
+        // Given / When
+        let result = try await MockedTask(
+            headers: ["Content-Type": "text/html"],
+            content: { BaseURL("localhost") }
+        )
+        .collectData()
+        .acceptOnlyContentType("*/*")
+        .result()
+
+        // Then
+        #expect(result.head.headers.first(name: "Content-Type") == "text/html")
+    }
+
+    @Test
+    func emptyContentTypesAcceptsAnyResponse() async throws {
+        // Given / When
+        let result = try await MockedTask(
+            headers: ["Content-Type": "text/html"],
+            content: { BaseURL("localhost") }
+        )
+        .collectData()
+        .acceptOnlyContentType([])
+        .result()
+
+        // Then
+        #expect(result.head.headers.first(name: "Content-Type") == "text/html")
+    }
+
+    @Test
+    func mismatchedContentTypeThrows() async throws {
+        // Given
+        var thrown: UnacceptableContentTypeError<TaskResult<Data>>?
+
+        // When
+        do {
+            _ = try await MockedTask(
+                headers: ["Content-Type": "text/html"],
+                content: { BaseURL("localhost") }
+            )
+            .collectData()
+            .acceptOnlyContentType(.json)
+            .result()
+        } catch let error as UnacceptableContentTypeError<TaskResult<Data>> {
+            thrown = error
+        }
+
+        // Then
+        #expect(thrown?.data.head.headers.first(name: "Content-Type") == "text/html")
+    }
+
+    @Test
+    func missingContentTypeThrows() async throws {
+        // Given
+        var thrown: UnacceptableContentTypeError<TaskResult<Data>>?
+
+        // When
+        do {
+            _ = try await MockedTask(
+                content: { BaseURL("localhost") }
+            )
+            .collectData()
+            .acceptOnlyContentType(.json)
+            .result()
+        } catch let error as UnacceptableContentTypeError<TaskResult<Data>> {
+            thrown = error
+        }
+
+        // Then
+        #expect(thrown != nil)
+    }
+
+    @Test
+    func multipleAcceptedContentTypes() async throws {
+        // Given / When
+        let result = try await MockedTask(
+            headers: ["Content-Type": "application/xml"],
+            content: { BaseURL("localhost") }
+        )
+        .collectData()
+        .acceptOnlyContentType(.json, .xml)
+        .result()
+
+        // Then
+        #expect(result.head.headers.first(name: "Content-Type") == "application/xml")
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `Modifiers.AcceptOnlyContentType` / `RequestTask.acceptOnlyContentType(_:)`, a response modifier that validates the `Content-Type` response header against a set of accepted `ContentType` values — a status code alone (`AcceptOnlyStatusCode`) can't catch a `200 OK` that's actually an HTML error page from a proxy/CDN.
- Matching honors the `*/*` and `type/*` wildcards from RFC 9110 and ignores parameters (`charset`, etc.) on both sides, via a new `ContentType.matches(_:)` (internal `mediaType` widened from `private` to internal to support it).
- Throws `UnacceptableContentTypeError<Element>` (mirrors `InvalidStatusCodeError`) when the response has no `Content-Type` header or it matches none of the accepted types.

## Test plan
- [x] `swift test --filter RequestDLTests.ModifiersAcceptOnlyContentTypeTests` — 8/8 passing (exact match, charset-ignored match, subtype wildcard, full wildcard, empty-list-accepts-any, mismatch throws, missing header throws, multiple accepted types)
- [x] `swift test --filter RequestDLTests.ModifiersStatusCodeTests` — no regressions
- [x] `swift build`
- [x] `swift format lint --recursive --strict` on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)