### PR TITLE
Fix Session.compression(_:) to actually work under .urlSession

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -83,6 +83,7 @@ let package = Package(
                 .product(name: "NIOFoundationEssentialsCompat", package: "swift-nio"),
                 .product(name: "NIOHTTP1", package: "swift-nio"),
                 .product(name: "NIOPosix", package: "swift-nio"),
+                .product(name: "NIOEmbedded", package: "swift-nio"),
                 .product(name: "_NIOFileSystem", package: "swift-nio"),
                 .product(name: "NIOHTTPCompression", package: "swift-nio-extras"),
                 .product(name: "NIOSSL", package: "swift-nio-ssl"),

--- a/Sources/RequestDL/Properties/Sources/Session/Session/Models/DuplicateContentEncodingError.swift
+++ b/Sources/RequestDL/Properties/Sources/Session/Session/Models/DuplicateContentEncodingError.swift
@@ -1,0 +1,25 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+/// An error thrown by ``Session/compression(_:onDuplicateHeader:)`` when the request already
+/// carries a `Content-Encoding` header and ``Session/DuplicateHeaderBehavior`` is left at its
+/// default, ``Session/DuplicateHeaderBehavior/error``.
+public struct DuplicateContentEncodingError: Error, Sendable {
+
+    /// The `Content-Encoding` value the request already carried.
+    public let value: String
+}
+
+// MARK: - CustomStringConvertible
+
+extension DuplicateContentEncodingError: CustomStringConvertible {
+
+    public var description: String {
+        """
+        RequestDL could not enable request-body compression because a `Content-Encoding` header \
+        ("\(value)") is already set on this request. Pass `.replace` or `.skip` to \
+        .compression(_:onDuplicateHeader:) to allow this, or remove the existing header.
+        """
+    }
+}

--- a/Sources/RequestDL/Properties/Sources/Session/Session/Models/Session.DuplicateHeaderBehavior.swift
+++ b/Sources/RequestDL/Properties/Sources/Session/Session/Models/Session.DuplicateHeaderBehavior.swift
@@ -1,0 +1,35 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+import RequestDLInternals
+
+extension Session {
+
+    /// What ``Session/compression(_:onDuplicateHeader:)`` does when the request already carries
+    /// a `Content-Encoding` header before compression would set its own.
+    public enum DuplicateHeaderBehavior: Sendable, Hashable {
+
+        /// Throws ``DuplicateContentEncodingError``. The default.
+        case error
+
+        /// Replaces the existing header value with the configured algorithm's.
+        case replace
+
+        /// Silently skips compression when the header already exists.
+        case skip
+
+        // MARK: - Internal methods
+
+        func build() -> Internals.Compression.DuplicateHeaderBehavior {
+            switch self {
+            case .error:
+                return .error
+            case .replace:
+                return .replace
+            case .skip:
+                return .skip
+            }
+        }
+    }
+}

--- a/Sources/RequestDL/Properties/Sources/Session/Session/Session.swift
+++ b/Sources/RequestDL/Properties/Sources/Session/Session/Session.swift
@@ -311,17 +311,38 @@ public struct Session: Property {
     }
 
     ///
-    /// Compresses the outgoing request body before it's sent over the wire, setting the
-    /// `Content-Encoding` header accordingly.
+    /// Compresses the outgoing request body before it's sent, setting the `Content-Encoding`
+    /// header accordingly.
     ///
     /// This is independent of which `Payload` source produced the body (`Data`/`JSON`/`String`/
-    /// `File`/`Form`) and only applies to connections negotiated as HTTP/1.1.
+    /// `File`/`Form`) and of which ``Session/Executor`` the request resolves to -- the body is
+    /// compressed once, up front, rather than on the wire, so `.urlSession`/`.nioTransportServices`/
+    /// `.nio` and every negotiated HTTP version all see the same already-compressed bytes.
     ///
-    /// - Parameter algorithm: The algorithm used to compress the request body.
+    /// Compression is only worth its CPU cost for bodies that are both sizable and not already
+    /// compressed (a large JSON payload, say, but not an image) -- use `shouldCompressBodyData`
+    /// to gate it on the body's byte count, the same threshold Alamofire's own
+    /// `DeflateRequestCompressor.shouldCompressBodyData` recommends. Left `nil`, every request
+    /// with a body is compressed whenever `compression` is enabled, regardless of size.
+    ///
+    /// - Parameters:
+    ///   - algorithm: The algorithm used to compress the request body.
+    ///   - behavior: What to do if the request already carries a `Content-Encoding` header.
+    ///   Defaults to ``DuplicateHeaderBehavior/error``.
+    ///   - shouldCompressBodyData: Given the outgoing body's byte count, decides whether to
+    ///   compress it. Defaults to `nil`, which always compresses.
     /// - Returns: The modified `Session` instance with request-body compression configured.
     ///
-    public func compression(_ algorithm: CompressionAlgorithm) -> Self {
-        edit { $0.compression = .enabled(algorithm.build()) }
+    public func compression(
+        _ algorithm: CompressionAlgorithm,
+        onDuplicateHeader behavior: DuplicateHeaderBehavior = .error,
+        shouldCompressBodyData: (@Sendable (Int) -> Bool)? = nil
+    ) -> Self {
+        edit {
+            $0.compression = .enabled(algorithm.build())
+            $0.compressionDuplicateHeaderBehavior = behavior.build()
+            $0.shouldCompressBodyData = shouldCompressBodyData
+        }
     }
 
     ///

--- a/Sources/RequestDL/Request/RequestConfiguration+Compression.swift
+++ b/Sources/RequestDL/Request/RequestConfiguration+Compression.swift
@@ -1,0 +1,70 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+import NIOCore
+import RequestDLInternals
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import struct Foundation.Data
+#endif
+
+extension RequestConfiguration {
+
+    /// Compresses ``body`` in place when `compression` is enabled, and sets `Content-Encoding`/
+    /// `Content-Length` to match.
+    ///
+    /// Runs once, here, before this configuration ever reaches `build(eventLoop:)` (the `.nio`
+    /// path) or `buildURLRequest()`/the streamed-upload path (the `.urlSession` path) --
+    /// `RequestBody` backs the outgoing body identically for both, so compressing it at this
+    /// layer, instead of at the wire layer the way this package used to (a
+    /// `NIOHTTPRequestCompressor` spliced into the `.nio` executor's connection pipeline, which
+    /// only ever ran for HTTP/1.1 and was entirely invisible to `.urlSession`), makes compression
+    /// behave identically on every executor and every negotiated HTTP version.
+    ///
+    /// A no-op when there's no body, the body is empty, `compression` is `.disabled`, or
+    /// `shouldCompressBodyData` declines this body's size -- the common case, so callers that
+    /// never touch `Session.compression(_:)` pay nothing here.
+    mutating func applyCompression(
+        _ compression: Internals.Compression,
+        onDuplicateHeader behavior: Internals.Compression.DuplicateHeaderBehavior,
+        shouldCompressBodyData: (@Sendable (Int) -> Bool)?
+    ) async throws {
+        guard case .enabled(let algorithm) = compression, let body, body.totalSize > .zero else {
+            return
+        }
+
+        if let shouldCompressBodyData, !shouldCompressBodyData(body.totalSize) {
+            return
+        }
+
+        if let existingContentEncoding = headers.first(name: "Content-Encoding") {
+            switch behavior {
+            case .error:
+                throw DuplicateContentEncodingError(value: existingContentEncoding)
+            case .skip:
+                return
+            case .replace:
+                break
+            }
+        }
+
+        var buffer = ByteBufferAllocator().buffer(capacity: body.totalSize)
+
+        for await chunk in body {
+            var chunk = chunk
+            buffer.writeBuffer(&chunk)
+        }
+
+        let compressed = try algorithm.compress(buffer)
+        let compressedBody = await RequestBody(
+            buffers: [Internals.DataBuffer(Data(compressed.readableBytesView))]
+        )
+
+        self.body = compressedBody
+        headers.set(name: "Content-Encoding", value: algorithm.contentEncodingValue)
+        headers.set(name: "Content-Length", value: String(compressedBody.totalSize))
+    }
+}

--- a/Sources/RequestDL/Tasks/Sources/Raw Task/Raw/RawTask.swift
+++ b/Sources/RequestDL/Tasks/Sources/Raw Task/Raw/RawTask.swift
@@ -217,6 +217,13 @@ struct RawTask<Content: Property>: RequestTask {
         logger: Internals.TaskLogger?
     ) async throws -> (task: SessionTask, onResponseHead: OnResponseHead?) {
         var configuration = resolved.requestConfiguration
+
+        try await configuration.applyCompression(
+            resolved.session.configuration.compression,
+            onDuplicateHeader: resolved.session.configuration.compressionDuplicateHeaderBehavior,
+            shouldCompressBodyData: resolved.session.configuration.shouldCompressBodyData
+        )
+
         let tracer = resolved.session.configuration.tracer
         let span = startRequestSpan(tracer: tracer, configuration: &configuration)
 

--- a/Sources/RequestDLInternals/Sources/Session/Session Configuration/Internals.Session.Configuration.swift
+++ b/Sources/RequestDLInternals/Sources/Session/Session Configuration/Internals.Session.Configuration.swift
@@ -4,8 +4,6 @@
 
 import AsyncHTTPClient
 import NIOCore
-import NIOHTTP1
-import NIOHTTPCompression
 import Tracing
 
 extension Internals.Session {
@@ -51,6 +49,25 @@ extension Internals.Session {
         #endif
 
         package var compression: Internals.Compression = .disabled
+
+        /// What `RequestConfiguration.applyCompression(_:onDuplicateHeader:)` does when the
+        /// request already carries a `Content-Encoding` header before `compression` would set
+        /// its own. Kept as a separate field, rather than folded into `Internals.Compression
+        /// .enabled`'s associated value, so existing `compression == .enabled(algorithm)` call
+        /// sites (session pooling's cache key included) don't have to change shape for a setting
+        /// that only matters once compression is already known to be on.
+        package var compressionDuplicateHeaderBehavior: Internals.Compression.DuplicateHeaderBehavior = .error
+
+        /// Gates `compression` on the outgoing body's byte count -- `nil` (the default) always
+        /// compresses when `compression` is enabled. Mirrors Alamofire's `DeflateRequestCompressor
+        /// .shouldCompressBodyData`, whose own doc recommends this: compressing a body that's
+        /// already small, or already compressed (e.g. an image), wastes CPU for no wire-size win.
+        ///
+        /// Takes the byte count rather than the body itself -- `RequestBody.totalSize` is already
+        /// known without draining the body, so a caller that skips compression here never pays to
+        /// materialize it first. Excluded from `Equatable`/`Hashable`, same reasoning as `tracer`.
+        package var shouldCompressBodyData: (@Sendable (Int) -> Bool)?
+
         package var dnsOverride: [String: String] = [:]
 
         /// Renamed from the old `networkFrameworkWaitForConnectivity` -- no longer a straight
@@ -109,26 +126,6 @@ extension Internals.Session {
             // Always suppressed here, regardless of `tracer` above -- see the doc comment on that
             // property for why `async-http-client`'s own built-in tracing is never engaged.
             configuration.tracing.tracer = NoOpTracer()
-
-            if case .enabled(let algorithm) = compression {
-                let encoding = algorithm.build()
-
-                // `NIOHTTPRequestCompressor` is deliberately not `Sendable` (mutable per-connection
-                // compression state), so it can only be added via the synchronous pipeline API, which
-                // requires running on the channel's own event loop. AsyncHTTPClient doesn't guarantee
-                // this debug initializer runs there, hence the explicit `submit`.
-                configuration.http1_1ConnectionDebugInitializer = { channel in
-                    channel.eventLoop.submit {
-                        let sync = channel.pipeline.syncOperations
-                        let requestEncoderContext = try sync.context(handlerType: HTTPRequestEncoder.self)
-
-                        try sync.addHandler(
-                            NIOHTTPRequestCompressor(encoding: encoding),
-                            position: .after(requestEncoderContext.handler)
-                        )
-                    }
-                }
-            }
 
             return configuration
         }
@@ -211,6 +208,7 @@ extension Internals.Session.Configuration: Equatable {
             && lhs.ignoreUncleanSSLShutdown == rhs.ignoreUncleanSSLShutdown
             && lhs.decompression == rhs.decompression
             && lhs.compression == rhs.compression
+            && lhs.compressionDuplicateHeaderBehavior == rhs.compressionDuplicateHeaderBehavior
             && lhs.dnsOverride == rhs.dnsOverride
             && lhs.waitsForConnectivity == rhs.waitsForConnectivity
             && lhs.allowsCellularAccess == rhs.allowsCellularAccess
@@ -346,13 +344,19 @@ extension Internals.Session.Configuration {
     ///
     /// Only `timeout.read` maps onto `timeoutIntervalForRequest` -- `URLSessionConfiguration` has
     /// no distinct connect-phase timeout to receive `timeout.connect`. Every other field this
-    /// configuration could carry that has no `URLSessionConfiguration` counterpart (`connectionPool`,
-    /// `ignoreUncleanSSLShutdown`, `networkFrameworkWaitForConnectivity`, `compression`) is either
-    /// NIO/NIOTS-specific with nothing to translate to, or -- for the fields that matter, like
-    /// `dnsOverride`/`httpVersion == .http1Only`/`proxy.connectHeaders`/`.socks`/`.bearer`/
+    /// configuration could carry that has no `URLSessionConfiguration` counterpart
+    /// (`connectionPool`, `ignoreUncleanSSLShutdown`, `networkFrameworkWaitForConnectivity`) is
+    /// either NIO/NIOTS-specific with nothing to translate to, or -- for the fields that matter,
+    /// like `dnsOverride`/`httpVersion == .http1Only`/`proxy.connectHeaders`/`.socks`/`.bearer`/
     /// `decompression == .disabled` -- already excluded from resolving to `.urlSession` at all by
     /// `urlSessionIncompatibilityReasons()`, so there is nothing left for a compatible
     /// configuration to lose in translation.
+    ///
+    /// `compression` is deliberately absent from both lists: it no longer needs a
+    /// `URLSessionConfiguration` counterpart at all. `RequestConfiguration
+    /// .applyCompression(_:onDuplicateHeader:)` compresses `RequestBody` itself, once, before
+    /// either this method or `RequestConfiguration.build(eventLoop:)` ever runs -- every executor
+    /// receives an already-compressed body, so there is nothing left for this method to translate.
     func buildURLSessionConfiguration() -> URLSessionConfiguration {
         let configuration = URLSessionConfiguration.ephemeral
 

--- a/Sources/RequestDLInternals/Sources/Session/Session Configuration/Models/Internals.Compression+Encode.swift
+++ b/Sources/RequestDLInternals/Sources/Session/Session Configuration/Models/Internals.Compression+Encode.swift
@@ -1,0 +1,54 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+import NIOCore
+import NIOEmbedded
+import NIOHTTP1
+import NIOHTTPCompression
+
+extension Internals.Compression.Algorithm {
+
+    /// The wire name this algorithm's `Content-Encoding` value takes -- `NIOCompression
+    /// .Algorithm`'s own `description`, so this always matches whatever `NIOHTTPRequestCompressor`
+    /// itself would have written into the header.
+    package var contentEncodingValue: String {
+        build().description
+    }
+
+    /// Compresses `buffer` as a whole, using the same codec `NIOHTTPRequestCompressor` applies on
+    /// the wire for the `.nio` executor.
+    ///
+    /// Driven through an `EmbeddedChannel` rather than a live connection pipeline: by the time
+    /// this runs, the whole body is already sitting in memory as one `ByteBuffer` (see
+    /// `RequestConfiguration.applyCompression(_:onDuplicateHeader:)`), not arriving in wire order
+    /// the way a real HTTP/1.1 connection would hand it to that handler chunk by chunk. Reusing
+    /// the handler itself -- rather than binding `CNIOExtrasZlib` directly, which isn't a public
+    /// product of `swift-nio-extras` -- keeps this byte-for-byte identical to what the old
+    /// connection-pipeline-only implementation produced.
+    package func compress(_ buffer: ByteBuffer) throws -> ByteBuffer {
+        let channel = EmbeddedChannel()
+        defer { _ = try? channel.finish() }
+
+        try channel.pipeline.syncOperations.addHandler(
+            NIOHTTPRequestCompressor(encoding: build())
+        )
+
+        let head = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/")
+        try channel.writeOutbound(HTTPClientRequestPart.head(head))
+        try channel.writeOutbound(HTTPClientRequestPart.body(.byteBuffer(buffer)))
+        try channel.writeOutbound(HTTPClientRequestPart.end(nil))
+
+        var compressed = channel.allocator.buffer(capacity: buffer.readableBytes)
+
+        while let part = try channel.readOutbound(as: HTTPClientRequestPart.self) {
+            guard case .body(.byteBuffer(var chunk)) = part else {
+                continue
+            }
+
+            compressed.writeBuffer(&chunk)
+        }
+
+        return compressed
+    }
+}

--- a/Sources/RequestDLInternals/Sources/Session/Session Configuration/Models/Internals.Compression.swift
+++ b/Sources/RequestDLInternals/Sources/Session/Session Configuration/Models/Internals.Compression.swift
@@ -31,4 +31,14 @@ extension Internals.Compression {
             }
         }
     }
+
+    /// What to do when the request already carries a `Content-Encoding` header before
+    /// compression would set its own. Mirrors `Session.DuplicateHeaderBehavior`, which is the
+    /// public type this one is built from.
+    package enum DuplicateHeaderBehavior: Sendable, Hashable {
+
+        case error
+        case replace
+        case skip
+    }
 }

--- a/Tests/RequestDLTests/Properties/Sources/Session/Session/SessionTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Session/Session/SessionTests.swift
@@ -343,6 +343,73 @@ struct SessionTests {
     }
 
     @Test
+    func session_whenCompressionDefault_shouldUseErrorDuplicateHeaderBehavior() async throws {
+        // Given
+        let property = Session()
+            .compression(.gzip)
+
+        // When
+        let resolved = try await resolve(TestProperty { property })
+
+        // Then
+        #expect(resolved.session.configuration.compressionDuplicateHeaderBehavior == .error)
+    }
+
+    @Test
+    func session_whenCompressionDefault_shouldAlwaysCompress() async throws {
+        // Given
+        let property = Session()
+            .compression(.gzip)
+
+        // When
+        let resolved = try await resolve(TestProperty { property })
+
+        // Then
+        #expect(resolved.session.configuration.shouldCompressBodyData == nil)
+    }
+
+    @Test
+    func session_whenCompressionShouldCompressBodyDataSet_shouldBeValid() async throws {
+        // Given
+        let property = Session()
+            .compression(.gzip, shouldCompressBodyData: { $0 > 100 * 1_024 })
+
+        // When
+        let resolved = try await resolve(TestProperty { property })
+
+        // Then
+        let shouldCompressBodyData = try #require(resolved.session.configuration.shouldCompressBodyData)
+        #expect(shouldCompressBodyData(100 * 1_024) == false)
+        #expect(shouldCompressBodyData(100 * 1_024 + 1) == true)
+    }
+
+    @Test
+    func session_whenCompressionOnDuplicateHeaderReplace_shouldBeValid() async throws {
+        // Given
+        let property = Session()
+            .compression(.gzip, onDuplicateHeader: .replace)
+
+        // When
+        let resolved = try await resolve(TestProperty { property })
+
+        // Then
+        #expect(resolved.session.configuration.compressionDuplicateHeaderBehavior == .replace)
+    }
+
+    @Test
+    func session_whenCompressionOnDuplicateHeaderSkip_shouldBeValid() async throws {
+        // Given
+        let property = Session()
+            .compression(.gzip, onDuplicateHeader: .skip)
+
+        // When
+        let resolved = try await resolve(TestProperty { property })
+
+        // Then
+        #expect(resolved.session.configuration.compressionDuplicateHeaderBehavior == .skip)
+    }
+
+    @Test
     func session_whenPreferredExecutor_shouldBeValid() async throws {
         // Given
         let property = Session()

--- a/Tests/RequestDLTests/Request/RequestConfigurationCompressionTests.swift
+++ b/Tests/RequestDLTests/Request/RequestConfigurationCompressionTests.swift
@@ -1,0 +1,231 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+import NIOCore
+import Testing
+
+@testable import RequestDL
+@testable import RequestDLInternals
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import struct Foundation.Data
+#endif
+
+struct RequestConfigurationCompressionTests {
+
+    @Test
+    func applyCompression_whenDisabled_doesNothing() async throws {
+        // Given
+        var configuration = RequestConfiguration()
+        let payload = Data(String(repeating: "a", count: 1_024).utf8)
+        configuration.body = await RequestBody(buffers: [Internals.DataBuffer(payload)])
+
+        // When
+        try await configuration.applyCompression(.disabled, onDuplicateHeader: .error, shouldCompressBodyData: nil)
+
+        // Then
+        #expect(configuration.headers.first(name: "Content-Encoding") == nil)
+        #expect(await bytes(of: configuration.body) == payload)
+    }
+
+    @Test
+    func applyCompression_whenNoBody_doesNothing() async throws {
+        // Given
+        var configuration = RequestConfiguration()
+
+        // When
+        try await configuration.applyCompression(
+            .enabled(.gzip),
+            onDuplicateHeader: .error,
+            shouldCompressBodyData: nil
+        )
+
+        // Then
+        #expect(configuration.body == nil)
+        #expect(configuration.headers.first(name: "Content-Encoding") == nil)
+    }
+
+    @Test
+    func applyCompression_whenBodyIsEmpty_doesNothing() async throws {
+        // Given
+        var configuration = RequestConfiguration()
+        configuration.body = RequestBody(buffers: [])
+
+        // When
+        try await configuration.applyCompression(
+            .enabled(.gzip),
+            onDuplicateHeader: .error,
+            shouldCompressBodyData: nil
+        )
+
+        // Then
+        #expect(configuration.headers.first(name: "Content-Encoding") == nil)
+    }
+
+    @Test
+    func applyCompression_whenShouldCompressBodyDataReturnsFalse_doesNothing() async throws {
+        // Given
+        var configuration = RequestConfiguration()
+        let payload = Data(String(repeating: "a", count: 100_000).utf8)
+        configuration.body = await RequestBody(buffers: [Internals.DataBuffer(payload)])
+
+        // When
+        try await configuration.applyCompression(
+            .enabled(.gzip),
+            onDuplicateHeader: .error,
+            shouldCompressBodyData: { _ in false }
+        )
+
+        // Then
+        #expect(configuration.headers.first(name: "Content-Encoding") == nil)
+        #expect(await bytes(of: configuration.body) == payload)
+    }
+
+    @Test
+    func applyCompression_whenShouldCompressBodyDataReturnsTrue_receivesTheBodysByteCountAndCompresses() async throws {
+        // Given
+        var configuration = RequestConfiguration()
+        let payload = Data(String(repeating: "a", count: 100_000).utf8)
+        configuration.body = await RequestBody(buffers: [Internals.DataBuffer(payload)])
+
+        // When -- the closure only agrees to compress if it was handed exactly the body's byte
+        // count, so a `Content-Encoding` header afterward is itself proof the right value arrived.
+        try await configuration.applyCompression(
+            .enabled(.gzip),
+            onDuplicateHeader: .error,
+            shouldCompressBodyData: { $0 == payload.count }
+        )
+
+        // Then
+        #expect(configuration.headers.first(name: "Content-Encoding") == "gzip")
+    }
+
+    @Test
+    func applyCompression_whenGzipEnabled_compressesBodyAndSetsHeaders() async throws {
+        // Given
+        var configuration = RequestConfiguration()
+        let payload = Data(String(repeating: "a", count: 100_000).utf8)
+        configuration.body = await RequestBody(buffers: [Internals.DataBuffer(payload)])
+
+        // When
+        try await configuration.applyCompression(
+            .enabled(.gzip),
+            onDuplicateHeader: .error,
+            shouldCompressBodyData: nil
+        )
+
+        // Then
+        #expect(configuration.headers.first(name: "Content-Encoding") == "gzip")
+
+        let compressed = try #require(await bytes(of: configuration.body))
+        #expect(configuration.headers.first(name: "Content-Length") == String(compressed.count))
+
+        // Highly compressible, so this leaves no doubt real compression happened, not a
+        // pass-through.
+        #expect(compressed.count < payload.count / 2)
+
+        // The gzip magic number.
+        #expect(compressed.prefix(2) == Data([0x1F, 0x8B]))
+    }
+
+    @Test
+    func applyCompression_whenDeflateEnabled_compressesBodyAndSetsHeaders() async throws {
+        // Given
+        var configuration = RequestConfiguration()
+        let payload = Data(String(repeating: "a", count: 100_000).utf8)
+        configuration.body = await RequestBody(buffers: [Internals.DataBuffer(payload)])
+
+        // When
+        try await configuration.applyCompression(
+            .enabled(.deflate),
+            onDuplicateHeader: .error,
+            shouldCompressBodyData: nil
+        )
+
+        // Then
+        #expect(configuration.headers.first(name: "Content-Encoding") == "deflate")
+
+        let compressed = try #require(await bytes(of: configuration.body))
+        #expect(configuration.headers.first(name: "Content-Length") == String(compressed.count))
+        #expect(compressed.count < payload.count / 2)
+
+        // The zlib header for a default-strategy, 32K-window deflate stream.
+        #expect(compressed.first == 0x78)
+    }
+
+    @Test
+    func applyCompression_whenContentEncodingAlreadySet_andBehaviorIsError_throws() async throws {
+        // Given
+        var configuration = RequestConfiguration()
+        configuration.headers.set(name: "Content-Encoding", value: "br")
+        configuration.body = await RequestBody(buffers: [Internals.DataBuffer(Data("payload".utf8))])
+
+        // When / Then
+        do {
+            try await configuration.applyCompression(
+                .enabled(.gzip),
+                onDuplicateHeader: .error,
+                shouldCompressBodyData: nil
+            )
+            Issue.record("Expected DuplicateContentEncodingError to be thrown")
+        } catch let error as DuplicateContentEncodingError {
+            #expect(error.value == "br")
+        }
+    }
+
+    @Test
+    func applyCompression_whenContentEncodingAlreadySet_andBehaviorIsSkip_leavesRequestUntouched() async throws {
+        // Given
+        var configuration = RequestConfiguration()
+        configuration.headers.set(name: "Content-Encoding", value: "br")
+        let payload = Data("payload".utf8)
+        configuration.body = await RequestBody(buffers: [Internals.DataBuffer(payload)])
+
+        // When
+        try await configuration.applyCompression(.enabled(.gzip), onDuplicateHeader: .skip, shouldCompressBodyData: nil)
+
+        // Then
+        #expect(configuration.headers.first(name: "Content-Encoding") == "br")
+        #expect(await bytes(of: configuration.body) == payload)
+    }
+
+    @Test
+    func applyCompression_whenContentEncodingAlreadySet_andBehaviorIsReplace_compresses() async throws {
+        // Given
+        var configuration = RequestConfiguration()
+        configuration.headers.set(name: "Content-Encoding", value: "br")
+        let payload = Data(String(repeating: "a", count: 100_000).utf8)
+        configuration.body = await RequestBody(buffers: [Internals.DataBuffer(payload)])
+
+        // When
+        try await configuration.applyCompression(
+            .enabled(.gzip),
+            onDuplicateHeader: .replace,
+            shouldCompressBodyData: nil
+        )
+
+        // Then
+        #expect(configuration.headers.first(name: "Content-Encoding") == "gzip")
+
+        let compressed = try #require(await bytes(of: configuration.body))
+        #expect(compressed.count < payload.count / 2)
+    }
+}
+
+extension RequestConfigurationCompressionTests {
+
+    private func bytes(of body: RequestBody?) async -> Data? {
+        guard let body else {
+            return nil
+        }
+
+        var data = Data()
+        for await chunk in body {
+            data.append(contentsOf: chunk.readableBytesView)
+        }
+        return data
+    }
+}

--- a/Tests/RequestDLTests/Tasks/Sources/Raw Task/Raw/RawTaskExecutorDispatchTests.swift
+++ b/Tests/RequestDLTests/Tasks/Sources/Raw Task/Raw/RawTaskExecutorDispatchTests.swift
@@ -16,6 +16,7 @@ import Testing
 import FoundationEssentials
 #else
 import struct Foundation.UUID
+import struct Foundation.Data
 #endif
 
 /// `RawTask.result()` dispatches through `Internals.Session.resolvedClient()` (backed by
@@ -122,6 +123,66 @@ struct RawTaskExecutorDispatchTests {
 
         guard case .nio = try await resolved.session.resolvedClient() else {
             Issue.record("Expected the DataTask call above to have dispatched over .nio")
+            return
+        }
+    }
+
+    /// Regression coverage for the gap `Session.compression(_:)` used to have: its
+    /// `NIOHTTPRequestCompressor` was spliced into the `.nio` executor's own connection pipeline
+    /// (`Internals.Session.Configuration.build()`), which `.urlSession` never runs through --
+    /// `compression` wasn't even listed in `urlSessionIncompatibilityReasons()`, so a session
+    /// pinned (or, on Darwin, defaulted) to `.urlSession` silently sent the body uncompressed,
+    /// no error anywhere. `RequestConfiguration.applyCompression(_:onDuplicateHeader:)` now
+    /// compresses `RequestBody` itself, once, before either executor ever sees it -- this proves
+    /// that fix through the real, public `DataTask` API, pinned to `.urlSession` explicitly so
+    /// there is no ambiguity about which executor actually sent the request.
+    @Test
+    func dataTask_whenCompressionEnabledOverURLSession_sendsCompressedBody() async throws {
+        // Given
+        let localServer = try await LocalServer(.standard)
+        let uri = "/" + UUID().uuidString
+        let certificate = Certificates().server()
+        let output = "Hello World"
+
+        // Highly compressible: a single repeated byte, so gzip shrinks it drastically.
+        let payload = Data(String(repeating: "a", count: 100_000).utf8)
+
+        let response = try LocalServer.ResponseConfiguration(jsonObject: output)
+        localServer.cleanup(at: uri)
+        localServer.insert(response, at: uri)
+        defer { localServer.cleanup(at: uri) }
+
+        let content = TestProperty {
+            BaseURL(localServer.baseURL)
+            Path(uri)
+
+            Session("com.requestdl.tests.7b3-dispatch.\(UUID())")
+                .requiredExecutor(.urlSession)
+                .compression(.gzip)
+
+            SecureConnection {
+                TrustRoots(certificate.certificateURL.absolutePath(percentEncoded: false))
+            }
+
+            Payload(data: payload)
+        }
+
+        // When
+        let data = try await DataTask { content }.extractPayload().result()
+
+        // Then
+        let result = try HTTPResult<String>(data)
+        #expect(result.response == output)
+
+        // The server only ever sees the wire bytes it read, so a `receivedBytes` well below the
+        // original payload size is proof the request body actually went out gzip-compressed --
+        // over `.urlSession`, not just over `.nio`.
+        #expect(result.receivedBytes < payload.count / 2)
+
+        let resolved = try await resolve(content)
+
+        guard case .urlSession = try await resolved.session.resolvedClient() else {
+            Issue.record("Expected the DataTask call above to have dispatched over .urlSession")
             return
         }
     }

--- a/Tests/RequestDLTests/Tasks/Sources/Raw Task/Raw/SessionExecutionTests.swift
+++ b/Tests/RequestDLTests/Tasks/Sources/Raw Task/Raw/SessionExecutionTests.swift
@@ -20,11 +20,19 @@ import struct Foundation.URL
 /// Executes `requestConfiguration` through `session` with caching bypassed, mirroring the
 /// cache-then-execute orchestration `RawTask.result()` performs -- this file drives
 /// `Internals.Session` directly (no `Property` tree to resolve), so it takes over just the
-/// `client()` + `execute(client:request:...)` half of that pipeline.
+/// `applyCompression(_:onDuplicateHeader:)` + `client()` + `execute(client:request:...)` half of
+/// that pipeline (`RawTask.executeTraced` is the other caller of the first of those).
 private func execute(
     session: Internals.Session,
     requestConfiguration: RequestConfiguration
 ) async throws -> AsyncResponse {
+    var requestConfiguration = requestConfiguration
+    try await requestConfiguration.applyCompression(
+        session.configuration.compression,
+        onDuplicateHeader: session.configuration.compressionDuplicateHeaderBehavior,
+        shouldCompressBodyData: session.configuration.shouldCompressBodyData
+    )
+
     let client = try await session.client()
     let request = try requestConfiguration.build(eventLoop: client.eventLoopGroup.any())
 


### PR DESCRIPTION
## Summary

`Session.compression(_:)` (#275) compressed the outgoing request body by splicing a `NIOHTTPRequestCompressor` into the `.nio` executor's own connection pipeline (`http1_1ConnectionDebugInitializer`). That's invisible to `.urlSession` — Darwin's default executor whenever a session's configuration is compatible with it — and to HTTP/2 on every executor, with no error raised either way: compression just silently did nothing.

`RequestConfiguration.applyCompression(_:onDuplicateHeader:shouldCompressBodyData:)` replaces that approach: it compresses `RequestBody` itself, once, before any executor ever builds its transport-specific request. `RequestBody` backs the outgoing body identically for `.nio`/`.nioTransportServices`/`.urlSession`, so every executor and every negotiated HTTP version now sees the same already-compressed bytes. Compression still runs through `NIOHTTPRequestCompressor` (`swift-nio-extras`) for byte-for-byte identical wire output — just driven over an `EmbeddedChannel` instead of a live connection pipeline, so the whole body can be compressed up front instead of at the wire layer.

Also adds, mirroring Alamofire's `DeflateRequestCompressor`:
- `onDuplicateHeader: .error` (default) / `.replace` / `.skip` — what to do when the request already carries a `Content-Encoding` header.
- `shouldCompressBodyData: ((Int) -> Bool)?` — an optional gate on the body's byte count (not the full `Data`, since `RequestBody.totalSize` is already known without draining the body), so small or already-compressed bodies (e.g. images) can skip the CPU cost. `nil` (default) always compresses.

## Breaking change

`Session.compression(_:)` no longer compresses over the `.nio` executor's connection pipeline. No public API depended on that internal detail, but the *effective* behavior over `.urlSession` changes from "silently uncompressed" to "actually compressed" — labeled `breaking-changes` for the same reason #275 was.

## Test plan
- [x] `swift build`
- [x] `swift test` — full suite (1169 tests) passes
- [x] `swift format lint --recursive --strict Sources Tests Package.swift`
- [x] New regression test (`dataTask_whenCompressionEnabledOverURLSession_sendsCompressedBody`) drives a real `DataTask` pinned to `.requiredExecutor(.urlSession)` and asserts the server received well under half the original bytes — this fails without the fix, proving compression previously no-opped on `.urlSession`
- [x] Unit tests for `RequestConfiguration.applyCompression` covering `.error`/`.replace`/`.skip`, `shouldCompressBodyData`, gzip/deflate magic-byte and `Content-Length` correctness
- [x] Existing `Session.compression(_:)`/`SessionExecutionTests` compression tests updated and still passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)