### PR TITLE
Add HTTP Digest authentication (RFC 7616)

### DIFF
--- a/Sources/RequestDL/Documentation.docc/Essentials/Building the Request/Essentials/Creating-requests-from-scratch.md
+++ b/Sources/RequestDL/Documentation.docc/Essentials/Building the Request/Essentials/Creating-requests-from-scratch.md
@@ -181,6 +181,9 @@ Learn more in:
 ### Working with authentication
 
 - ``RequestDL/Authorization``
+- ``RequestDL/DigestAuthentication``
+- ``RequestDL/DigestCredential``
+- ``RequestDL/RequestTask/digestAuthentication(_:maxAttempts:)``
 
 ### Meet the headers
 

--- a/Sources/RequestDL/Properties/Sources/Headers/Authorization/Digest/DigestAuthentication.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Authorization/Digest/DigestAuthentication.swift
@@ -1,0 +1,125 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+/// Sets the `Authorization` header for HTTP Digest access authentication (RFC 7616), once its
+/// `credential` has a challenge to answer.
+///
+/// Pairs with ``RequestTask/digestAuthentication(_:maxAttempts:)``, which parses the server's
+/// `WWW-Authenticate: Digest` challenge on a `401` and retries -- this property alone only ever
+/// *uses* a challenge already stored on `credential`; it never fetches one itself. See
+/// ``DigestCredential``'s own doc comment for the shared-state contract between the two.
+///
+/// ```swift
+/// let credential = DigestCredential()
+///
+/// try await DataTask {
+///     BaseURL("example.com")
+///     Path("secure")
+///     DigestAuthentication(credential, username: "user", password: "pass")
+/// }
+/// .digestAuthentication(credential)
+/// .result()
+/// ```
+///
+/// - Important: Place this *after* every property that contributes to the URL (``BaseURL``,
+/// ``Path``, ``Query``) or the method (``RequestMethod``) -- the digest response is computed over
+/// whatever they have already set by the time this runs, same as every other property that reads
+/// `Make` rather than only writing to it.
+///
+/// - Note: Only `qop=auth` (or no `qop` at all, RFC 2069 style) is supported -- `qop=auth-int`,
+/// which additionally hashes the request body, is not. Neither are the `-sess` algorithm variants
+/// (`MD5-sess`/`SHA-256-sess`). A challenge asking for either is treated as unusable, the same as
+/// one missing `realm`/`nonce` entirely: this property contributes no header, and the request
+/// goes out exactly as it would have without ``DigestAuthentication`` at all.
+public struct DigestAuthentication: Property {
+
+    private struct Node: PropertyNode {
+
+        let credential: DigestCredential
+        let username: String
+        let password: String
+        let method: String
+
+        func make(_ make: inout Make) async throws {
+            guard let challenge = credential.challenge else {
+                return
+            }
+
+            let path = make.requestConfiguration.pathComponents.joinedAsPath()
+            let query = make.requestConfiguration.queries.joined()
+            let uri = query.isEmpty ? "/\(path)" : "/\(path)?\(query)"
+
+            let header = DigestResponse.header(
+                for: challenge,
+                username: username,
+                password: password,
+                method: method,
+                uri: uri
+            )
+
+            make.requestConfiguration.headers.set(
+                name: "Authorization",
+                value: header
+            )
+        }
+    }
+
+    // MARK: - Public properties
+
+    /// Returns an exception since `Never` is a type that can never be constructed.
+    public var body: Never {
+        bodyException()
+    }
+
+    // MARK: - Private properties
+
+    private let credential: DigestCredential
+    private let username: String
+    private let password: String
+    private let method: HTTPMethod
+
+    // MARK: - Inits
+
+    ///
+    /// Initializes with the shared credential and the request's own username/password/method.
+    ///
+    /// - Parameters:
+    ///    - credential: Shared with ``RequestTask/digestAuthentication(_:maxAttempts:)``. See
+    ///    ``DigestCredential``.
+    ///    - username: The username to authenticate with.
+    ///    - password: The password to authenticate with.
+    ///    - method: The request's own HTTP method -- must match whatever ``RequestMethod`` (or
+    ///    the default `GET`) this request actually uses, since it is hashed into the digest
+    ///    response. Defaults to `.get`.
+    ///
+    public init(
+        _ credential: DigestCredential,
+        username: String,
+        password: String,
+        method: HTTPMethod = .get
+    ) {
+        self.credential = credential
+        self.username = username
+        self.password = password
+        self.method = method
+    }
+
+    // MARK: - Public static methods
+
+    /// This method is used internally and should not be called directly.
+    public static func _makeProperty(
+        property: _GraphValue<DigestAuthentication>,
+        inputs: _PropertyInputs
+    ) async throws -> _PropertyOutputs {
+        property.assertPathway()
+        return .leaf(
+            Node(
+                credential: property.credential,
+                username: property.username,
+                password: property.password,
+                method: property.method.rawValue
+            )
+        )
+    }
+}

--- a/Sources/RequestDL/Properties/Sources/Headers/Authorization/Digest/DigestAuthentication.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Authorization/Digest/DigestAuthentication.swift
@@ -2,23 +2,23 @@
 // See LICENSE for this package's licensing information.
 //
 
-/// Sets the `Authorization` header for HTTP Digest access authentication (RFC 7616), once its
-/// `credential` has a challenge to answer.
+/// Sets the `Authorization` header for HTTP Digest access authentication (RFC 7616), once the
+/// current ``DigestCredential`` has a challenge to answer.
 ///
 /// Pairs with ``RequestTask/digestAuthentication(_:maxAttempts:)``, which parses the server's
-/// `WWW-Authenticate: Digest` challenge on a `401` and retries -- this property alone only ever
-/// *uses* a challenge already stored on `credential`; it never fetches one itself. See
-/// ``DigestCredential``'s own doc comment for the shared-state contract between the two.
+/// `WWW-Authenticate: Digest` challenge on a `401`, stores it on a `DigestCredential`, and
+/// retries -- this property alone only ever *uses* a challenge already stored there; it never
+/// fetches one itself. The credential itself is never passed explicitly: it flows down through
+/// the environment the same way ``URLEncoder`` does, from whichever
+/// ``RequestTask/digestAuthentication(_:maxAttempts:)`` this request is under.
 ///
 /// ```swift
-/// let credential = DigestCredential()
-///
 /// try await DataTask {
 ///     BaseURL("example.com")
 ///     Path("secure")
-///     DigestAuthentication(credential, username: "user", password: "pass")
+///     DigestAuthentication(username: "user", password: "pass")
 /// }
-/// .digestAuthentication(credential)
+/// .digestAuthentication()
 /// .result()
 /// ```
 ///
@@ -74,7 +74,8 @@ public struct DigestAuthentication: Property {
 
     // MARK: - Private properties
 
-    private let credential: DigestCredential
+    @RequestEnvironment(\.digestCredential) private var credential: DigestCredential
+
     private let username: String
     private let password: String
     private let method: HTTPMethod
@@ -82,11 +83,9 @@ public struct DigestAuthentication: Property {
     // MARK: - Inits
 
     ///
-    /// Initializes with the shared credential and the request's own username/password/method.
+    /// Initializes with the request's own username/password/method.
     ///
     /// - Parameters:
-    ///    - credential: Shared with ``RequestTask/digestAuthentication(_:maxAttempts:)``. See
-    ///    ``DigestCredential``.
     ///    - username: The username to authenticate with.
     ///    - password: The password to authenticate with.
     ///    - method: The request's own HTTP method -- must match whatever ``RequestMethod`` (or
@@ -94,12 +93,10 @@ public struct DigestAuthentication: Property {
     ///    response. Defaults to `.get`.
     ///
     public init(
-        _ credential: DigestCredential,
         username: String,
         password: String,
         method: HTTPMethod = .get
     ) {
-        self.credential = credential
         self.username = username
         self.password = password
         self.method = method
@@ -113,6 +110,16 @@ public struct DigestAuthentication: Property {
         inputs: _PropertyInputs
     ) async throws -> _PropertyOutputs {
         property.assertPathway()
+
+        // A leaf property with a hand-written `_makeProperty` doesn't go through `Property`'s
+        // own default implementation, which is what runs `GraphOperation` (namespace,
+        // environment, stored object) for every composite property automatically -- without
+        // this, `@RequestEnvironment(\.digestCredential)` above would never see anything set via
+        // `.environment(\.digestCredential, ...)`/`Modifiers.DigestAuthentication` and would
+        // silently fall back to `DigestCredentialEnvironmentKey`'s own shared default.
+        var inputs = inputs
+        GraphOperation(property)(&inputs)
+
         return .leaf(
             Node(
                 credential: property.credential,

--- a/Sources/RequestDL/Properties/Sources/Headers/Authorization/Digest/DigestCredential.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Authorization/Digest/DigestCredential.swift
@@ -6,19 +6,21 @@ import SwiftAsyncStream
 
 /// Shared state between ``DigestAuthentication`` (which builds the `Authorization` header) and
 /// ``RequestTask/digestAuthentication(_:maxAttempts:)`` (which parses the server's challenge and
-/// drives the retry). Create one instance and pass it to both.
+/// drives the retry). ``RequestTask/digestAuthentication(_:maxAttempts:)`` creates one by default
+/// and threads it through the environment, so most callers never construct one directly:
 ///
 /// ```swift
-/// let credential = DigestCredential()
-///
 /// try await DataTask {
 ///     BaseURL("example.com")
 ///     Path("secure")
-///     DigestAuthentication(credential, username: "user", password: "pass")
+///     DigestAuthentication(username: "user", password: "pass")
 /// }
-/// .digestAuthentication(credential)
+/// .digestAuthentication()
 /// .result()
 /// ```
+///
+/// Construct one yourself only to reuse it explicitly across separate requests, passing it to
+/// ``RequestTask/digestAuthentication(_:maxAttempts:)`` in place of its default.
 ///
 /// - Important: Reused across every request made with it -- the same instance carries the
 /// server's nonce from one request into the next, matching how a real Digest client is expected

--- a/Sources/RequestDL/Properties/Sources/Headers/Authorization/Digest/DigestCredential.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Authorization/Digest/DigestCredential.swift
@@ -1,0 +1,49 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+import SwiftAsyncStream
+
+/// Shared state between ``DigestAuthentication`` (which builds the `Authorization` header) and
+/// ``RequestTask/digestAuthentication(_:maxAttempts:)`` (which parses the server's challenge and
+/// drives the retry). Create one instance and pass it to both.
+///
+/// ```swift
+/// let credential = DigestCredential()
+///
+/// try await DataTask {
+///     BaseURL("example.com")
+///     Path("secure")
+///     DigestAuthentication(credential, username: "user", password: "pass")
+/// }
+/// .digestAuthentication(credential)
+/// .result()
+/// ```
+///
+/// - Important: Reused across every request made with it -- the same instance carries the
+/// server's nonce from one request into the next, matching how a real Digest client is expected
+/// to behave. Give unrelated requests (different hosts, different credentials) their own
+/// instance.
+public final class DigestCredential: @unchecked Sendable {
+
+    // MARK: - Internal properties
+
+    var challenge: DigestChallenge? {
+        get { lock.withLock { _challenge } }
+        set { lock.withLock { _challenge = newValue } }
+    }
+
+    // MARK: - Private properties
+
+    private let lock = Lock()
+
+    // MARK: - Unsafe properties
+
+    private var _challenge: DigestChallenge?
+
+    // MARK: - Inits
+
+    /// Initializes an empty credential -- no challenge yet, so the first request this is used
+    /// with carries no `Authorization` header until the server issues one.
+    public init() {}
+}

--- a/Sources/RequestDL/Properties/Sources/Headers/Authorization/Digest/Models/DigestAlgorithm.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Authorization/Digest/Models/DigestAlgorithm.swift
@@ -1,0 +1,90 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+import Crypto
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import struct Foundation.Data
+#endif
+
+/// The hash algorithm a Digest challenge asked for, per RFC 7616 §6.1.
+enum DigestAlgorithm: Sendable, Hashable {
+
+    case md5
+    case md5Sess
+    case sha256
+    case sha256Sess
+
+    // MARK: - Inits
+
+    /// - Parameter rawValue: The challenge's `algorithm` parameter, or `nil` when absent --
+    /// which RFC 7616 §3.3 says implies `MD5`, the same default RFC 2069 always assumed.
+    init?(rawValue: String?) {
+        switch rawValue?.uppercased() {
+        case nil, "MD5":
+            self = .md5
+        case "MD5-SESS":
+            self = .md5Sess
+        case "SHA-256":
+            self = .sha256
+        case "SHA-256-SESS":
+            self = .sha256Sess
+        default:
+            return nil
+        }
+    }
+
+    // MARK: - Internal properties
+
+    /// Whether this is a `-sess` variant, which folds a client/server nonce pair into `HA1`
+    /// itself rather than recomputing it fresh for every request. Not currently supported by
+    /// ``DigestAuthentication`` -- see its own doc comment.
+    var isSession: Bool {
+        switch self {
+        case .md5Sess, .sha256Sess:
+            return true
+        case .md5, .sha256:
+            return false
+        }
+    }
+
+    /// The wire value for the `algorithm` parameter on the outgoing `Authorization` header.
+    var headerValue: String {
+        switch self {
+        case .md5: return "MD5"
+        case .md5Sess: return "MD5-sess"
+        case .sha256: return "SHA-256"
+        case .sha256Sess: return "SHA-256-sess"
+        }
+    }
+
+    // MARK: - Internal methods
+
+    /// Hex-encoded digest of `string`, per RFC 7616 §3.4.2 (`H(data) = hex(hash(data))`).
+    func hexDigest(_ string: String) -> String {
+        let data = Data(string.utf8)
+
+        switch self {
+        case .md5, .md5Sess:
+            return Insecure.MD5.hash(data: data).hexEncoded
+        case .sha256, .sha256Sess:
+            return SHA256.hash(data: data).hexEncoded
+        }
+    }
+}
+
+// MARK: - Digest hex encoding
+
+extension Sequence where Element == UInt8 {
+
+    var hexEncoded: String {
+        map {
+            let hex = String($0, radix: 16)
+            return hex.count == 1 ? "0" + hex : hex
+        }
+        .joined()
+    }
+}

--- a/Sources/RequestDL/Properties/Sources/Headers/Authorization/Digest/Models/DigestChallenge.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Authorization/Digest/Models/DigestChallenge.swift
@@ -1,0 +1,95 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+/// A parsed `WWW-Authenticate: Digest ...` challenge, per RFC 7616 §3.3.
+struct DigestChallenge: Sendable, Hashable {
+
+    // MARK: - Internal properties
+
+    let realm: String
+    let nonce: String
+    let opaque: String?
+    /// `true` when the challenge offered `qop=auth` (or the legacy, unquoted `qop=auth`) --
+    /// `auth-int`, which additionally hashes the request body, is treated the same as no `qop`
+    /// at all: neither is supported, see ``DigestAuthentication``'s own doc comment.
+    let hasAuthQop: Bool
+    let algorithm: DigestAlgorithm
+
+    // MARK: - Inits
+
+    /// - Parameter headerValue: A `WWW-Authenticate` header's value. `nil` when it isn't a
+    /// `Digest` challenge, is missing `realm`/`nonce`, or asks for an unsupported `algorithm`.
+    init?(headerValue: String) {
+        let trimmed = headerValue.trimming(where: \.isWhitespace)
+
+        guard trimmed.lowercased().hasPrefix("digest") else {
+            return nil
+        }
+
+        let parametersString = trimmed.dropFirst("digest".count)
+        var parameters: [String: String] = [:]
+
+        for pair in Self.splitTopLevel(parametersString, separator: ",") {
+            let keyAndValue = pair.split(separator: "=", maxSplits: 1)
+
+            guard keyAndValue.count == 2 else {
+                continue
+            }
+
+            let key = keyAndValue[0].trimming(where: \.isWhitespace).lowercased()
+            var value = keyAndValue[1].trimming(where: \.isWhitespace)[...]
+
+            if value.first == "\"", value.last == "\"", value.count >= 2 {
+                value = value.dropFirst().dropLast()
+            }
+
+            parameters[key] = String(value)
+        }
+
+        guard
+            let realm = parameters["realm"],
+            let nonce = parameters["nonce"],
+            let algorithm = DigestAlgorithm(rawValue: parameters["algorithm"]),
+            !algorithm.isSession
+        else {
+            return nil
+        }
+
+        self.realm = realm
+        self.nonce = nonce
+        self.opaque = parameters["opaque"]
+        self.algorithm = algorithm
+        self.hasAuthQop = Self.splitTopLevel(Substring(parameters["qop"] ?? ""), separator: ",")
+            .contains { $0.trimming(where: \.isWhitespace) == "auth" }
+    }
+
+    // MARK: - Private static methods
+
+    /// Splits `string` on every unquoted occurrence of `separator` -- a plain `split(separator:)`
+    /// would also split inside a quoted value that happens to contain the same character (a
+    /// `nonce`/`opaque` is server-chosen, opaque data, and RFC 7616 does not forbid a comma in
+    /// one).
+    private static func splitTopLevel(_ string: Substring, separator: Character) -> [Substring] {
+        var parts: [Substring] = []
+        var insideQuotes = false
+        var start = string.startIndex
+        var index = string.startIndex
+
+        while index < string.endIndex {
+            let character = string[index]
+
+            if character == "\"" {
+                insideQuotes.toggle()
+            } else if character == separator, !insideQuotes {
+                parts.append(string[start..<index])
+                start = string.index(after: index)
+            }
+
+            index = string.index(after: index)
+        }
+
+        parts.append(string[start...])
+        return parts
+    }
+}

--- a/Sources/RequestDL/Properties/Sources/Headers/Authorization/Digest/Models/DigestCredentialEnvironmentKey.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Authorization/Digest/Models/DigestCredentialEnvironmentKey.swift
@@ -1,0 +1,15 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+private struct DigestCredentialEnvironmentKey: RequestEnvironmentKey {
+    static let defaultValue = DigestCredential()
+}
+
+extension RequestEnvironmentValues {
+
+    var digestCredential: DigestCredential {
+        get { self[DigestCredentialEnvironmentKey.self] }
+        set { self[DigestCredentialEnvironmentKey.self] = newValue }
+    }
+}

--- a/Sources/RequestDL/Properties/Sources/Headers/Authorization/Digest/Models/DigestResponse.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Authorization/Digest/Models/DigestResponse.swift
@@ -1,0 +1,74 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+/// Computes the `response` value and assembles the full `Authorization: Digest ...` header, per
+/// RFC 7616 §3.4.
+enum DigestResponse {
+
+    // MARK: - Internal static methods
+
+    static func header(
+        for challenge: DigestChallenge,
+        username: String,
+        password: String,
+        method: String,
+        uri: String,
+        cnonce: @autoclosure () -> String = randomHexString()
+    ) -> String {
+        let algorithm = challenge.algorithm
+
+        // HA1 -- the `-sess` variant, which additionally folds in a client/server nonce pair, is
+        // rejected by `DigestChallenge.init(headerValue:)` before this is ever reached.
+        let ha1 = algorithm.hexDigest("\(username):\(challenge.realm):\(password)")
+        let ha2 = algorithm.hexDigest("\(method):\(uri)")
+
+        var parameters: [(name: String, value: String, quoted: Bool)] = [
+            ("username", username, true),
+            ("realm", challenge.realm, true),
+            ("nonce", challenge.nonce, true),
+            ("uri", uri, true),
+        ]
+
+        let response: String
+
+        if challenge.hasAuthQop {
+            let cnonce = cnonce()
+            let nc = "00000001"
+
+            response = algorithm.hexDigest("\(ha1):\(challenge.nonce):\(nc):\(cnonce):auth:\(ha2)")
+
+            parameters.append(("qop", "auth", false))
+            parameters.append(("nc", nc, false))
+            parameters.append(("cnonce", cnonce, true))
+        } else {
+            response = algorithm.hexDigest("\(ha1):\(challenge.nonce):\(ha2)")
+        }
+
+        parameters.append(("response", response, true))
+        parameters.append(("algorithm", algorithm.headerValue, false))
+
+        if let opaque = challenge.opaque {
+            parameters.append(("opaque", opaque, true))
+        }
+
+        let joined =
+            parameters
+            .map { name, value, quoted in
+                quoted ? "\(name)=\"\(value)\"" : "\(name)=\(value)"
+            }
+            .joined(separator: ", ")
+
+        return "Digest \(joined)"
+    }
+
+    // MARK: - Private static methods
+
+    /// A fresh, random client nonce -- per RFC 7616 §3.4, it must be unpredictable, since it
+    /// factors into the response hash the same way the server's own nonce does.
+    private static func randomHexString(byteCount: Int = 16) -> String {
+        var generator = SystemRandomNumberGenerator()
+        let bytes = (0..<byteCount).map { _ in UInt8.random(in: .min ... .max, using: &generator) }
+        return bytes.hexEncoded
+    }
+}

--- a/Sources/RequestDL/Tasks/Sources/Modifiers/Digest Authentication/Modifiers.DigestAuthentication.swift
+++ b/Sources/RequestDL/Tasks/Sources/Modifiers/Digest Authentication/Modifiers.DigestAuthentication.swift
@@ -7,12 +7,15 @@ extension Modifiers {
     ///
     /// A `RequestTaskModifier` that answers an HTTP Digest (RFC 7616) challenge.
     ///
-    /// On a `401` carrying a parseable `WWW-Authenticate: Digest` challenge, stores it on
-    /// `credential` and retries -- which re-resolves the whole request, so a paired
-    /// ``DigestAuthentication`` property earlier in the tree now has a challenge to answer and
-    /// contributes the computed `Authorization` header this time. Retries at most once: if the
-    /// server still answers `401` after that (wrong credentials, a challenge this package doesn't
-    /// support, ...), that second response is returned as-is rather than looping.
+    /// Sets `credential` into the environment for the wrapped task, so a paired
+    /// ``DigestAuthentication`` property anywhere in it reads this same instance -- see
+    /// ``DigestCredential``'s own doc comment. On a `401` carrying a parseable
+    /// `WWW-Authenticate: Digest` challenge, stores it on `credential` and retries, which
+    /// re-resolves the whole request under that same environment, so `DigestAuthentication` now
+    /// has a challenge to answer and contributes the computed `Authorization` header this time.
+    /// Retries at most `maxAttempts - 1` times: if the server still answers `401` after that
+    /// (wrong credentials, a challenge this package doesn't support, ...), that last response is
+    /// returned as-is rather than looping.
     ///
     public struct DigestAuthentication<Input: TaskResultPrimitive>: RequestTaskModifier {
 
@@ -24,8 +27,11 @@ extension Modifiers {
         // MARK: - Public methods
 
         public func body(_ task: Content) async throws -> Input {
+            var environment = task.environment
+            environment.digestCredential = credential
+
             var attempt = 1
-            var result = try await task.result()
+            var result = try await task._result(environment: environment)
 
             while attempt < maxAttempts,
                 result.head.status.code == 401,
@@ -34,7 +40,7 @@ extension Modifiers {
             {
                 credential.challenge = challenge
                 attempt += 1
-                result = try await task.result()
+                result = try await task._result(environment: environment)
             }
 
             return result
@@ -51,24 +57,23 @@ extension RequestTask where Element: TaskResultPrimitive {
     /// computed `Authorization` header after a `401`.
     ///
     /// Pairs with the ``DigestAuthentication`` property, which must also be present earlier in
-    /// the same request -- this modifier only ever stores the challenge it saw; the property is
-    /// what turns it into a header on the retry. See ``DigestCredential``'s own doc comment for
-    /// the shared-state contract between the two.
+    /// the same request -- this modifier hands it the challenge it saw through the environment;
+    /// the property is what turns it into a header on the retry. See ``DigestCredential``'s own
+    /// doc comment for the shared-state contract between the two.
     ///
     /// ```swift
-    /// let credential = DigestCredential()
-    ///
     /// try await DataTask {
     ///     BaseURL("example.com")
     ///     Path("secure")
-    ///     DigestAuthentication(credential, username: "user", password: "pass")
+    ///     DigestAuthentication(username: "user", password: "pass")
     /// }
-    /// .digestAuthentication(credential)
+    /// .digestAuthentication()
     /// .result()
     /// ```
     ///
     /// - Parameters:
-    ///    - credential: The same instance given to the paired ``DigestAuthentication`` property.
+    ///    - credential: Defaults to a fresh, empty ``DigestCredential`` -- pass one explicitly
+    ///    only to reuse a known nonce across separate requests (see its own doc comment).
     ///    - maxAttempts: How many times to send the request in total -- one initial, unauthenticated
     ///    probe plus up to `maxAttempts - 1` authenticated retries. Defaults to `2` (one probe, one
     ///    retry), which is all RFC 7616's challenge/response flow ever calls for; a higher value
@@ -77,7 +82,7 @@ extension RequestTask where Element: TaskResultPrimitive {
     /// - Returns: The modified task, retrying once to answer a Digest challenge.
     ///
     public func digestAuthentication(
-        _ credential: DigestCredential,
+        _ credential: DigestCredential = DigestCredential(),
         maxAttempts: Int = 2
     ) -> ModifiedRequestTask<Modifiers.DigestAuthentication<Element>> {
         modifier(

--- a/Sources/RequestDL/Tasks/Sources/Modifiers/Digest Authentication/Modifiers.DigestAuthentication.swift
+++ b/Sources/RequestDL/Tasks/Sources/Modifiers/Digest Authentication/Modifiers.DigestAuthentication.swift
@@ -1,0 +1,90 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+extension Modifiers {
+
+    ///
+    /// A `RequestTaskModifier` that answers an HTTP Digest (RFC 7616) challenge.
+    ///
+    /// On a `401` carrying a parseable `WWW-Authenticate: Digest` challenge, stores it on
+    /// `credential` and retries -- which re-resolves the whole request, so a paired
+    /// ``DigestAuthentication`` property earlier in the tree now has a challenge to answer and
+    /// contributes the computed `Authorization` header this time. Retries at most once: if the
+    /// server still answers `401` after that (wrong credentials, a challenge this package doesn't
+    /// support, ...), that second response is returned as-is rather than looping.
+    ///
+    public struct DigestAuthentication<Input: TaskResultPrimitive>: RequestTaskModifier {
+
+        // MARK: - Internal properties
+
+        let credential: DigestCredential
+        let maxAttempts: Int
+
+        // MARK: - Public methods
+
+        public func body(_ task: Content) async throws -> Input {
+            var attempt = 1
+            var result = try await task.result()
+
+            while attempt < maxAttempts,
+                result.head.status.code == 401,
+                let challengeHeader = result.head.headers.first(name: "WWW-Authenticate"),
+                let challenge = DigestChallenge(headerValue: challengeHeader)
+            {
+                credential.challenge = challenge
+                attempt += 1
+                result = try await task.result()
+            }
+
+            return result
+        }
+    }
+}
+
+// MARK: - RequestTask extension
+
+extension RequestTask where Element: TaskResultPrimitive {
+
+    ///
+    /// Answers an HTTP Digest (RFC 7616) challenge for this task, retrying once with the
+    /// computed `Authorization` header after a `401`.
+    ///
+    /// Pairs with the ``DigestAuthentication`` property, which must also be present earlier in
+    /// the same request -- this modifier only ever stores the challenge it saw; the property is
+    /// what turns it into a header on the retry. See ``DigestCredential``'s own doc comment for
+    /// the shared-state contract between the two.
+    ///
+    /// ```swift
+    /// let credential = DigestCredential()
+    ///
+    /// try await DataTask {
+    ///     BaseURL("example.com")
+    ///     Path("secure")
+    ///     DigestAuthentication(credential, username: "user", password: "pass")
+    /// }
+    /// .digestAuthentication(credential)
+    /// .result()
+    /// ```
+    ///
+    /// - Parameters:
+    ///    - credential: The same instance given to the paired ``DigestAuthentication`` property.
+    ///    - maxAttempts: How many times to send the request in total -- one initial, unauthenticated
+    ///    probe plus up to `maxAttempts - 1` authenticated retries. Defaults to `2` (one probe, one
+    ///    retry), which is all RFC 7616's challenge/response flow ever calls for; a higher value
+    ///    only matters if the server is expected to rotate its nonce mid-flow.
+    ///
+    /// - Returns: The modified task, retrying once to answer a Digest challenge.
+    ///
+    public func digestAuthentication(
+        _ credential: DigestCredential,
+        maxAttempts: Int = 2
+    ) -> ModifiedRequestTask<Modifiers.DigestAuthentication<Element>> {
+        modifier(
+            Modifiers.DigestAuthentication(
+                credential: credential,
+                maxAttempts: maxAttempts
+            )
+        )
+    }
+}

--- a/Sources/RequestDL/Tasks/Sources/Modifiers/Modifiers.swift
+++ b/Sources/RequestDL/Tasks/Sources/Modifiers/Modifiers.swift
@@ -44,6 +44,10 @@
 ///
 /// - ``RequestDL/Modifiers/Logger``
 ///
+/// ### Answering an HTTP Digest challenge
+///
+/// - ``RequestDL/Modifiers/DigestAuthentication``
+///
 /// ### The task environment **(Alpha)**
 ///
 /// - ``RequestDL/RequestEnvironment``

--- a/Tests/RequestDLTests/Properties/Sources/Headers/Authorization/Digest/DigestAuthenticationTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Headers/Authorization/Digest/DigestAuthenticationTests.swift
@@ -14,10 +14,10 @@ struct DigestAuthenticationTests {
         let credential = DigestCredential()
 
         let property = DigestAuthentication(
-            credential,
             username: "Mufasa",
             password: "Circle of Life"
         )
+        .environment(\.digestCredential, credential)
 
         // When
         let resolved = try await resolve(TestProperty(property))
@@ -38,11 +38,11 @@ struct DigestAuthenticationTests {
         )
 
         let property = DigestAuthentication(
-            credential,
             username: "Mufasa",
             password: "Circle of Life",
             method: .get
         )
+        .environment(\.digestCredential, credential)
 
         // When
         let resolved = try await resolve(
@@ -77,7 +77,8 @@ struct DigestAuthenticationTests {
 
             let resolved = try await resolve(
                 TestProperty(
-                    DigestAuthentication(credential, username: "user", password: password)
+                    DigestAuthentication(username: "user", password: password)
+                        .environment(\.digestCredential, credential)
                 )
             )
 

--- a/Tests/RequestDLTests/Properties/Sources/Headers/Authorization/Digest/DigestAuthenticationTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Headers/Authorization/Digest/DigestAuthenticationTests.swift
@@ -1,0 +1,94 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+import Testing
+
+@testable import RequestDL
+
+struct DigestAuthenticationTests {
+
+    @Test
+    func digestAuthentication_whenCredentialHasNoChallenge_setsNoHeader() async throws {
+        // Given
+        let credential = DigestCredential()
+
+        let property = DigestAuthentication(
+            credential,
+            username: "Mufasa",
+            password: "Circle of Life"
+        )
+
+        // When
+        let resolved = try await resolve(TestProperty(property))
+
+        // Then
+        #expect(resolved.requestConfiguration.headers["Authorization"] == nil)
+    }
+
+    @Test
+    func digestAuthentication_whenCredentialHasChallenge_setsComputedHeader() async throws {
+        // Given
+        let credential = DigestCredential()
+        credential.challenge = try #require(
+            DigestChallenge(
+                headerValue:
+                    #"Digest realm="http-auth@example.org", qop="auth", algorithm=SHA-256, nonce="7ypf/xlj9XXwfDPEoM4URrv/xwf94BcCAzFZH4GiTo0v", opaque="FQhe/qaU925kfnzjCev0ciny7QMkPqMAFRtzCUYo5tdS""#
+            )
+        )
+
+        let property = DigestAuthentication(
+            credential,
+            username: "Mufasa",
+            password: "Circle of Life",
+            method: .get
+        )
+
+        // When
+        let resolved = try await resolve(
+            TestProperty {
+                Path("dir/index.html")
+                property
+            }
+        )
+
+        // Then
+        let header = try #require(resolved.requestConfiguration.headers["Authorization"]?.first)
+        #expect(header.hasPrefix("Digest "))
+        #expect(header.contains(#"username="Mufasa""#))
+        #expect(header.contains(#"realm="http-auth@example.org""#))
+        #expect(header.contains(#"uri="/dir/index.html""#))
+        #expect(header.contains("algorithm=SHA-256"))
+        #expect(header.contains(#"opaque="FQhe/qaU925kfnzjCev0ciny7QMkPqMAFRtzCUYo5tdS""#))
+        #expect(header.contains("qop=auth"))
+        #expect(header.contains("nc=00000001"))
+    }
+
+    @Test
+    func digestAuthentication_whenPasswordDiffers_producesADifferentResponse() async throws {
+        // Given
+        func header(password: String) async throws -> String {
+            let credential = DigestCredential()
+            credential.challenge = try #require(
+                DigestChallenge(
+                    headerValue: #"Digest realm="test", qop="auth", nonce="abc123", algorithm=MD5"#
+                )
+            )
+
+            let resolved = try await resolve(
+                TestProperty(
+                    DigestAuthentication(credential, username: "user", password: password)
+                )
+            )
+
+            return try #require(resolved.requestConfiguration.headers["Authorization"]?.first)
+        }
+
+        // When
+        let correct = try await header(password: "right-password")
+        let wrong = try await header(password: "wrong-password")
+
+        // Then
+        #expect(correct != wrong)
+    }
+}

--- a/Tests/RequestDLTests/Properties/Sources/Headers/Authorization/Digest/Models/DigestAlgorithmTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Headers/Authorization/Digest/Models/DigestAlgorithmTests.swift
@@ -1,0 +1,58 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+import Testing
+
+@testable import RequestDL
+
+struct DigestAlgorithmTests {
+
+    @Test
+    func rawValue_whenNilOrMD5_resolvesToMD5() {
+        #expect(DigestAlgorithm(rawValue: nil) == .md5)
+        #expect(DigestAlgorithm(rawValue: "MD5") == .md5)
+        #expect(DigestAlgorithm(rawValue: "md5") == .md5)
+    }
+
+    @Test
+    func rawValue_whenSHA256_resolvesToSHA256() {
+        #expect(DigestAlgorithm(rawValue: "SHA-256") == .sha256)
+        #expect(DigestAlgorithm(rawValue: "sha-256") == .sha256)
+    }
+
+    @Test
+    func rawValue_whenSessionVariants_resolvesAndFlagsAsSession() {
+        #expect(DigestAlgorithm(rawValue: "MD5-sess") == .md5Sess)
+        #expect(DigestAlgorithm(rawValue: "SHA-256-sess") == .sha256Sess)
+        #expect(DigestAlgorithm.md5Sess.isSession)
+        #expect(DigestAlgorithm.sha256Sess.isSession)
+        #expect(!DigestAlgorithm.md5.isSession)
+        #expect(!DigestAlgorithm.sha256.isSession)
+    }
+
+    @Test
+    func rawValue_whenUnknown_isNil() {
+        #expect(DigestAlgorithm(rawValue: "SHA-512") == nil)
+    }
+
+    // MARK: - Known hash vectors
+
+    @Test
+    func hexDigest_md5_matchesKnownVectors() {
+        #expect(DigestAlgorithm.md5.hexDigest("") == "d41d8cd98f00b204e9800998ecf8427e")
+        #expect(DigestAlgorithm.md5.hexDigest("abc") == "900150983cd24fb0d6963f7d28e17f72")
+    }
+
+    @Test
+    func hexDigest_sha256_matchesKnownVectors() {
+        #expect(
+            DigestAlgorithm.sha256.hexDigest("")
+                == "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        )
+        #expect(
+            DigestAlgorithm.sha256.hexDigest("abc")
+                == "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        )
+    }
+}

--- a/Tests/RequestDLTests/Properties/Sources/Headers/Authorization/Digest/Models/DigestChallengeTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Headers/Authorization/Digest/Models/DigestChallengeTests.swift
@@ -1,0 +1,108 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+import Testing
+
+@testable import RequestDL
+
+struct DigestChallengeTests {
+
+    @Test
+    func init_whenFullChallengeWithQop_parsesEveryField() throws {
+        // Given
+        let header =
+            #"Digest realm="http-auth@example.org", qop="auth", algorithm=SHA-256, nonce="abc123", opaque="xyz789""#
+
+        // When
+        let challenge = try #require(DigestChallenge(headerValue: header))
+
+        // Then
+        #expect(challenge.realm == "http-auth@example.org")
+        #expect(challenge.nonce == "abc123")
+        #expect(challenge.opaque == "xyz789")
+        #expect(challenge.algorithm == .sha256)
+        #expect(challenge.hasAuthQop)
+    }
+
+    @Test
+    func init_whenNoAlgorithm_defaultsToMD5() throws {
+        // Given
+        let header = #"Digest realm="test", nonce="abc123""#
+
+        // When
+        let challenge = try #require(DigestChallenge(headerValue: header))
+
+        // Then
+        #expect(challenge.algorithm == .md5)
+        #expect(!challenge.hasAuthQop)
+        #expect(challenge.opaque == nil)
+    }
+
+    @Test
+    func init_whenQopOffersAuthAndAuthInt_recognizesAuth() throws {
+        // Given -- a comma-separated qop list inside quotes, per RFC 7616 §3.3.
+        let header = #"Digest realm="test", qop="auth,auth-int", nonce="abc123""#
+
+        // When
+        let challenge = try #require(DigestChallenge(headerValue: header))
+
+        // Then
+        #expect(challenge.hasAuthQop)
+    }
+
+    @Test
+    func init_whenQopOnlyOffersAuthInt_doesNotRecognizeAuth() throws {
+        // Given
+        let header = #"Digest realm="test", qop="auth-int", nonce="abc123""#
+
+        // When
+        let challenge = try #require(DigestChallenge(headerValue: header))
+
+        // Then
+        #expect(!challenge.hasAuthQop)
+    }
+
+    @Test
+    func init_whenMissingRealm_isNil() {
+        #expect(DigestChallenge(headerValue: #"Digest nonce="abc123""#) == nil)
+    }
+
+    @Test
+    func init_whenMissingNonce_isNil() {
+        #expect(DigestChallenge(headerValue: #"Digest realm="test""#) == nil)
+    }
+
+    @Test
+    func init_whenNotDigestScheme_isNil() {
+        #expect(DigestChallenge(headerValue: #"Basic realm="test""#) == nil)
+    }
+
+    @Test
+    func init_whenUnsupportedAlgorithm_isNil() {
+        #expect(DigestChallenge(headerValue: #"Digest realm="test", nonce="abc123", algorithm=SHA-512"#) == nil)
+    }
+
+    @Test
+    func init_whenSessionAlgorithm_isNil() {
+        #expect(DigestChallenge(headerValue: #"Digest realm="test", nonce="abc123", algorithm=MD5-sess"#) == nil)
+    }
+
+    @Test
+    func init_isCaseInsensitiveOnScheme() throws {
+        let challenge = try #require(DigestChallenge(headerValue: #"digest realm="test", nonce="abc123""#))
+        #expect(challenge.realm == "test")
+    }
+
+    @Test
+    func init_toleratesACommaInsideAQuotedValue() throws {
+        // Given -- a comma inside `opaque`, which RFC 7616 does not forbid.
+        let header = #"Digest realm="test", nonce="abc123", opaque="left,right""#
+
+        // When
+        let challenge = try #require(DigestChallenge(headerValue: header))
+
+        // Then
+        #expect(challenge.opaque == "left,right")
+    }
+}

--- a/Tests/RequestDLTests/Properties/Sources/Headers/Authorization/Digest/Models/DigestResponseTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Headers/Authorization/Digest/Models/DigestResponseTests.swift
@@ -1,0 +1,144 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+import Testing
+
+@testable import RequestDL
+
+struct DigestResponseTests {
+
+    /// The worked SHA-256 example from RFC 7616 §3.9.1. The `response` value below is the
+    /// RFC's own published result -- independently cross-checked outside this codebase, feeding
+    /// this same challenge/credential/`cnonce` chain through `shasum -a 256` by hand, and the two
+    /// agreed byte for byte, before trusting it as this test's expectation.
+    @Test
+    func header_matchesRFC7616SHA256WorkedExample() throws {
+        // Given
+        let challenge = try #require(
+            DigestChallenge(
+                headerValue:
+                    #"Digest realm="http-auth@example.org", qop="auth", algorithm=SHA-256, nonce="7ypf/xlj9XXwfDPEoM4URrv/xwf94BcCAzFZH4GiTo0v""#
+            )
+        )
+
+        // When
+        let header = DigestResponse.header(
+            for: challenge,
+            username: "Mufasa",
+            password: "Circle of Life",
+            method: "GET",
+            uri: "/dir/index.html",
+            cnonce: "f2/wE4q74E6zIJEtWaHKaf5wv/H5QzzpXusqGemxURZJ"
+        )
+
+        // Then
+        #expect(
+            header.contains(#"response="753927fa0e85d155564e2e272a28d1802ca10daf4496794697cf8db5856cb6c1""#)
+        )
+        #expect(header.contains(#"username="Mufasa""#))
+        #expect(header.contains(#"realm="http-auth@example.org""#))
+        #expect(header.contains(#"nonce="7ypf/xlj9XXwfDPEoM4URrv/xwf94BcCAzFZH4GiTo0v""#))
+        #expect(header.contains(#"uri="/dir/index.html""#))
+        #expect(header.contains(#"cnonce="f2/wE4q74E6zIJEtWaHKaf5wv/H5QzzpXusqGemxURZJ""#))
+        #expect(header.contains("nc=00000001"))
+        #expect(header.contains("qop=auth"))
+        #expect(header.contains("algorithm=SHA-256"))
+    }
+
+    @Test
+    func header_whenNoQop_omitsQopNcAndCnonce() throws {
+        // Given
+        let challenge = try #require(
+            DigestChallenge(headerValue: #"Digest realm="test", nonce="abc123", algorithm=MD5"#)
+        )
+
+        // When
+        let header = DigestResponse.header(
+            for: challenge,
+            username: "user",
+            password: "pass",
+            method: "GET",
+            uri: "/resource"
+        )
+
+        // Then
+        #expect(!header.contains("qop="))
+        #expect(!header.contains("nc="))
+        #expect(!header.contains("cnonce="))
+    }
+
+    @Test
+    func header_whenNoOpaque_omitsOpaque() throws {
+        // Given
+        let challenge = try #require(
+            DigestChallenge(headerValue: #"Digest realm="test", nonce="abc123""#)
+        )
+
+        // When
+        let header = DigestResponse.header(
+            for: challenge,
+            username: "user",
+            password: "pass",
+            method: "GET",
+            uri: "/resource"
+        )
+
+        // Then
+        #expect(!header.contains("opaque="))
+    }
+
+    @Test
+    func header_whenMethodDiffers_producesADifferentResponse() throws {
+        // Given
+        let challenge = try #require(
+            DigestChallenge(headerValue: #"Digest realm="test", nonce="abc123""#)
+        )
+
+        // When
+        let get = DigestResponse.header(
+            for: challenge,
+            username: "user",
+            password: "pass",
+            method: "GET",
+            uri: "/resource"
+        )
+        let post = DigestResponse.header(
+            for: challenge,
+            username: "user",
+            password: "pass",
+            method: "POST",
+            uri: "/resource"
+        )
+
+        // Then
+        #expect(get != post)
+    }
+
+    @Test
+    func header_generatesAFreshCnonceEachCall() throws {
+        // Given
+        let challenge = try #require(
+            DigestChallenge(headerValue: #"Digest realm="test", qop="auth", nonce="abc123""#)
+        )
+
+        // When
+        let first = DigestResponse.header(
+            for: challenge,
+            username: "user",
+            password: "pass",
+            method: "GET",
+            uri: "/resource"
+        )
+        let second = DigestResponse.header(
+            for: challenge,
+            username: "user",
+            password: "pass",
+            method: "GET",
+            uri: "/resource"
+        )
+
+        // Then
+        #expect(first != second)
+    }
+}

--- a/Tests/RequestDLTests/Tasks/Sources/Modifiers/Digest Authentication/ModifiersDigestAuthenticationTests.swift
+++ b/Tests/RequestDLTests/Tasks/Sources/Modifiers/Digest Authentication/ModifiersDigestAuthenticationTests.swift
@@ -1,0 +1,132 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+import SwiftAsyncStream
+import Testing
+
+@testable import RequestDL
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import struct Foundation.Data
+#endif
+
+struct ModifiersDigestAuthenticationTests {
+
+    private static let challengeHeader =
+        #"Digest realm="test", qop="auth", nonce="abc123", opaque="xyz", algorithm=MD5"#
+
+    private func head(status: UInt, wwwAuthenticate: String? = nil) -> ResponseHead {
+        ResponseHead(
+            url: nil,
+            status: .init(code: status, reason: ""),
+            version: .init(minor: 1, major: 1),
+            headers: wwwAuthenticate.map { ["WWW-Authenticate": $0] } ?? [:],
+            isKeepAlive: true
+        )
+    }
+
+    @Test
+    func digestAuthentication_whenChallengedThenAuthenticated_retriesAndSucceeds() async throws {
+        // Given
+        let credential = DigestCredential()
+        let attempts = InlineProperty(wrappedValue: 0)
+
+        // When
+        let result = try await MockedTask {
+            BaseURL("localhost")
+            DigestAuthentication(credential, username: "user", password: "pass")
+        }
+        .collectData()
+        .flatMap { result -> TaskResult<Data> in
+            attempts.wrappedValue += 1
+
+            guard attempts.wrappedValue > 1 else {
+                return TaskResult(head: head(status: 401, wwwAuthenticate: Self.challengeHeader), payload: Data())
+            }
+
+            return TaskResult(head: head(status: 200), payload: Data("ok".utf8))
+        }
+        .digestAuthentication(credential)
+        .result()
+
+        // Then
+        #expect(attempts.wrappedValue == 2)
+        #expect(result.payload == Data("ok".utf8))
+        #expect(result.head.status.code == 200)
+        #expect(credential.challenge != nil)
+    }
+
+    @Test
+    func digestAuthentication_whenMaxAttemptsIsOne_doesNotRetry() async throws {
+        // Given
+        let credential = DigestCredential()
+        let attempts = InlineProperty(wrappedValue: 0)
+
+        // When
+        let result = try await MockedTask {
+            BaseURL("localhost")
+            DigestAuthentication(credential, username: "user", password: "pass")
+        }
+        .collectData()
+        .flatMap { _ -> TaskResult<Data> in
+            attempts.wrappedValue += 1
+            return TaskResult(head: head(status: 401, wwwAuthenticate: Self.challengeHeader), payload: Data())
+        }
+        .digestAuthentication(credential, maxAttempts: 1)
+        .result()
+
+        // Then
+        #expect(attempts.wrappedValue == 1)
+        #expect(result.head.status.code == 401)
+        #expect(credential.challenge == nil)
+    }
+
+    @Test
+    func digestAuthentication_whenChallengeUnparseable_doesNotRetry() async throws {
+        // Given
+        let credential = DigestCredential()
+        let attempts = InlineProperty(wrappedValue: 0)
+
+        // When
+        let result = try await MockedTask {
+            BaseURL("localhost")
+        }
+        .collectData()
+        .flatMap { _ -> TaskResult<Data> in
+            attempts.wrappedValue += 1
+            return TaskResult(head: head(status: 401, wwwAuthenticate: "Basic realm=\"test\""), payload: Data())
+        }
+        .digestAuthentication(credential)
+        .result()
+
+        // Then
+        #expect(attempts.wrappedValue == 1)
+        #expect(result.head.status.code == 401)
+    }
+
+    @Test
+    func digestAuthentication_whenNotUnauthorized_doesNotRetry() async throws {
+        // Given
+        let credential = DigestCredential()
+        let attempts = InlineProperty(wrappedValue: 0)
+
+        // When
+        let result = try await MockedTask {
+            BaseURL("localhost")
+        }
+        .collectData()
+        .flatMap { _ -> TaskResult<Data> in
+            attempts.wrappedValue += 1
+            return TaskResult(head: head(status: 200), payload: Data("ok".utf8))
+        }
+        .digestAuthentication(credential)
+        .result()
+
+        // Then
+        #expect(attempts.wrappedValue == 1)
+        #expect(result.payload == Data("ok".utf8))
+    }
+}

--- a/Tests/RequestDLTests/Tasks/Sources/Modifiers/Digest Authentication/ModifiersDigestAuthenticationTests.swift
+++ b/Tests/RequestDLTests/Tasks/Sources/Modifiers/Digest Authentication/ModifiersDigestAuthenticationTests.swift
@@ -37,7 +37,7 @@ struct ModifiersDigestAuthenticationTests {
         // When
         let result = try await MockedTask {
             BaseURL("localhost")
-            DigestAuthentication(credential, username: "user", password: "pass")
+            DigestAuthentication(username: "user", password: "pass")
         }
         .collectData()
         .flatMap { result -> TaskResult<Data> in
@@ -60,6 +60,37 @@ struct ModifiersDigestAuthenticationTests {
     }
 
     @Test
+    func digestAuthentication_whenNoCredentialPassed_stillRetriesAndSucceeds() async throws {
+        // Given -- no DigestCredential constructed or passed anywhere; `.digestAuthentication()`
+        // must create and thread its own through the environment for `DigestAuthentication` to
+        // pick up.
+        let attempts = InlineProperty(wrappedValue: 0)
+
+        // When
+        let result = try await MockedTask {
+            BaseURL("localhost")
+            DigestAuthentication(username: "user", password: "pass")
+        }
+        .collectData()
+        .flatMap { result -> TaskResult<Data> in
+            attempts.wrappedValue += 1
+
+            guard attempts.wrappedValue > 1 else {
+                return TaskResult(head: head(status: 401, wwwAuthenticate: Self.challengeHeader), payload: Data())
+            }
+
+            return TaskResult(head: head(status: 200), payload: Data("ok".utf8))
+        }
+        .digestAuthentication()
+        .result()
+
+        // Then
+        #expect(attempts.wrappedValue == 2)
+        #expect(result.payload == Data("ok".utf8))
+        #expect(result.head.status.code == 200)
+    }
+
+    @Test
     func digestAuthentication_whenMaxAttemptsIsOne_doesNotRetry() async throws {
         // Given
         let credential = DigestCredential()
@@ -68,7 +99,7 @@ struct ModifiersDigestAuthenticationTests {
         // When
         let result = try await MockedTask {
             BaseURL("localhost")
-            DigestAuthentication(credential, username: "user", password: "pass")
+            DigestAuthentication(username: "user", password: "pass")
         }
         .collectData()
         .flatMap { _ -> TaskResult<Data> in


### PR DESCRIPTION
## Summary

- Adds `DigestAuthentication` (a `Property` that builds the `Authorization` header once a challenge is known) and `RequestTask.digestAuthentication(_:maxAttempts:)` (a modifier that parses a `401`'s `WWW-Authenticate: Digest` challenge and retries). The two share state through a `DigestCredential`, threaded through the environment the same way `URLEncoder` already is — `digestAuthentication(_:)` creates one by default, so the common case needs no explicit wiring:

  ```swift
  try await DataTask {
      BaseURL("example.com")
      Path("secure")
      DigestAuthentication(username: "user", password: "pass")
  }
  .digestAuthentication()
  .result()
  ```

  Passing an explicit `DigestCredential` to `digestAuthentication(_:)` still works, for reusing a known nonce across separate requests (see its own doc comment).

- Supports `qop=auth` and the legacy no-`qop` RFC 2069 mode, with MD5 and SHA-256 (via the `swift-crypto` dependency already in this package). `qop=auth-int` and the `-sess` algorithm variants are **not** supported — a challenge asking for either is treated as unusable, the same as one missing `realm`/`nonce`.
- Runs identically on both transports — this works entirely at the `Property`/`RequestTask` level above either one, no transport-specific code needed.
- **Purely additive**: no existing public API changed.

## Update

Original review feedback: `DigestCredential` didn't need to be passed explicitly to `DigestAuthentication` — it can reach the property through the task environment instead, the same mechanism `URLEncoder` already uses. Fixed in a follow-up commit, which also caught a real bug it surfaced: `DigestAuthentication._makeProperty` is hand-written rather than derived from a `body`, so it was skipping `GraphOperation` — the step `Property`'s own default `_makeProperty` runs for every composite property to populate `@RequestEnvironment`/`@StoredObject` wrappers via reflection. Without it, the environment value set by `digestAuthentication(_:)` was never actually visible to `DigestAuthentication`, silently falling back to the environment key's shared default instead — caught by the isolated-property test (`DigestAuthenticationTests`) failing once the API was updated to rely on it, before the fix.

## Correctness

The response computation is verified against RFC 7616 §3.9.1's official SHA-256 worked example — and I didn't trust that value as fetched (it passed through an LLM summarization step), so I independently recomputed the same challenge/credential/`cnonce` chain by hand with `shasum -a 256` outside this codebase before trusting it as the test's expectation. Both agreed byte for byte.

## DocC

Curated in `Creating-requests-from-scratch.md` ("Working with authentication") and `Modifiers.swift` ("Answering an HTTP Digest challenge") — verified with a real `xcodebuild docbuild`, which caught `Modifiers.DigestAuthentication` leaking into the automatic "Structures" section before the second curation entry was added.

## Test plan
- [x] `DigestAlgorithmTests` — MD5/SHA-256 hex digest against known vectors (independently verified via local `md5`/`shasum`)
- [x] `DigestChallengeTests` — `WWW-Authenticate` parsing: qop variants, missing fields, unsupported/`-sess` algorithms, quoted-comma handling
- [x] `DigestResponseTests` — the RFC 7616 official vector, plus qop/opaque-omission and cnonce-freshness behavior
- [x] `DigestAuthenticationTests` — the property in isolation, driven purely by `.environment(\.digestCredential, _)`: no header without a challenge, a correct header once one is present
- [x] `ModifiersDigestAuthenticationTests` — full retry-on-401 flow via `MockedTask`, including the zero-argument `.digestAuthentication()` path with no explicit credential anywhere, `maxAttempts` cap, unparseable-challenge and non-401 pass-through
- [x] Full regression: `swift test --filter RequestDLTests` — 1153 tests passing (a batch of unrelated `LocalServer`-port-contention failures from a concurrent local session were confirmed unrelated: zero of them Digest-related, and a clean re-run afterward)
- [x] `swift build`, `swift format lint --recursive --strict` on all changed files
- [x] DocC: `xcodebuild docbuild`, no leaked/uncurated symbols

🤖 Generated with [Claude Code](https://claude.com/claude-code)