### PR TITLE
Add decodeIfPresent to treat an empty response body as nil

### DIFF
--- a/Sources/RequestDL/Tasks/Sources/Modifiers/Decode/Modifiers.DecodeIfPresent.swift
+++ b/Sources/RequestDL/Tasks/Sources/Modifiers/Decode/Modifiers.DecodeIfPresent.swift
@@ -1,0 +1,117 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import struct Foundation.Data
+import class Foundation.JSONDecoder
+#endif
+
+extension Modifiers {
+
+    ///
+    /// A `RequestTaskModifier` that decodes the data returned by the `RequestTask` into an
+    /// optional instance of a specified type, treating an empty body as `nil` instead of
+    /// attempting to run it through `JSONDecoder`.
+    ///
+    /// Unlike ``Decode``, which always hands the raw bytes to `JSONDecoder` -- and therefore
+    /// fails with an opaque "the given data was not valid JSON" on an empty body -- this is meant
+    /// for endpoints that may legitimately answer with no body at all, such as a `204 No Content`
+    /// or `205 Reset Content` response to a `DELETE`/`PUT`.
+    ///
+    public struct DecodeIfPresent<Input: Sendable, Element: Decodable & Sendable, Output: Sendable>: RequestTaskModifier
+    {
+
+        // MARK: - Internal properties
+
+        let type: Element.Type
+        let decoder: JSONDecoder
+
+        // MARK: - Private properties
+
+        fileprivate let data: @Sendable (Input) -> Data
+        fileprivate let output: @Sendable (Input, Element?) -> Output
+
+        // MARK: - Public methods
+
+        ///
+        /// Decodes the data of the specified `RequestTask` instance into an instance of the
+        /// `Element` type specified during initialization, or `nil` when the body is empty.
+        ///
+        /// - Parameter task: The `RequestTask` instance whose data is to be decoded.
+        /// - Returns: A `Output` instance containing the decoded data, or `nil` when the body was
+        /// empty.
+        /// - Throws: If the body is non-empty and the decoding operation fails.
+        ///
+        public func body(_ task: Content) async throws -> Output {
+            let result = try await task.result()
+            let bytes = data(result)
+
+            guard !bytes.isEmpty else {
+                return output(result, nil)
+            }
+
+            return output(result, try decoder.decode(type, from: bytes))
+        }
+    }
+}
+
+// MARK: - RequestTask extensions
+
+extension RequestTask {
+
+    ///
+    /// Returns a new instance of `ModifiedTask` that applies the `DecodeIfPresent` modifier to
+    /// the original `RequestTask`, decoding an empty body as `nil` rather than throwing.
+    ///
+    /// - Parameters:
+    ///    - type: The type to decode the result data into when the body is non-empty.
+    ///    - decoder: The `JSONDecoder` instance to use for the decoding operation.
+    /// - Returns: A new instance of `ModifiedTask` with the `DecodeIfPresent` modifier applied.
+    ///
+    public func decodeIfPresent<T: Decodable>(
+        _ type: T.Type,
+        decoder: JSONDecoder = .init()
+    ) -> ModifiedRequestTask<Modifiers.DecodeIfPresent<Element, T, TaskResult<T?>>>
+    where Element == TaskResult<Data> {
+        modifier(
+            Modifiers.DecodeIfPresent(
+                type: type,
+                decoder: decoder,
+                data: \.payload,
+                output: {
+                    TaskResult(
+                        head: $0.head,
+                        payload: $1
+                    )
+                }
+            )
+        )
+    }
+
+    ///
+    /// Returns a new instance of `ModifiedTask` that applies the `DecodeIfPresent` modifier to
+    /// the original `RequestTask`, decoding an empty body as `nil` rather than throwing.
+    ///
+    /// - Parameters:
+    ///    - type: The type to decode the data into when the body is non-empty.
+    ///    - decoder: The `JSONDecoder` instance to use for the decoding operation.
+    /// - Returns: A new instance of `ModifiedTask` with the `DecodeIfPresent` modifier applied.
+    ///
+    public func decodeIfPresent<T: Decodable>(
+        _ type: T.Type,
+        decoder: JSONDecoder = .init()
+    ) -> ModifiedRequestTask<Modifiers.DecodeIfPresent<Element, T, T?>>
+    where Element == Data {
+        modifier(
+            Modifiers.DecodeIfPresent(
+                type: type,
+                decoder: decoder,
+                data: { $0 },
+                output: { $1 }
+            )
+        )
+    }
+}

--- a/Sources/RequestDL/Tasks/Sources/Modifiers/Modifiers.swift
+++ b/Sources/RequestDL/Tasks/Sources/Modifiers/Modifiers.swift
@@ -18,6 +18,7 @@
 /// ### Handling the response
 ///
 /// - ``RequestDL/Modifiers/Decode``
+/// - ``RequestDL/Modifiers/DecodeIfPresent``
 /// - ``RequestDL/Modifiers/ExtractPayload``
 /// - ``RequestDL/Modifiers/KeyPath``
 ///

--- a/Tests/RequestDLTests/Tasks/Sources/Modifiers/Decode/ModifiersDecodeIfPresentTests.swift
+++ b/Tests/RequestDLTests/Tasks/Sources/Modifiers/Decode/ModifiersDecodeIfPresentTests.swift
@@ -1,0 +1,118 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+import Testing
+
+@testable import RequestDL
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import struct Foundation.Data
+import class Foundation.JSONEncoder
+#endif
+
+struct ModifiersDecodeIfPresentTests {
+
+    struct MockModel: Codable, Equatable {
+        let id: Int
+    }
+
+    @Test
+    func emptyBodyDecodesAsNil() async throws {
+        // Given / When
+        let result = try await MockedTask(
+            status: .init(code: 204, reason: "No Content"),
+            content: {
+                BaseURL("localhost")
+                Payload(data: Data())
+            }
+        )
+        .collectData()
+        .extractPayload()
+        .decodeIfPresent(MockModel.self)
+        .result()
+
+        // Then
+        #expect(result == nil)
+    }
+
+    @Test
+    func missingPayloadDecodesAsNil() async throws {
+        // Given / When
+        let result = try await MockedTask(
+            status: .init(code: 205, reason: "Reset Content"),
+            content: { BaseURL("localhost") }
+        )
+        .collectData()
+        .extractPayload()
+        .decodeIfPresent(MockModel.self)
+        .result()
+
+        // Then
+        #expect(result == nil)
+    }
+
+    @Test
+    func nonEmptyBodyDecodesTheValue() async throws {
+        // Given
+        let mock = MockModel(id: 42)
+        let data = try JSONEncoder().encode(mock)
+
+        // When
+        let result = try await MockedTask(content: {
+            BaseURL("localhost")
+            Payload(data: data)
+        })
+        .collectData()
+        .extractPayload()
+        .decodeIfPresent(MockModel.self)
+        .result()
+
+        // Then
+        #expect(result == mock)
+    }
+
+    @Test
+    func invalidNonEmptyBodyStillThrows() async throws {
+        // Given
+        var thrown = false
+
+        // When
+        do {
+            _ = try await MockedTask(content: {
+                BaseURL("localhost")
+                Payload(data: Data("not json".utf8))
+            })
+            .collectData()
+            .extractPayload()
+            .decodeIfPresent(MockModel.self)
+            .result()
+        } catch is DecodingError {
+            thrown = true
+        }
+
+        // Then
+        #expect(thrown)
+    }
+
+    @Test
+    func preservesTaskResultHeadWhenEmpty() async throws {
+        // Given / When
+        let result = try await MockedTask(
+            status: .init(code: 204, reason: "No Content"),
+            content: {
+                BaseURL("localhost")
+                Payload(data: Data())
+            }
+        )
+        .collectData()
+        .decodeIfPresent(MockModel.self)
+        .result()
+
+        // Then
+        #expect(result.head.status.code == 204)
+        #expect(result.payload == nil)
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `Modifiers.DecodeIfPresent` / `RequestTask.decodeIfPresent(_:decoder:)`, an explicit, additive sibling to `.decode(_:)` that treats an empty response body as `nil` instead of handing it to `JSONDecoder` and surfacing an opaque "the given data was not valid JSON" error.
- Targets the common `204 No Content` / `205 Reset Content` case on `DELETE`/`PUT` endpoints — the package already models both status codes (`StatusCode.noContent`, `.resetContent`) but no existing modifier connects them to decoding.
- Opt-in by design: existing `.decode(_:)` call sites are untouched (new sibling type, no shared code path), and a non-empty-but-invalid body still throws `DecodingError` exactly as before.

## Test plan
- [x] `swift test --filter RequestDLTests.ModifiersDecodeIfPresentTests` — 5/5 passing (empty body → nil, missing payload → nil, valid body decodes, invalid non-empty body still throws, `TaskResult` head preserved on empty)
- [x] `swift test --filter RequestDLTests.ModifiersDecodeTests` — no regressions on the existing `Decode` modifier
- [x] `swift build`
- [x] `swift format lint --recursive --strict` on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)