### PR TITLE
Add AcceptEncodingHeader and ContentCoding

### DIFF
--- a/Sources/RequestDL/Properties/Sources/Headers/Headers/Accept Encoding/AcceptEncodingHeader.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Headers/Accept Encoding/AcceptEncodingHeader.swift
@@ -14,10 +14,10 @@ import RequestDLInternals
 /// // "gzip;q=1.0, deflate;q=0.9"
 /// ```
 ///
-/// > Important: There is no default value. Only advertise a coding this package's session can
-/// actually decompress — see ``ContentCoding`` for why `.brotli` is not offered, and
-/// ``RequestDL/Session`` for enabling response decompression in the first place, which is off
-/// by default.
+/// > Important: There is no default value. Only advertise a coding something in the pipeline
+/// can actually decompress — either this package's own response decompression (see
+/// ``RequestDL/Session``, off by default and limited to `gzip`/`deflate`), or, for ``ContentCoding/brotli``,
+/// a decoder the caller runs itself against the raw response body.
 public struct AcceptEncodingHeader: Property {
 
     // MARK: - Public properties

--- a/Sources/RequestDL/Properties/Sources/Headers/Headers/Accept Encoding/AcceptEncodingHeader.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Headers/Accept Encoding/AcceptEncodingHeader.swift
@@ -1,0 +1,77 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+import RequestDLInternals
+
+/// Sets the `Accept-Encoding` header in the request.
+///
+/// Each coding is assigned a descending `q` weight by position, per
+/// [RFC 7231 §5.3.1](https://tools.ietf.org/html/rfc7231#section-5.3.1):
+///
+/// ```swift
+/// AcceptEncodingHeader(.gzip, .deflate)
+/// // "gzip;q=1.0, deflate;q=0.9"
+/// ```
+///
+/// > Important: There is no default value. Only advertise a coding this package's session can
+/// actually decompress — see ``ContentCoding`` for why `.brotli` is not offered, and
+/// ``RequestDL/Session`` for enabling response decompression in the first place, which is off
+/// by default.
+public struct AcceptEncodingHeader: Property {
+
+    // MARK: - Public properties
+
+    /// Returns an exception since `Never` is a type that can never be constructed.
+    public var body: Never {
+        bodyException()
+    }
+
+    // MARK: - Private properties
+
+    private let value: String
+
+    // MARK: - Inits
+
+    ///
+    /// Initializes a new instance for an explicit, ordered list of ``ContentCoding``s.
+    ///
+    /// - Parameters:
+    ///   - coding: The most preferred content coding.
+    ///   - rest: Additional codings, in decreasing order of preference.
+    ///
+    public init(_ coding: ContentCoding, _ rest: ContentCoding...) {
+        value = Self.weighted([coding] + rest)
+    }
+
+    // MARK: - Public static methods
+
+    /// This method is used internally and should not be called directly.
+    public static func _makeProperty(
+        property: _GraphValue<AcceptEncodingHeader>,
+        inputs: _PropertyInputs
+    ) async throws -> _PropertyOutputs {
+        property.assertPathway()
+        return .leaf(
+            HeaderNode(
+                key: "Accept-Encoding",
+                value: property.value,
+                strategy: inputs.environment.headerStrategy,
+                separator: inputs.environment.headerSeparator
+            )
+        )
+    }
+
+    // MARK: - Private static methods
+
+    /// Joins `codings` into a single `Accept-Encoding` value, assigning each a descending `q`
+    /// weight: `1.0`, `0.9`, `0.8`, ... floored at `0.1` so a longer list never reaches zero.
+    private static func weighted(_ codings: [ContentCoding]) -> String {
+        codings.enumerated()
+            .map { index, coding in
+                let quality = max(0.1, 1 - Double(index) * 0.1)
+                return "\(coding.rawValue);q=\(quality.fixed(fractionDigits: 1))"
+            }
+            .joined(separator: ", ")
+    }
+}

--- a/Sources/RequestDL/Properties/Sources/Headers/Headers/Accept Encoding/Models/ContentCoding.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Headers/Accept Encoding/Models/ContentCoding.swift
@@ -11,11 +11,12 @@
 /// > Important: If the desired coding is not included in the predefined static properties, use
 /// a string literal to initialize an instance of `ContentCoding`.
 ///
-/// > Note: There is no `.brotli` static property. This package's response decompression
-/// (`Internals.Decompression`, over `AsyncHTTPClient`'s `NIOHTTPCompression`) only implements
-/// `gzip` and `deflate` — there is no Brotli support yet. Advertising it here would let a
-/// compliant server pick it and leave the response undecodable. `ContentCoding("br")` still
-/// works from a string literal, for a caller with its own way of decoding the response.
+/// > Note: This package's built-in response decompression (`Internals.Decompression`, over
+/// `AsyncHTTPClient`'s `NIOHTTPCompression`) only implements `gzip` and `deflate` — there is no
+/// Brotli support in NIO yet. Advertising ``brotli`` here does not need it: it only tells the
+/// server that a Brotli-encoded response is acceptable, and it is up to the caller to decode
+/// it — for example by disabling automatic decompression and reading the raw
+/// `Content-Encoding: br` body themselves.
 public struct ContentCoding: Sendable, Hashable {
 
     // MARK: - Public static properties
@@ -25,6 +26,13 @@ public struct ContentCoding: Sendable, Hashable {
 
     /// The `deflate` content coding.
     public static let deflate: ContentCoding = "deflate"
+
+    /// The `br` (Brotli) content coding.
+    ///
+    /// - Important: Neither `AsyncHTTPClient` nor `swift-nio-extras` decompresses Brotli, so
+    /// this package never does it automatically. Only advertise it if the caller decodes the
+    /// response body itself.
+    public static let brotli: ContentCoding = "br"
 
     /// The `identity` content coding, i.e. no compression.
     public static let identity: ContentCoding = "identity"

--- a/Sources/RequestDL/Properties/Sources/Headers/Headers/Accept Encoding/Models/ContentCoding.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Headers/Accept Encoding/Models/ContentCoding.swift
@@ -1,0 +1,72 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+/// A content coding, as registered with IANA and used by the `Accept-Encoding` header.
+///
+/// ```swift
+/// let coding: ContentCoding = .gzip
+/// ```
+///
+/// > Important: If the desired coding is not included in the predefined static properties, use
+/// a string literal to initialize an instance of `ContentCoding`.
+///
+/// > Note: There is no `.brotli` static property. This package's response decompression
+/// (`Internals.Decompression`, over `AsyncHTTPClient`'s `NIOHTTPCompression`) only implements
+/// `gzip` and `deflate` — there is no Brotli support yet. Advertising it here would let a
+/// compliant server pick it and leave the response undecodable. `ContentCoding("br")` still
+/// works from a string literal, for a caller with its own way of decoding the response.
+public struct ContentCoding: Sendable, Hashable {
+
+    // MARK: - Public static properties
+
+    /// The `gzip` content coding.
+    public static let gzip: ContentCoding = "gzip"
+
+    /// The `deflate` content coding.
+    public static let deflate: ContentCoding = "deflate"
+
+    /// The `identity` content coding, i.e. no compression.
+    public static let identity: ContentCoding = "identity"
+
+    /// The `*` wildcard, matching any content coding not listed elsewhere in the header.
+    public static let all: ContentCoding = "*"
+
+    // MARK: - Internal properties
+
+    let rawValue: String
+
+    // MARK: - Inits
+
+    ///
+    /// Initializes a `ContentCoding` instance with a given string value.
+    ///
+    /// - Parameter rawValue: The content coding token, e.g. `"gzip"`.
+    ///
+    public init<S: StringProtocol>(_ rawValue: S) {
+        self.rawValue = String(rawValue)
+    }
+}
+
+// MARK: - ExpressibleByStringLiteral
+
+extension ContentCoding: ExpressibleByStringLiteral {
+
+    ///
+    /// Initializes a `ContentCoding` instance using a string literal.
+    ///
+    /// - Parameter value: A string literal representing the content coding.
+    ///
+    public init(stringLiteral value: StringLiteralType) {
+        self.rawValue = value
+    }
+}
+
+// MARK: - LosslessStringConvertible
+
+extension ContentCoding: LosslessStringConvertible {
+
+    public var description: String {
+        rawValue
+    }
+}

--- a/Tests/RequestDLTests/Properties/Sources/Headers/Headers/Accept Encoding/AcceptEncodingHeaderTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Headers/Headers/Accept Encoding/AcceptEncodingHeaderTests.swift
@@ -39,6 +39,23 @@ struct AcceptEncodingHeaderTests {
     }
 
     @Test
+    func brotliCanBeAdvertisedForACallerSuppliedDecoder() async throws {
+        // Given
+        let resolved = try await resolve(
+            TestProperty {
+                AcceptEncodingHeader(.brotli, .gzip, .deflate)
+            }
+        )
+
+        // Then
+        #expect(
+            resolved.requestConfiguration.headers["Accept-Encoding"] == [
+                "br;q=1.0, gzip;q=0.9, deflate;q=0.8"
+            ]
+        )
+    }
+
+    @Test
     func weightNeverDropsBelowTheFloor() async throws {
         // Given
         let codings = (0...10).map { ContentCoding("c\($0)") }

--- a/Tests/RequestDLTests/Properties/Sources/Headers/Headers/Accept Encoding/AcceptEncodingHeaderTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Headers/Headers/Accept Encoding/AcceptEncodingHeaderTests.swift
@@ -1,0 +1,80 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+import Testing
+
+@testable import RequestDL
+
+struct AcceptEncodingHeaderTests {
+
+    @Test
+    func singleCodingGetsFullWeight() async throws {
+        // Given
+        let resolved = try await resolve(
+            TestProperty {
+                AcceptEncodingHeader(.gzip)
+            }
+        )
+
+        // Then
+        #expect(resolved.requestConfiguration.headers["Accept-Encoding"] == ["gzip;q=1.0"])
+    }
+
+    @Test
+    func multipleCodingsDescendInWeightByPosition() async throws {
+        // Given
+        let resolved = try await resolve(
+            TestProperty {
+                AcceptEncodingHeader(.gzip, .deflate, .identity)
+            }
+        )
+
+        // Then
+        #expect(
+            resolved.requestConfiguration.headers["Accept-Encoding"] == [
+                "gzip;q=1.0, deflate;q=0.9, identity;q=0.8"
+            ]
+        )
+    }
+
+    @Test
+    func weightNeverDropsBelowTheFloor() async throws {
+        // Given
+        let codings = (0...10).map { ContentCoding("c\($0)") }
+
+        // When
+        let resolved = try await resolve(
+            TestProperty {
+                AcceptEncodingHeader(
+                    codings[0],
+                    codings[1],
+                    codings[2],
+                    codings[3],
+                    codings[4],
+                    codings[5],
+                    codings[6],
+                    codings[7],
+                    codings[8],
+                    codings[9],
+                    codings[10]
+                )
+            }
+        )
+
+        // Then
+        // Index 9 already floors at 0.1 (1 - 9 * 0.1); index 10 would go negative without the
+        // floor, so both land on the same weight.
+        let value = try #require(resolved.requestConfiguration.headers["Accept-Encoding"]?.first)
+        #expect(value.hasSuffix("c9;q=0.1, c10;q=0.1"))
+    }
+
+    @Test
+    func neverBody() async throws {
+        // Given
+        let property = AcceptEncodingHeader(.gzip)
+
+        // Then
+        try await assertNever(property.body)
+    }
+}

--- a/Tests/RequestDLTests/Properties/Sources/Headers/Headers/Accept Encoding/Models/ContentCodingTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Headers/Headers/Accept Encoding/Models/ContentCodingTests.swift
@@ -19,6 +19,11 @@ struct ContentCodingTests {
     }
 
     @Test
+    func brotliRawValue() {
+        #expect(ContentCoding.brotli == "br")
+    }
+
+    @Test
     func identityRawValue() {
         #expect(ContentCoding.identity == "identity")
     }
@@ -31,10 +36,10 @@ struct ContentCodingTests {
     @Test
     func initAcceptsAnyStringProtocol() {
         // Given
-        let substring = "br gzip".split(separator: " ").first!
+        let substring = "zstd gzip".split(separator: " ").first!
 
         // Then
-        #expect(ContentCoding(substring) == "br")
+        #expect(ContentCoding(substring) == "zstd")
     }
 
     @Test

--- a/Tests/RequestDLTests/Properties/Sources/Headers/Headers/Accept Encoding/Models/ContentCodingTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Headers/Headers/Accept Encoding/Models/ContentCodingTests.swift
@@ -1,0 +1,44 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+import Testing
+
+@testable import RequestDL
+
+struct ContentCodingTests {
+
+    @Test
+    func gzipRawValue() {
+        #expect(ContentCoding.gzip == "gzip")
+    }
+
+    @Test
+    func deflateRawValue() {
+        #expect(ContentCoding.deflate == "deflate")
+    }
+
+    @Test
+    func identityRawValue() {
+        #expect(ContentCoding.identity == "identity")
+    }
+
+    @Test
+    func allRawValue() {
+        #expect(ContentCoding.all == "*")
+    }
+
+    @Test
+    func initAcceptsAnyStringProtocol() {
+        // Given
+        let substring = "br gzip".split(separator: " ").first!
+
+        // Then
+        #expect(ContentCoding(substring) == "br")
+    }
+
+    @Test
+    func descriptionReturnsTheRawValue() {
+        #expect(ContentCoding.gzip.description == "gzip")
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `ContentCoding`, an open (IANA content-coding) string-backed value type, same shape as `ContentType`/`LanguageTag`, with static members for `.gzip`, `.deflate`, `.brotli`, `.identity` and `.all` ("*").
- Adds `AcceptEncodingHeader`, a `Property` that sets `Accept-Encoding` from an explicit ordered list (`AcceptEncodingHeader(.brotli, .gzip, .deflate)`), each entry weighted the same way as `AcceptLanguageHeader` (descending `q`: `1.0`, `0.9`, `0.8`, ... floored at `0.1`, per RFC 7231 §5.3.1).

## Design notes
- **`.brotli` is included even though this package can't decode it.** Advertising a coding in `Accept-Encoding` doesn't require the client to decode it — it only tells the server that coding is acceptable. Neither `AsyncHTTPClient` nor `swift-nio-extras` decompresses Brotli, so this package's built-in response decompression never handles it, but a caller who wants Brotli can disable automatic decompression and decode the raw `Content-Encoding: br` body itself. The doc comments on `ContentCoding.brotli` and `AcceptEncodingHeader` spell this out.
- **Deliberately no default `init()`**, unlike `AcceptLanguageHeader`. Encoding preference is capability-driven — the caller has to actually be able to consume whatever it advertises — so there's no safe value to guess; the caller always states the codings explicitly.
- Mirrors `AcceptLanguageHeader`'s weighting contract exactly (variadic ordered list, auto-descending `q`) for API consistency between the two headers.

## Test plan
- [x] `swift build` — clean build
- [x] `swift test --filter "AcceptEncodingHeaderTests|ContentCodingTests"` — 12/12 passing
- [x] `swift test --filter "HeaderTests|HeadersTests|AcceptHeaderTests|AcceptCharsetHeaderTests|UserAgentHeaderTests"` — 72/72 passing, no regressions
- [x] `swift format lint` clean on the new files

🤖 Generated with [Claude Code](https://claude.com/claude-code)