### PR TITLE
chore: bump async-http-client dependency to 1.37.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/request-dl/async-http-client",
-            from: "1.37.0-beta.5"
+            from: "1.37.0"
         ),
         .package(
             url: "https://github.com/apple/swift-nio",


### PR DESCRIPTION
## Summary
- Bumps the `async-http-client` dependency pin in [Package.swift](Package.swift) from `1.37.0-beta.5` to the stable `1.37.0` tag now published on the fork
- `Package.resolved` (gitignored) picks up the corresponding resolved revision automatically

## Test plan
- [x] `swift build` succeeds
- [x] `swift test` — 500 tests passed (3 known issues, no failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)