### PR TITLE
Sanitize processName into a valid RFC 9110 token for User-Agent

### DIFF
--- a/Sources/RequestDLInternals/Extensions/CharacterSet+Methods.swift
+++ b/Sources/RequestDLInternals/Extensions/CharacterSet+Methods.swift
@@ -76,4 +76,40 @@ extension Character {
             return false
         }
     }
+
+    /// Whether this character may appear in an HTTP `token`, per RFC 9110 §5.6.2.
+    ///
+    /// Used to keep the `User-Agent` header's `product` value well-formed: a `token` cannot be
+    /// quoted or percent-encoded like the rest of a header value, so a disallowed character
+    /// (a space in a process name, say) has to be substituted rather than escaped.
+    package var isRFC9110TokenAllowed: Bool {
+        guard let ascii = asciiValue else {
+            return false
+        }
+
+        switch ascii {
+        case 48...57,  // 0-9
+            65...90,  // A-Z
+            97...122,  // a-z
+            33,  // !
+            35,  // #
+            36,  // $
+            37,  // %
+            38,  // &
+            39,  // '
+            42,  // *
+            43,  // +
+            45,  // -
+            46,  // .
+            94,  // ^
+            95,  // _
+            96,  // `
+            124,  // |
+            126:  // ~
+            return true
+
+        default:
+            return false
+        }
+    }
 }

--- a/Sources/RequestDLInternals/Extensions/ProcessInfo+.swift
+++ b/Sources/RequestDLInternals/Extensions/ProcessInfo+.swift
@@ -19,11 +19,15 @@ extension ProcessInfo {
     /// The bundle identifier where there is a bundle, the process name everywhere else. Used
     /// for the `User-Agent` and to name the on-disk cache directory, so it wants to be the same
     /// string across launches of the same program, not globally unique.
+    ///
+    /// - Note: `processName` is sanitized to a valid RFC 9110 `token` — unlike a bundle
+    /// identifier, it is not guaranteed to already be one (it may contain spaces or other
+    /// characters a shell or OS allows in an executable name).
     package var applicationIdentifier: String {
         #if canImport(Darwin)
-        return Bundle.main.bundleIdentifier ?? processName
+        return Bundle.main.bundleIdentifier ?? processName.sanitizedAsRFC9110Token
         #else
-        return processName
+        return processName.sanitizedAsRFC9110Token
         #endif
     }
 

--- a/Sources/RequestDLInternals/Extensions/String+Methods.swift
+++ b/Sources/RequestDLInternals/Extensions/String+Methods.swift
@@ -91,6 +91,16 @@ extension StringProtocol {
         let trimmedSuffix = trimmedPrefix.reversed().drop(while: shouldBeTrimmed)
         return String(trimmedSuffix.reversed())
     }
+
+    /// Replaces every character outside the RFC 9110 `token` grammar with `-`, so the result is
+    /// safe to use unquoted as a `product` token in headers like `User-Agent`.
+    ///
+    /// - Note: Falls back to `"-"` when nothing survives — an empty or fully non-ASCII input —
+    /// since an empty token would leave a stray `/` in `product/version`.
+    package var sanitizedAsRFC9110Token: String {
+        let sanitized = String(map { $0.isRFC9110TokenAllowed ? $0 : "-" })
+        return sanitized.isEmpty ? "-" : sanitized
+    }
 }
 
 extension Array where Element == String {

--- a/Tests/RequestDLInternalsTests/Extensions/StringMethodsTests.swift
+++ b/Tests/RequestDLInternalsTests/Extensions/StringMethodsTests.swift
@@ -1,0 +1,36 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+import Testing
+
+@testable import RequestDLInternals
+
+struct StringMethodsTests {
+
+    @Test
+    func tokenAllowedCharactersPassThroughUnchanged() {
+        let allowed = "AZaz09!#$%&'*+-.^_`|~"
+        #expect(allowed.sanitizedAsRFC9110Token == allowed)
+    }
+
+    @Test
+    func spacesAndOtherDisallowedCharactersAreReplacedWithAHyphen() {
+        #expect("My App (Beta)".sanitizedAsRFC9110Token == "My-App--Beta-")
+    }
+
+    @Test
+    func nonASCIICharactersAreReplacedWithAHyphen() {
+        #expect("café".sanitizedAsRFC9110Token == "caf-")
+    }
+
+    @Test
+    func emptyInputFallsBackToAHyphen() {
+        #expect("".sanitizedAsRFC9110Token == "-")
+    }
+
+    @Test
+    func fullyDisallowedInputReplacesEachCharacterWithAHyphen() {
+        #expect("   ".sanitizedAsRFC9110Token == "---")
+    }
+}


### PR DESCRIPTION
## Summary
- `ProcessInfo.applicationIdentifier` (used to build the default `User-Agent` value) falls back to `processName` off Darwin, and whenever there's no bundle identifier. Unlike a bundle identifier — which Apple guarantees is alphanumeric plus `.`/`-` — `processName` isn't guaranteed to already be a valid HTTP `token` (RFC 9110 §5.6.2): it can contain spaces or other characters a shell/OS allows in an executable name, which would make the generated `User-Agent` violate the header's grammar.
- Adds `Character.isRFC9110TokenAllowed` (mirrors the existing `isRFC3986QueryAllowed`/`isURLPathAllowed` pattern) and `String.sanitizedAsRFC9110Token`, which replaces every disallowed character with `-` (falling back to `-` itself if nothing survives, so `product/version` never ends up with an empty `product`).
- Applies the sanitizer to the `processName` fallback in `ProcessInfo.applicationIdentifier`.

## Test plan
- [x] `swift build` — clean build
- [x] `swift test --filter StringMethodsTests` — 5/5 passing (allowed chars pass through, spaces/punctuation/non-ASCII replaced, empty input falls back)
- [x] `swift test --filter UserAgentHeaderTests` — 5/5 passing, no regressions
- [x] `swift format lint` clean on the changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)