### PR TITLE
Add AcceptLanguageHeader and LanguageTag

### DIFF
--- a/Sources/RequestDL/Properties/Sources/Headers/Headers/Accept Language/AcceptLanguageHeader.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Headers/Accept Language/AcceptLanguageHeader.swift
@@ -1,0 +1,98 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+import RequestDLInternals
+
+#if canImport(Darwin)
+import struct Foundation.Locale
+#endif
+
+/// Sets the `Accept-Language` header in the request.
+///
+/// ``RequestDL/AcceptLanguageHeader`` provides two ways to build the header value:
+///
+/// - An explicit, ordered list of ``LanguageTag``s, most preferred first:
+///
+/// ```swift
+/// AcceptLanguageHeader("pt-BR", "en-US")
+/// ```
+///
+/// - On Darwin, the system's preferred languages (`Locale.preferredLanguages`), via the empty
+/// initializer ``RequestDL/AcceptLanguageHeader/init()``. This is a separate, opt-in
+/// initializer rather than something applied implicitly: not every app should track the
+/// system's language — one that pins its own in-app language regardless of Settings has no use
+/// for it.
+///
+/// Either way, each language is assigned a descending `q` weight, per
+/// [RFC 7231 §5.3.5](https://tools.ietf.org/html/rfc7231#section-5.3.5).
+public struct AcceptLanguageHeader: Property {
+
+    // MARK: - Public properties
+
+    /// Returns an exception since `Never` is a type that can never be constructed.
+    public var body: Never {
+        bodyException()
+    }
+
+    // MARK: - Private properties
+
+    private let value: String
+
+    // MARK: - Inits
+
+    ///
+    /// Initializes a new instance for an explicit, ordered list of ``LanguageTag``s.
+    ///
+    /// - Parameters:
+    ///   - languageTag: The most preferred language.
+    ///   - rest: Additional languages, in decreasing order of preference.
+    ///
+    public init(_ languageTag: LanguageTag, _ rest: LanguageTag...) {
+        value = Self.weighted([languageTag] + rest)
+    }
+
+    #if canImport(Darwin)
+    ///
+    /// Initializes a new instance from the system's preferred languages
+    /// (`Locale.preferredLanguages`), taking up to the top 6.
+    ///
+    /// - Important: Darwin only. `Locale.preferredLanguages` reads the user's Settings, which
+    /// is not always what an app's outgoing requests should advertise.
+    ///
+    public init() {
+        value = Self.weighted(Locale.preferredLanguages.prefix(6).map(LanguageTag.init))
+    }
+    #endif
+
+    // MARK: - Public static methods
+
+    /// This method is used internally and should not be called directly.
+    public static func _makeProperty(
+        property: _GraphValue<AcceptLanguageHeader>,
+        inputs: _PropertyInputs
+    ) async throws -> _PropertyOutputs {
+        property.assertPathway()
+        return .leaf(
+            HeaderNode(
+                key: "Accept-Language",
+                value: property.value,
+                strategy: inputs.environment.headerStrategy,
+                separator: inputs.environment.headerSeparator
+            )
+        )
+    }
+
+    // MARK: - Private static methods
+
+    /// Joins `tags` into a single `Accept-Language` value, assigning each a descending `q`
+    /// weight: `1.0`, `0.9`, `0.8`, ... floored at `0.1` so a longer list never reaches zero.
+    private static func weighted(_ tags: [LanguageTag]) -> String {
+        tags.enumerated()
+            .map { index, tag in
+                let quality = max(0.1, 1 - Double(index) * 0.1)
+                return "\(tag.rawValue);q=\(quality.fixed(fractionDigits: 1))"
+            }
+            .joined(separator: ", ")
+    }
+}

--- a/Sources/RequestDL/Properties/Sources/Headers/Headers/Accept Language/Models/LanguageTag.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Headers/Accept Language/Models/LanguageTag.swift
@@ -1,0 +1,53 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+/// A BCP 47 language tag, such as `"en"`, `"en-US"` or `"pt-BR"`.
+///
+/// Used to specify one entry of an ``AcceptLanguageHeader``. Unlike ``ContentType`` or
+/// ``Charset``, there is no static registry of known values here: languages are open-ended,
+/// so every `LanguageTag` comes from a string.
+///
+/// ```swift
+/// let languageTag: LanguageTag = "pt-BR"
+/// ```
+public struct LanguageTag: Sendable, Hashable {
+
+    // MARK: - Internal properties
+
+    let rawValue: String
+
+    // MARK: - Inits
+
+    ///
+    /// Initializes a `LanguageTag` instance with a given string value.
+    ///
+    /// - Parameter rawValue: The BCP 47 language tag, e.g. `"en"`, `"en-US"`, `"pt-BR"`.
+    ///
+    public init<S: StringProtocol>(_ rawValue: S) {
+        self.rawValue = String(rawValue)
+    }
+}
+
+// MARK: - ExpressibleByStringLiteral
+
+extension LanguageTag: ExpressibleByStringLiteral {
+
+    ///
+    /// Initializes a `LanguageTag` instance using a string literal.
+    ///
+    /// - Parameter value: A string literal representing the language tag.
+    ///
+    public init(stringLiteral value: StringLiteralType) {
+        self.rawValue = value
+    }
+}
+
+// MARK: - LosslessStringConvertible
+
+extension LanguageTag: LosslessStringConvertible {
+
+    public var description: String {
+        rawValue
+    }
+}

--- a/Tests/RequestDLTests/Properties/Sources/Headers/Headers/Accept Language/AcceptLanguageHeaderTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Headers/Headers/Accept Language/AcceptLanguageHeaderTests.swift
@@ -1,0 +1,112 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+import RequestDLInternals
+import Testing
+
+@testable import RequestDL
+
+#if canImport(Darwin)
+import struct Foundation.Locale
+#endif
+
+struct AcceptLanguageHeaderTests {
+
+    @Test
+    func singleLanguageGetsFullWeight() async throws {
+        // Given
+        let resolved = try await resolve(
+            TestProperty {
+                AcceptLanguageHeader("pt-BR")
+            }
+        )
+
+        // Then
+        #expect(resolved.requestConfiguration.headers["Accept-Language"] == ["pt-BR;q=1.0"])
+    }
+
+    @Test
+    func multipleLanguagesDescendInWeightByPosition() async throws {
+        // Given
+        let resolved = try await resolve(
+            TestProperty {
+                AcceptLanguageHeader("pt-BR", "en-US", "es")
+            }
+        )
+
+        // Then
+        #expect(
+            resolved.requestConfiguration.headers["Accept-Language"] == [
+                "pt-BR;q=1.0, en-US;q=0.9, es;q=0.8"
+            ]
+        )
+    }
+
+    @Test
+    func weightNeverDropsBelowTheFloor() async throws {
+        // Given
+        let tags = (0...10).map { LanguageTag("l\($0)") }
+
+        // When
+        let resolved = try await resolve(
+            TestProperty {
+                AcceptLanguageHeader(
+                    tags[0],
+                    tags[1],
+                    tags[2],
+                    tags[3],
+                    tags[4],
+                    tags[5],
+                    tags[6],
+                    tags[7],
+                    tags[8],
+                    tags[9],
+                    tags[10]
+                )
+            }
+        )
+
+        // Then
+        // Index 9 already floors at 0.1 (1 - 9 * 0.1); index 10 would go negative without the
+        // floor, so both land on the same weight.
+        let value = try #require(resolved.requestConfiguration.headers["Accept-Language"]?.first)
+        #expect(value.hasSuffix("l9;q=0.1, l10;q=0.1"))
+    }
+
+    #if canImport(Darwin)
+    @Test
+    func defaultValueUsesTheSystemsPreferredLanguages() async throws {
+        // Given
+        // Independently reconstructs the expected value from the same public inputs
+        // (`Locale.preferredLanguages`) and the documented weighting rule, rather than reusing
+        // any private implementation detail of `AcceptLanguageHeader`.
+        let expectedValue = Locale.preferredLanguages.prefix(6)
+            .enumerated()
+            .map { index, tag in
+                let quality = max(0.1, 1 - Double(index) * 0.1)
+                return "\(tag);q=\(quality.fixed(fractionDigits: 1))"
+            }
+            .joined(separator: ", ")
+
+        // When
+        let resolved = try await resolve(
+            TestProperty {
+                AcceptLanguageHeader()
+            }
+        )
+
+        // Then
+        #expect(resolved.requestConfiguration.headers["Accept-Language"] == [expectedValue])
+    }
+    #endif
+
+    @Test
+    func neverBody() async throws {
+        // Given
+        let property = AcceptLanguageHeader("en")
+
+        // Then
+        try await assertNever(property.body)
+    }
+}

--- a/Tests/RequestDLTests/Properties/Sources/Headers/Headers/Accept Language/Models/LanguageTagTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Headers/Headers/Accept Language/Models/LanguageTagTests.swift
@@ -1,0 +1,33 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+import Testing
+
+@testable import RequestDL
+
+struct LanguageTagTests {
+
+    @Test
+    func stringLiteralInitMatchesRawValueInit() {
+        // Given
+        let literal: LanguageTag = "pt-BR"
+
+        // Then
+        #expect(literal == LanguageTag("pt-BR"))
+    }
+
+    @Test
+    func initAcceptsAnyStringProtocol() {
+        // Given
+        let substring = "en-US en-GB".split(separator: " ").first!
+
+        // Then
+        #expect(LanguageTag(substring) == "en-US")
+    }
+
+    @Test
+    func descriptionReturnsTheRawValue() {
+        #expect(LanguageTag("pt-BR").description == "pt-BR")
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `LanguageTag`, an open (BCP 47) string-backed value type for `Accept-Language` entries, mirroring `ContentType`'s shape (`ExpressibleByStringLiteral` + `LosslessStringConvertible`, no fixed case list since languages are open-ended).
- Adds `AcceptLanguageHeader`, a `Property` that sets `Accept-Language` either from an explicit ordered list (`AcceptLanguageHeader("pt-BR", "en-US")`) or, Darwin-only, from `Locale.preferredLanguages` via the empty initializer.
- Each language gets a descending `q` weight per RFC 7231 §5.3.5 (`1.0`, `0.9`, `0.8`, ... floored at `0.1`), computed the same way for both initializers.

## Design notes
- The Darwin-only `init()` is intentionally separate from the explicit initializer rather than an implicit default: not every app should mirror the system's language preference (e.g. an app that pins its own in-app language), so nothing is applied unless declared.
- `AcceptEncodingHeader` (the sibling header discussed alongside this one) is deliberately out of scope here — this package's default transport (AsyncHTTPClient) only decompresses gzip/deflate, decompression is off by default, and there's no Brotli support, so a smart default there would risk advertising a coding the client can't actually decode. That needs its own follow-up.

## Test plan
- [x] `swift build` — clean build
- [x] `swift test --filter "AcceptLanguageHeaderTests|LanguageTagTests"` — 8/8 passing
- [x] `swift test --filter "HeaderTests|HeadersTests|AcceptHeaderTests|AcceptCharsetHeaderTests|UserAgentHeaderTests"` — 73/73 passing, no regressions
- [x] `swift format lint` clean on the new files

🤖 Generated with [Claude Code](https://claude.com/claude-code)