### PR TITLE
Add ArrayEncodingStrategy.brackets

### DIFF
--- a/Sources/RequestDL/Properties/Sources/URL/Query/Models/Strategies/URLEncoder.ArrayEncodingStrategy.swift
+++ b/Sources/RequestDL/Properties/Sources/URL/Query/Models/Strategies/URLEncoder.ArrayEncodingStrategy.swift
@@ -12,7 +12,6 @@ extension URLEncoder {
 
         /// Encodes the index as a fixed, empty pair of square brackets, e.g. `[]`, the same for
         /// every element -- unlike ``subscripted``, the brackets never carry the actual index.
-        /// Matches Alamofire's `ArrayEncoding.brackets`, its own default.
         case brackets
 
         /// Encodes the index in square brackets, e.g. `[0]`.

--- a/Sources/RequestDL/Properties/Sources/URL/Query/Models/Strategies/URLEncoder.ArrayEncodingStrategy.swift
+++ b/Sources/RequestDL/Properties/Sources/URL/Query/Models/Strategies/URLEncoder.ArrayEncodingStrategy.swift
@@ -10,6 +10,11 @@ extension URLEncoder {
         /// Uses no index in the encoding. This is the default.
         case droppingIndex
 
+        /// Encodes the index as a fixed, empty pair of square brackets, e.g. `[]`, the same for
+        /// every element -- unlike ``subscripted``, the brackets never carry the actual index.
+        /// Matches Alamofire's `ArrayEncoding.brackets`, its own default.
+        case brackets
+
         /// Encodes the index in square brackets, e.g. `[0]`.
         case subscripted
 
@@ -26,6 +31,8 @@ extension URLEncoder {
             switch self {
             case .droppingIndex:
                 try encodeDroppingIndex(index, in: encoder)
+            case .brackets:
+                try encodeBrackets(index, in: encoder)
             case .subscripted:
                 try encodeSubscripted(index, in: encoder)
             case .accessMember:
@@ -40,6 +47,11 @@ extension URLEncoder {
         private func encodeDroppingIndex(_ index: Int, in encoder: URLEncoder.Encoder) throws {
             var container = encoder.keyContainer()
             try container.encode("")
+        }
+
+        private func encodeBrackets(_ index: Int, in encoder: URLEncoder.Encoder) throws {
+            var container = encoder.keyContainer()
+            try container.encode("[]")
         }
 
         private func encodeSubscripted(_ index: Int, in encoder: URLEncoder.Encoder) throws {

--- a/Sources/RequestDL/Properties/Sources/URL/Query/Models/Strategies/URLEncoder.DataEncodingStrategy.swift
+++ b/Sources/RequestDL/Properties/Sources/URL/Query/Models/Strategies/URLEncoder.DataEncodingStrategy.swift
@@ -16,12 +16,6 @@ extension URLEncoder {
         /// Encodes the data as a Base64-encoded string. This is the default.
         case base64
 
-        /// Defers to `Data`'s own `Encodable` conformance, which is itself a Base64-encoded
-        /// string -- so this produces byte-for-byte the same output as ``base64``. Exists for
-        /// parity with Alamofire's `DataEncoding.deferredToData`, which is the same alias there
-        /// for the same reason.
-        case deferredToData
-
         /// Encodes the data using a custom closure that takes a `Data` and an `Encoder` as input
         /// parameters and throws an error.
         case custom(@Sendable (Data, Encoder) throws -> Void)
@@ -30,7 +24,7 @@ extension URLEncoder {
 
         func encode(_ data: Data, in encoder: URLEncoder.Encoder) throws {
             switch self {
-            case .base64, .deferredToData:
+            case .base64:
                 try encodeBase64(data, in: encoder)
             case .custom(let closure):
                 try closure(data, encoder)

--- a/Sources/RequestDL/Properties/Sources/URL/Query/Models/Strategies/URLEncoder.DataEncodingStrategy.swift
+++ b/Sources/RequestDL/Properties/Sources/URL/Query/Models/Strategies/URLEncoder.DataEncodingStrategy.swift
@@ -16,6 +16,12 @@ extension URLEncoder {
         /// Encodes the data as a Base64-encoded string. This is the default.
         case base64
 
+        /// Defers to `Data`'s own `Encodable` conformance, which is itself a Base64-encoded
+        /// string -- so this produces byte-for-byte the same output as ``base64``. Exists for
+        /// parity with Alamofire's `DataEncoding.deferredToData`, which is the same alias there
+        /// for the same reason.
+        case deferredToData
+
         /// Encodes the data using a custom closure that takes a `Data` and an `Encoder` as input
         /// parameters and throws an error.
         case custom(@Sendable (Data, Encoder) throws -> Void)
@@ -24,7 +30,7 @@ extension URLEncoder {
 
         func encode(_ data: Data, in encoder: URLEncoder.Encoder) throws {
             switch self {
-            case .base64:
+            case .base64, .deferredToData:
                 try encodeBase64(data, in: encoder)
             case .custom(let closure):
                 try closure(data, encoder)

--- a/Tests/RequestDLTests/Properties/Sources/URL/Query/Models/URLEncoderTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/URL/Query/Models/URLEncoderTests.swift
@@ -422,6 +422,29 @@ struct URLEncoderTests {
     }
 
     @Test
+    func encoder_whenArrayWithBrackets() throws {
+        let urlEncoder = URLEncoder()
+        // Given
+
+        let key = "foo"
+        let value = ["a", "ab", "abc", "abcd"]
+
+        urlEncoder.arrayEncodingStrategy = .brackets
+
+        // When
+        let sut = try urlEncoder.encode(value, forKey: key)
+
+        // Then
+        #expect(
+            sut
+                == value.map {
+                    let key = "\(key)[]".addingRFC3986PercentEncoding()
+                    return "\(key)=\($0)"
+                }.joined(separator: "&")
+        )
+    }
+
+    @Test
     func encoder_whenArrayWithSubscripted() throws {
         let urlEncoder = URLEncoder()
         // Given
@@ -673,6 +696,27 @@ struct URLEncoderTests {
         // Given
         let key = "foo"
         let value = await Data.randomData(length: 64)
+
+        // When
+        let sut = try urlEncoder.encode(value, forKey: key)
+
+        // Then
+        let expectedValue =
+            value
+            .base64EncodedString()
+            .addingRFC3986PercentEncoding()
+
+        #expect(sut == "\(key)=\(expectedValue)")
+    }
+
+    @Test
+    func encoder_whenDataWithDeferredToData() async throws {
+        let urlEncoder = URLEncoder()
+        // Given
+        let key = "foo"
+        let value = await Data.randomData(length: 64)
+
+        urlEncoder.dataEncodingStrategy = .deferredToData
 
         // When
         let sut = try urlEncoder.encode(value, forKey: key)

--- a/Tests/RequestDLTests/Properties/Sources/URL/Query/Models/URLEncoderTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/URL/Query/Models/URLEncoderTests.swift
@@ -710,27 +710,6 @@ struct URLEncoderTests {
     }
 
     @Test
-    func encoder_whenDataWithDeferredToData() async throws {
-        let urlEncoder = URLEncoder()
-        // Given
-        let key = "foo"
-        let value = await Data.randomData(length: 64)
-
-        urlEncoder.dataEncodingStrategy = .deferredToData
-
-        // When
-        let sut = try urlEncoder.encode(value, forKey: key)
-
-        // Then
-        let expectedValue =
-            value
-            .base64EncodedString()
-            .addingRFC3986PercentEncoding()
-
-        #expect(sut == "\(key)=\(expectedValue)")
-    }
-
-    @Test
     func encoder_whenDataWithCustom() async throws {
         let urlEncoder = URLEncoder()
         // Given


### PR DESCRIPTION
## Summary
- Adds `ArrayEncodingStrategy.brackets` to `URLEncoder`: a fixed, empty `[]` per element (`foo[]=1&foo[]=2`), the same for every element regardless of its index. `URLEncoder`'s own default stays `.droppingIndex` (`foo=1&foo=2`) — unchanged, so this is purely additive with no behavior change for existing callers.
- Was already reachable through `.custom`; this gives it a name for discoverability, rounding out `ArrayEncodingStrategy` alongside `.droppingIndex`, `.subscripted`, and `.accessMember`.

## Test plan
- [x] `swift test --filter RequestDLTests.URLEncoderTests` — 57/57 passing (new: `encoder_whenArrayWithBrackets`)
- [x] `swift build`
- [x] `swift format lint --recursive --strict` on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)