### PR TITLE
Fix header combining correctness; drop default UA under .urlSession

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -24,15 +24,15 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/apple/swift-nio",
-            from: "2.101.3"
+            from: "2.102.0"
         ),
         .package(
             url: "https://github.com/apple/swift-nio-extras",
-            from: "1.34.3"
+            from: "1.35.1"
         ),
         .package(
             url: "https://github.com/apple/swift-nio-ssl",
-            from: "2.37.2"
+            from: "2.37.4"
         ),
         .package(
             url: "https://github.com/apple/swift-nio-transport-services",
@@ -69,7 +69,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/apple/swift-crypto.git",
-            from: "4.5.1"
+            from: "4.5.2"
         ),
     ],
     targets: [

--- a/Sources/RequestDL/Properties/Sources/Extra Properties/Configured/Configured.swift
+++ b/Sources/RequestDL/Properties/Sources/Extra Properties/Configured/Configured.swift
@@ -77,7 +77,7 @@ import NIOSSL
 ///   `secureConnection.spkiPinning.pins` (string array, required, non-empty — each entry a
 ///   Base64-encoded SHA-256 SPKI digest) and `secureConnection.spkiPinning.policy` (`"strict"` or
 ///   `"audit"`, default `"strict"`). Only SHA-256 pins are supported through `Configured`; use
-///   ``SPKIHash/init(_:algorithm:)`` directly for SHA-384/SHA-512 pins.
+///   ``SPKIHash/init(_:algorithm:)-(S,_)`` directly for SHA-384/SHA-512 pins.
 /// - `redirect` (scoped, optional): passed to ``Session``. Reads `redirect.mode` (`"follow"` or
 ///   `"disallow"`; absent entirely, the key contributes nothing rather than assuming either).
 ///   `"follow"` additionally reads `redirect.maxRedirects` (int, default `5`) and

--- a/Sources/RequestDL/Properties/Sources/Headers/Header Group/HeaderGroup.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Header Group/HeaderGroup.swift
@@ -72,6 +72,16 @@ extension HeaderGroup where Content == PropertyForEach<[String: String], String,
     ///
     /// Initializes a new `HeaderGroup` with a dictionary of headers.
     ///
+    /// - Important: `Dictionary` iteration order is unspecified and can vary between runs of the
+    /// same process. This is invisible for keys that are actually distinct headers, but if the
+    /// dictionary happens to carry two keys that only differ by case (e.g. `"User-Agent"` and
+    /// `"user-agent"` -- distinct dictionary keys to Swift, since `String` equality is
+    /// case-sensitive, but the same header once resolved, since header names are compared
+    /// case-insensitively per RFC 9110), which one wins -- or the order they combine in under
+    /// ``HeaderStrategy/adding`` -- is not guaranteed to be the same across runs. Use
+    /// ``init(content:)`` with an explicit, ordered list of ``CustomHeader``s instead when that
+    /// matters.
+    ///
     /// - Parameter dictionary: A dictionary containing header properties.
     ///
     public init(_ dictionary: [String: Any]) {

--- a/Sources/RequestDL/Properties/Sources/Headers/Headers/Accept Charset/AcceptCharsetHeader.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Headers/Accept Charset/AcceptCharsetHeader.swift
@@ -7,6 +7,20 @@
 /// This is a specific feature that should be explored according to the needs of each endpoint. JSON in Swift, for
 /// example, uses `UTF-8`, `UTF-16`, and `UTF-32` during decoding and fails if other charsets are used.
 /// Therefore, always use this option only if it is truly necessary.
+///
+/// - Warning: `Accept-Charset` is a legacy header the web platform has moved away from. The
+/// WHATWG Fetch Standard lists it among the forbidden request-header names a browser refuses to
+/// let a caller set at all (`fetch()`/`XMLHttpRequest.setRequestHeader` both reject it), and
+/// browsers stopped sending it on ordinary navigations years ago -- most servers, and every JSON
+/// endpoint (UTF-8 by definition), already ignore it. Sending it today mostly just signals a
+/// non-browser client. Prefer negotiating charset through the response's own `Content-Type`, or
+/// an application-level convention with the server, instead.
+@available(
+    *,
+    deprecated,
+    message:
+        "Accept-Charset is a legacy header most servers already ignore, and the WHATWG Fetch Standard forbids browsers from sending it at all. Negotiate charset through the response's own Content-Type instead."
+)
 public struct AcceptCharsetHeader: Property {
 
     // MARK: - Public properties

--- a/Sources/RequestDL/Properties/Sources/Headers/Headers/Cache/CacheHeader.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Headers/Cache/CacheHeader.swift
@@ -63,11 +63,14 @@ public struct CacheHeader: Property {
     ) async throws -> _PropertyOutputs {
         property.assertPathway()
 
-        let separator = inputs.environment.headerSeparator ?? ","
-
+        // Cache-Control's directive list (RFC 9111 §5.2, `1#cache-directive`) is comma-delimited
+        // by definition -- hardcoded here rather than deferring to `.headerSeparator(_:)`, the
+        // same way `HeaderNode`'s own `commaSeparatedNames` forces this header's *cross-instance*
+        // combining to "," regardless of what the environment configures. Anything else joined
+        // in would parse as one opaque, meaningless directive instead of a recognizable list.
         let value = property.pointer()
             .makeContents()
-            .joined(separator: separator)
+            .joined(separator: ",")
 
         if value.isEmpty {
             return .empty
@@ -78,7 +81,7 @@ public struct CacheHeader: Property {
                 key: "Cache-Control",
                 value: value,
                 strategy: inputs.environment.headerStrategy,
-                separator: separator
+                separator: ","
             )
         )
     }

--- a/Sources/RequestDL/Properties/Sources/Headers/Headers/Header Node/HeaderNode.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Headers/Header Node/HeaderNode.swift
@@ -49,10 +49,42 @@ struct HeaderNode: PropertyNode {
         }
     }
 
+    // MARK: - Private properties
+
+    /// Header names whose value every governing spec defines as singular -- repeating the field
+    /// line, or splicing a second value into it with whatever separator happens to be in scope,
+    /// either violates the field's own grammar or produces something that fails to parse as
+    /// anything valid at all.
+    ///
+    /// `Host`: RFC 9110 §7.2 -- a server MUST 400 a request carrying more than one. `Origin`
+    /// (RFC 6454/Fetch) and `Referer` (RFC 9110 §10.1.3) are each a single serialized value, not
+    /// a list. `Authorization`, `Content-Type`, and `Content-Length` are each exactly one
+    /// credentials/media-type/byte-count value -- `Payload`/`Authorization`/`DigestAuthentication`
+    /// already write them via a direct `headers.set(...)`, bypassing `HeaderNode` entirely, but
+    /// that only stops those *specific* properties from duplicating themselves. It does nothing
+    /// to stop an unrelated `CustomHeader` that happens to case-insensitively collide with one of
+    /// these names (e.g. `CustomHeader(name: "content-type", ...)` after a `Payload`) from
+    /// appending onto it via `.adding`, or -- worse, when a separator is also in scope -- from
+    /// splicing its value directly into the existing one, silently corrupting it into a single
+    /// unparseable string. Enforcing this here, for every write regardless of which `Property`
+    /// produced it, is the one place that closes both vectors.
+    ///
+    /// Deliberately excludes `User-Agent`: combining multiple ``UserAgentHeader`` instances is a
+    /// documented, intentional feature (see its own doc comment), so it cannot be forced to
+    /// always overwrite the way these can.
+    private static let singleValuedNames: Set<String> = [
+        "host", "origin", "referer", "authorization", "content-type", "content-length",
+    ]
+
     // MARK: - Private methods
 
     private func callAsFunction(_ headers: inout HTTPHeaders) {
         guard !key.isEmpty else {
+            return
+        }
+
+        guard !Self.singleValuedNames.contains(key.lowercased()) else {
+            headers.set(name: key, value: value)
             return
         }
 

--- a/Sources/RequestDL/Properties/Sources/Headers/Headers/Header Node/HeaderNode.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Headers/Header Node/HeaderNode.swift
@@ -44,7 +44,10 @@ struct HeaderNode: PropertyNode {
     func make(_ make: inout Make) async throws {
         self(&make.requestConfiguration.headers)
 
-        if key.caseInsensitiveCompare("User-Agent") == .orderedSame {
+        // `.lowercased()`, not Foundation's `caseInsensitiveCompare(_:)` -- unavailable outside
+        // Darwin (FoundationEssentials/Linux/Android), and this path runs for every executor,
+        // not just `.urlSession`.
+        if key.lowercased() == "user-agent" {
             make.requestConfiguration.markUserAgentWritten(isDefault: isDefaultUserAgent)
         }
     }

--- a/Sources/RequestDL/Properties/Sources/Headers/Headers/Header Node/HeaderNode.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Headers/Header Node/HeaderNode.swift
@@ -11,6 +11,14 @@ struct HeaderNode: PropertyNode {
     let strategy: HeaderStrategy
     let separator: String?
 
+    /// Whether this node is RequestDL's own untouched default `User-Agent`
+    /// (``UserAgentHeader/init()``), as opposed to a caller-supplied value.
+    ///
+    /// `false` for every header other than the default `User-Agent`. See
+    /// `RequestConfiguration.hasDefaultUserAgent` for how this is folded across every `User-Agent`
+    /// node in the tree.
+    let isDefaultUserAgent: Bool
+
     var makeHeadersClosure: @Sendable (inout HTTPHeaders) -> Void {
         { self(&$0) }
     }
@@ -21,18 +29,24 @@ struct HeaderNode: PropertyNode {
         key: String,
         value: String,
         strategy: HeaderStrategy,
-        separator: String?
+        separator: String?,
+        isDefaultUserAgent: Bool = false
     ) {
         self.key = key
         self.value = value
         self.strategy = strategy
         self.separator = separator
+        self.isDefaultUserAgent = isDefaultUserAgent
     }
 
     // MARK: - Internal methods
 
     func make(_ make: inout Make) async throws {
         self(&make.requestConfiguration.headers)
+
+        if key.caseInsensitiveCompare("User-Agent") == .orderedSame {
+            make.requestConfiguration.markUserAgentWritten(isDefault: isDefaultUserAgent)
+        }
     }
 
     // MARK: - Private methods
@@ -69,6 +83,7 @@ extension HeaderNode: CustomReflectable {
                 (label: "value", value: value),
                 (label: "strategy", value: strategy),
                 (label: "separator", value: separator as Any),
+                (label: "isDefaultUserAgent", value: isDefaultUserAgent),
             ]
         )
     }

--- a/Sources/RequestDL/Properties/Sources/Headers/Headers/Header Node/HeaderNode.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Headers/Header Node/HeaderNode.swift
@@ -76,6 +76,26 @@ struct HeaderNode: PropertyNode {
         "host", "origin", "referer", "authorization", "content-type", "content-length",
     ]
 
+    /// Header names whose combined value RFC 9110/9111 define as a comma-separated list --
+    /// `,` (plus optional whitespace) is the *only* separator any spec sanctions for folding
+    /// multiple field lines into one, regardless of what `.headerSeparator(_:)` a caller passes.
+    ///
+    /// This isn't a matter of taste: `;` in particular already means something inside these
+    /// headers' own grammar. `Accept`/`Accept-Charset`/`Accept-Encoding`/`Accept-Language` use it
+    /// to attach a `q` parameter to the *previous* element (`text/html;q=0.9`) -- joining two
+    /// instances with `.headerSeparator(";")` produces `text/html;q=0.9;application/json`, which
+    /// a compliant `#(media-range)` parser reads as `application/json` being an (invalid)
+    /// parameter of `text/html`, not a second accepted type. `Cache-Control`'s directive list
+    /// (`1#cache-directive`, RFC 9111 §5.2) has no comparable internal use of `;`, but still
+    /// parses as one opaque, meaningless directive if joined with anything but `,`.
+    ///
+    /// Only for headers RequestDL itself defines the semantics of. `CustomHeader` is deliberately
+    /// left alone -- for an arbitrary, non-standard header name, whatever separator its own
+    /// backend expects (if any) isn't something RequestDL can know or second-guess.
+    private static let commaSeparatedNames: Set<String> = [
+        "accept", "accept-charset", "accept-encoding", "accept-language", "cache-control",
+    ]
+
     // MARK: - Private methods
 
     private func callAsFunction(_ headers: inout HTTPHeaders) {
@@ -91,8 +111,9 @@ struct HeaderNode: PropertyNode {
         switch strategy {
         case .adding:
             if let separator {
+                let effectiveSeparator = Self.commaSeparatedNames.contains(key.lowercased()) ? "," : separator
                 let currentValue = (headers[key] ?? [])
-                let inlineValue = (currentValue + [value]).joined(separator: separator)
+                let inlineValue = (currentValue + [value]).joined(separator: effectiveSeparator)
                 headers.set(name: key, value: inlineValue)
             } else {
                 headers.add(name: key, value: value)

--- a/Sources/RequestDL/Properties/Sources/Headers/Headers/User Agent/UserAgentHeader.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Headers/User Agent/UserAgentHeader.swift
@@ -45,6 +45,13 @@ public struct UserAgentHeader: Property {
     /// the wire as given.
     private let isDefault: Bool
 
+    /// `ProcessInfo.processInfo.userAgent` bundle/version/OS lookups and string interpolation,
+    /// computed once per process rather than on every ``init()`` call -- none of its inputs
+    /// change while the process is running, and `init()` runs again every time a request's
+    /// property tree is rebuilt (`_makeProperty` is called once per resolve), not once per app
+    /// launch.
+    private static let defaultValue = ProcessInfo.processInfo.userAgent
+
     // MARK: - Inits
 
     ///
@@ -59,7 +66,7 @@ public struct UserAgentHeader: Property {
 
     /// Initialize the `User-Agent` with **APP\_NAME/APP\_VERSION SYS\_NAME/SYS\_VERSION** value.
     public init() {
-        value = ProcessInfo.processInfo.userAgent
+        value = Self.defaultValue
         isDefault = true
     }
 

--- a/Sources/RequestDL/Properties/Sources/Headers/Headers/User Agent/UserAgentHeader.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Headers/User Agent/UserAgentHeader.swift
@@ -35,6 +35,16 @@ public struct UserAgentHeader: Property {
 
     private let value: String
 
+    /// Whether this is RequestDL's own built-in default (the empty ``init()``), as opposed to a
+    /// caller-supplied value from ``init(_:)``.
+    ///
+    /// Threaded through to ``HeaderNode`` so the `.urlSession` executor can later drop this
+    /// header and let URLSession report its own native `CFNetwork`/`Darwin` value instead of
+    /// RequestDL's neutral one — see `RequestConfiguration.dropDefaultUserAgentForNativeReporting()`.
+    /// Only the untouched default may be dropped this way; anything the caller wrote must reach
+    /// the wire as given.
+    private let isDefault: Bool
+
     // MARK: - Inits
 
     ///
@@ -44,11 +54,13 @@ public struct UserAgentHeader: Property {
     ///
     public init<S: StringProtocol>(_ userAgent: S) {
         self.value = String(userAgent)
+        self.isDefault = false
     }
 
     /// Initialize the `User-Agent` with **APP\_NAME/APP\_VERSION SYS\_NAME/SYS\_VERSION** value.
     public init() {
         value = ProcessInfo.processInfo.userAgent
+        isDefault = true
     }
 
     // MARK: - Public static methods
@@ -64,7 +76,8 @@ public struct UserAgentHeader: Property {
                 key: "User-Agent",
                 value: property.value.trimming(where: \.isWhitespace),
                 strategy: inputs.environment.headerStrategy,
-                separator: " "
+                separator: " ",
+                isDefaultUserAgent: property.isDefault
             )
         )
     }

--- a/Sources/RequestDL/Request/RequestConfiguration.swift
+++ b/Sources/RequestDL/Request/RequestConfiguration.swift
@@ -78,6 +78,21 @@ public struct RequestConfiguration: Sendable {
 
     var readingMode: Internals.DownloadStep.ReadingMode
 
+    /// `true` only when the `User-Agent` currently in ``headers`` is exactly RequestDL's own
+    /// untouched default (``UserAgentHeader/init()``) — no other `User-Agent` node has written
+    /// to it since. Kept up to date by `markUserAgentWritten(isDefault:)` as `HeaderNode`s fold
+    /// into this configuration.
+    ///
+    /// Lets `.urlSession` drop the header and defer to URLSession's own native
+    /// `CFNetwork`/`Darwin` report — see `dropDefaultUserAgentForNativeReporting()` — without
+    /// ever touching a value the caller actually asked for.
+    private(set) var hasDefaultUserAgent = false
+
+    /// Whether any `User-Agent` node has folded in yet. Once true, a second write — default or
+    /// not — means the header is no longer purely RequestDL's untouched default, so
+    /// `hasDefaultUserAgent` latches to `false` for the rest of resolution.
+    private var didWriteUserAgent = false
+
     // MARK: - Inits
 
     init() {
@@ -94,6 +109,32 @@ public struct RequestConfiguration: Sendable {
     }
 
     // MARK: - Internal methods
+
+    /// Records that a `User-Agent` `HeaderNode` folded into ``headers``, updating
+    /// ``hasDefaultUserAgent`` accordingly. Called once per `User-Agent` node, in tree order.
+    mutating func markUserAgentWritten(isDefault: Bool) {
+        hasDefaultUserAgent = !didWriteUserAgent && isDefault
+        didWriteUserAgent = true
+    }
+
+    /// Removes RequestDL's own default `User-Agent`, when present untouched, so the executor
+    /// that actually sends this request can report itself instead.
+    ///
+    /// Only ever call this for the `.urlSession` executor: URLSession synthesizes its own
+    /// accurate `AppName/version Darwin/version CFNetwork/version` header whenever a request
+    /// carries none at all, and RequestDL's neutral default would otherwise suppress that native
+    /// report. NIO and NIOTransportServices never synthesize a `User-Agent` of their own, so
+    /// dropping it there would just send the request with none — worse than RequestDL's
+    /// transport-agnostic default, not more honest. A no-op whenever the caller supplied their
+    /// own value: only the untouched default is eligible.
+    mutating func dropDefaultUserAgentForNativeReporting() {
+        guard hasDefaultUserAgent else {
+            return
+        }
+
+        headers.remove(name: "User-Agent")
+        hasDefaultUserAgent = false
+    }
 
     /// - Parameter eventLoop: Hosts the task that streams the body, when there is one. See
     /// ``RequestBody/connect(writer:body:eventLoop:)``.

--- a/Sources/RequestDL/Tasks/Sources/Modifiers/Description/TaskDescriptor.swift
+++ b/Sources/RequestDL/Tasks/Sources/Modifiers/Description/TaskDescriptor.swift
@@ -5,7 +5,7 @@
 /// Produces a description of a resolved request without performing it.
 ///
 /// ``DataTask``, ``DownloadTask``, and ``UploadTask`` each expose a generic
-/// ``RequestTask/description(_:)`` that resolves their `Property` content the same way
+/// ``DataTask/description(_:)`` that resolves their `Property` content the same way
 /// ``RequestTask/result()`` would, then hands the outcome to a `TaskDescriptor` instead of
 /// executing the request over the network.
 ///

--- a/Sources/RequestDL/Tasks/Sources/Raw Task/Raw/RawTask.swift
+++ b/Sources/RequestDL/Tasks/Sources/Raw Task/Raw/RawTask.swift
@@ -43,7 +43,7 @@ struct RawTask<Content: Property>: RequestTask {
             logger: environment.logger
         )
 
-        let client = try await resolveClient(resolved: resolved)
+        let (client, isURLSessionExecutor) = try await resolveClient(resolved: resolved)
 
         let cacheControl = Internals.CacheControl(
             requestConfiguration: resolved.requestConfiguration,
@@ -54,6 +54,7 @@ struct RawTask<Content: Property>: RequestTask {
         let (sessionTask, onResponseHead) = try await runSession(
             resolved: resolved,
             client: client,
+            isURLSessionExecutor: isURLSessionExecutor,
             cacheControl: cacheControl,
             logger: logger,
             deadline: deadline
@@ -117,14 +118,24 @@ struct RawTask<Content: Property>: RequestTask {
     /// one. `resolvedClient()` returns `Internals.ClientManager.Client` (an enum), not
     /// `any RequestExecutingClient` directly -- see that method's own doc comment for why -- so
     /// this is the one place that unwraps it into the existential everything below expects.
-    private func resolveClient(resolved: Resolved) async throws -> any RequestExecutingClient {
+    ///
+    /// Also the one place that knows, concretely, which case was picked -- surfaced as
+    /// `isURLSessionExecutor` so `executeTraced` can decide whether to drop RequestDL's default
+    /// `User-Agent` in favor of URLSession's own native one (see
+    /// `RequestConfiguration.dropDefaultUserAgentForNativeReporting()`). `.nioTransportServices`
+    /// never reaches its own case here -- `Internals.ClientManager.Client` only distinguishes
+    /// `.nio`/`.urlSession`, folding NIOTransportServices into `.nio` since both share the same
+    /// `RequestExecutingClient` conformance and differ only in which `EventLoopGroup` backs them.
+    private func resolveClient(
+        resolved: Resolved
+    ) async throws -> (client: any RequestExecutingClient, isURLSessionExecutor: Bool) {
         do {
             switch try await resolved.session.resolvedClient() {
             case .nio(let nioClient):
-                return nioClient
+                return (nioClient, false)
             #if canImport(Darwin)
             case .urlSession(let urlSessionClient):
-                return urlSessionClient
+                return (urlSessionClient, true)
             #endif
             }
         } catch let error as Internals.SecureFileLoadError {
@@ -152,12 +163,13 @@ struct RawTask<Content: Property>: RequestTask {
     ///
     /// Only rebinds the task-local when `RequestServiceContext` was actually declared -- leaving
     /// it untouched otherwise preserves whatever `ServiceContext.current` the caller's own task
-    /// already carries. `executeTraced(resolved:client:cache:logger:)` starts its span reading
-    /// this same task-local, so both the explicit and the ambient case are picked up correctly
-    /// here -- there's no `EventLoop` hop between the bind and the read.
+    /// already carries. `executeTraced(resolved:client:isURLSessionExecutor:cache:logger:)` starts
+    /// its span reading this same task-local, so both the explicit and the ambient case are picked
+    /// up correctly here -- there's no `EventLoop` hop between the bind and the read.
     private func runSession(
         resolved: Resolved,
         client: any RequestExecutingClient,
+        isURLSessionExecutor: Bool,
         cacheControl: Internals.CacheControl,
         logger: Internals.TaskLogger?,
         deadline: Internals.ResourceDeadline
@@ -176,6 +188,7 @@ struct RawTask<Content: Property>: RequestTask {
                 return try await Self.executeTraced(
                     resolved: resolved,
                     client: client,
+                    isURLSessionExecutor: isURLSessionExecutor,
                     cache: cache,
                     logger: logger
                 )
@@ -213,10 +226,18 @@ struct RawTask<Content: Property>: RequestTask {
     private static func executeTraced(
         resolved: Resolved,
         client: any RequestExecutingClient,
+        isURLSessionExecutor: Bool,
         cache: (@Sendable (Internals.ResponseHead) -> Internals.AsyncStream<Internals.DataBuffer>?)?,
         logger: Internals.TaskLogger?
     ) async throws -> (task: SessionTask, onResponseHead: OnResponseHead?) {
         var configuration = resolved.requestConfiguration
+
+        // Only `.urlSession` gets its default `User-Agent` dropped -- see
+        // `dropDefaultUserAgentForNativeReporting()`'s own doc comment for why NIO and
+        // NIOTransportServices keep RequestDL's neutral default instead.
+        if isURLSessionExecutor {
+            configuration.dropDefaultUserAgentForNativeReporting()
+        }
 
         try await configuration.applyCompression(
             resolved.session.configuration.compression,

--- a/Tests/RequestDLTestSupport/HTTP/LocalServer.HTTPHandler.swift
+++ b/Tests/RequestDLTestSupport/HTTP/LocalServer.HTTPHandler.swift
@@ -168,6 +168,10 @@ extension LocalServer {
                 jsonObject["receivedCookieHeader"] = .string(cookie)
             }
 
+            if let userAgent = _incomeHeaders?.first(name: "User-Agent") {
+                jsonObject["receivedUserAgentHeader"] = .string(userAgent)
+            }
+
             let encoder = JSONEncoder()
             encoder.outputFormatting = [.sortedKeys]
             return try? encoder.encode(jsonObject)

--- a/Tests/RequestDLTestSupport/HTTP/Models/HTTPResult.swift
+++ b/Tests/RequestDLTestSupport/HTTP/Models/HTTPResult.swift
@@ -21,6 +21,12 @@ struct HTTPResult<Response: Codable>: Codable, Equatable where Response: Equatab
     /// inline default is never decoded by the synthesized `init(from:)` at all -- it would stay
     /// `nil` even when the JSON has the key. See `LocalServer.HTTPHandler.responseData()`.
     var receivedCookieHeader: String? = nil
+
+    /// The `User-Agent` header value `LocalServer` actually received on this request, if any --
+    /// same additive shape as ``receivedCookieHeader`` above. Lets a test prove what actually
+    /// reached the wire: RequestDL's own neutral default, a caller-supplied value untouched, or
+    /// -- once dropped under `.urlSession` -- URLSession's own native `CFNetwork`/`Darwin` report.
+    var receivedUserAgentHeader: String? = nil
 }
 
 extension HTTPResult {

--- a/Tests/RequestDLTests/Properties/Sources/Graph/Resolve/ResolveTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Graph/Resolve/ResolveTests.swift
@@ -123,7 +123,8 @@ extension ResolveTests {
                         key = Accept,
                         value = application/json,
                         strategy = .adding,
-                        separator = nil
+                        separator = nil,
+                        isDefaultUserAgent = false
                     }
                 },
                 LeafNode<HeaderNode> {
@@ -133,7 +134,8 @@ extension ResolveTests {
                         strategy = .adding,
                         separator = Optional<String> {
                             some = ,
-                        }
+                        },
+                        isDefaultUserAgent = false
                     }
                 },
                 LeafNode<Node> {
@@ -187,7 +189,8 @@ extension ResolveTests {
                             key = Accept,
                             value = application/json,
                             strategy = .adding,
-                            separator = nil
+                            separator = nil,
+                            isDefaultUserAgent = false
                         }
                     },
                     LeafNode<HeaderNode> {
@@ -197,7 +200,8 @@ extension ResolveTests {
                             strategy = .adding,
                             separator = Optional<String> {
                                 some = ,
-                            }
+                            },
+                            isDefaultUserAgent = false
                         }
                     }
                 },

--- a/Tests/RequestDLTests/Properties/Sources/Headers/Headers/Header Node/HeaderNodeCommaSeparatedNamesTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Headers/Headers/Header Node/HeaderNodeCommaSeparatedNamesTests.swift
@@ -1,0 +1,112 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+import Testing
+
+@testable import RequestDL
+
+/// Regression coverage for `HeaderNode.commaSeparatedNames`: `Accept`, `Accept-Charset`,
+/// `Accept-Encoding`, `Accept-Language`, and `Cache-Control` must always combine with `,`, no
+/// matter what `.headerSeparator(_:)` is in scope -- RFC 9110/9111 define each of these as a
+/// comma-separated list, and `;` in particular already means something inside the `Accept-*`
+/// family's own grammar (`q` parameters), so honoring an arbitrary separator there wouldn't just
+/// be non-standard, it would actively misparse.
+struct HeaderNodeCommaSeparatedNamesTests {
+
+    // MARK: - Same property declared twice, non-comma separator in scope
+
+    @Test
+    func accept_whenCombinedUnderNonCommaSeparator_forcesComma() async throws {
+        // Given -- `;` already separates a media-range from its own `q` parameter; joining two
+        // instances with it instead of `,` would misparse the second value as a parameter of the
+        // first.
+        let resolved = try await resolve(
+            TestProperty {
+                HeaderGroup {
+                    AcceptHeader(.json)
+                    AcceptHeader(.jpeg)
+                }
+                .headerStrategy(.adding)
+                .headerSeparator(";")
+            }
+        )
+
+        #expect(resolved.requestConfiguration.headers["Accept"] == ["application/json,image/jpeg"])
+    }
+
+    @Test
+    func cacheControl_whenCombinedUnderNonCommaSeparator_forcesComma() async throws {
+        // Given
+        let resolved = try await resolve(
+            TestProperty {
+                HeaderGroup {
+                    CacheHeader().stored(false)
+                    CacheHeader().cached(false)
+                }
+                .headerStrategy(.adding)
+                .headerSeparator(";")
+            }
+        )
+
+        // Then -- RFC 9111 §5.2: `1#cache-directive` is comma-delimited; joined with anything
+        // else it would parse as one opaque, unrecognized directive.
+        #expect(resolved.requestConfiguration.headers["Cache-Control"] == ["no-store,no-cache"])
+    }
+
+    // MARK: - A single instance's own internal directive list
+
+    @Test
+    func cacheControl_whenHeaderSeparatorOverridden_stillJoinsOwnDirectivesWithComma() async throws {
+        // Given -- a single `CacheHeader` instance joins its *own* multiple directives before
+        // `HeaderNode` is ever involved, so this exercises `CacheHeader`'s own hardcoded `,`
+        // rather than `HeaderNode.commaSeparatedNames`.
+        let resolved = try await resolve(
+            TestProperty {
+                CacheHeader()
+                    .cached(false)
+                    .stored(false)
+            }
+            .headerSeparator(";")
+        )
+
+        #expect(resolved.requestConfiguration.headers["Cache-Control"] == ["no-cache,no-store"])
+    }
+
+    // MARK: - Collision with an unrelated `CustomHeader`, non-comma separator in scope
+
+    @Test
+    func acceptEncoding_whenCollidingWithCustomHeaderUnderNonCommaSeparator_forcesComma() async throws {
+        // Given
+        let resolved = try await resolve(
+            TestProperty {
+                AcceptEncodingHeader(.gzip)
+                CustomHeader(name: "accept-encoding", value: "br")
+                    .headerStrategy(.adding)
+                    .headerSeparator(";")
+            }
+        )
+
+        #expect(resolved.requestConfiguration.headers["Accept-Encoding"] == ["gzip;q=1.0,br"])
+    }
+
+    // MARK: - Control: an unrelated `CustomHeader` name keeps its own configured separator
+
+    @Test
+    func customHeader_whenCombinedUnderNonCommaSeparator_keepsItsOwnSeparator() async throws {
+        // Given -- an arbitrary header name RequestDL doesn't define the semantics of; forcing
+        // comma here would be an overreach `commaSeparatedNames` deliberately doesn't make.
+        let resolved = try await resolve(
+            TestProperty {
+                HeaderGroup {
+                    CustomHeader(name: "x-tags", value: "a")
+                    CustomHeader(name: "x-tags", value: "b")
+                }
+                .headerStrategy(.adding)
+                .headerSeparator(";")
+            }
+        )
+
+        #expect(resolved.requestConfiguration.headers["x-tags"] == ["a;b"])
+    }
+}

--- a/Tests/RequestDLTests/Properties/Sources/Headers/Headers/Header Node/HeaderNodeSingleValuedNamesTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Headers/Headers/Header Node/HeaderNodeSingleValuedNamesTests.swift
@@ -1,0 +1,146 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+import Testing
+
+@testable import RequestDL
+
+/// Regression coverage for `HeaderNode.singleValuedNames`: `Host`, `Origin`, `Referer`,
+/// `Authorization`, `Content-Type`, and `Content-Length` must always overwrite, never combine or
+/// duplicate, no matter what `.headerStrategy`/`.headerSeparator` is in scope or which `Property`
+/// produced the colliding write.
+///
+/// Two failure modes existed before this fix, both reproduced here:
+/// - No separator in scope: `.adding` fell through to `headers.add(...)`, leaving two raw values
+///   on the same logical entry -- which, for a header a server or client is only allowed to see
+///   once (RFC 9110 §7.2 mandates a 400 for a duplicate `Host`, for instance), reaches the wire
+///   as either two field lines or a client-coalesced single line, neither of them what any of
+///   these headers' own grammar defines.
+/// - A separator in scope: `.adding` spliced the new value directly into whatever was already
+///   there, producing one *corrupted* string (e.g. a `Content-Type` reading
+///   `"application/json; charset=UTF-8,application/xml"`) that fails to parse as anything valid
+///   at all -- strictly worse than the no-separator case, since even the original value is lost.
+struct HeaderNodeSingleValuedNamesTests {
+
+    // MARK: - Same property declared twice
+
+    @Test
+    func host_whenDeclaredTwiceUnderAddingStrategy_overwritesInsteadOfCombining() async throws {
+        // Given
+        let resolved = try await resolve(
+            TestProperty {
+                HeaderGroup {
+                    HostHeader("first.example.com")
+                    HostHeader("second.example.com")
+                }
+                .headerStrategy(.adding)
+            }
+        )
+
+        // Then -- RFC 9110 §7.2: a server MUST 400 a request carrying more than one Host field.
+        #expect(resolved.requestConfiguration.headers["Host"] == ["second.example.com"])
+    }
+
+    @Test
+    func origin_whenDeclaredTwiceUnderAddingStrategy_overwritesInsteadOfCombining() async throws {
+        // Given
+        let resolved = try await resolve(
+            TestProperty {
+                HeaderGroup {
+                    OriginHeader("https://first.example.com")
+                    OriginHeader("https://second.example.com")
+                }
+                .headerStrategy(.adding)
+            }
+        )
+
+        // Then -- a single serialized origin (RFC 6454/Fetch), never a list.
+        #expect(resolved.requestConfiguration.headers["Origin"] == ["https://second.example.com"])
+    }
+
+    @Test
+    func referer_whenDeclaredTwiceUnderAddingStrategy_overwritesInsteadOfCombining() async throws {
+        // Given
+        let resolved = try await resolve(
+            TestProperty {
+                HeaderGroup {
+                    RefererHeader("https://first.example.com/")
+                    RefererHeader("https://second.example.com/")
+                }
+                .headerStrategy(.adding)
+            }
+        )
+
+        // Then -- a single URI-reference (RFC 9110 §10.1.3), never a list.
+        #expect(resolved.requestConfiguration.headers["Referer"] == ["https://second.example.com/"])
+    }
+
+    // MARK: - Collision with an unrelated `CustomHeader`, no separator in scope
+
+    @Test
+    func host_whenCollidingWithDifferentlyCasedCustomHeader_overwritesWithoutDuplicating() async throws {
+        // Given
+        let resolved = try await resolve(
+            TestProperty {
+                HostHeader("original.example.com")
+                CustomHeader(name: "host", value: "collided.example.com")
+            }
+        )
+
+        // Then -- a plain `.add()` would have left two raw values instead of one.
+        #expect(resolved.requestConfiguration.headers["Host"] == ["collided.example.com"])
+    }
+
+    @Test
+    func authorization_whenCollidingWithDifferentlyCasedCustomHeader_overwritesWithoutDuplicating() async throws {
+        // Given -- `Authorization` writes via a direct `headers.set(...)`, bypassing `HeaderNode`
+        // entirely; that alone doesn't stop a later `CustomHeader` from appending onto it.
+        let resolved = try await resolve(
+            TestProperty {
+                Authorization(.bearer, token: "original-token")
+                CustomHeader(name: "authorization", value: "Bearer collided-token")
+            }
+        )
+
+        #expect(resolved.requestConfiguration.headers["Authorization"] == ["Bearer collided-token"])
+    }
+
+    // MARK: - Collision with an unrelated `CustomHeader`, explicit separator in scope
+
+    @Test
+    func host_whenCollidingWithCustomHeaderUnderExplicitSeparator_overwritesWithoutCorrupting() async throws {
+        // Given -- the sharper failure mode: with a separator in scope, `.adding` used to splice
+        // the new value directly into the existing one instead of just duplicating it.
+        let resolved = try await resolve(
+            TestProperty {
+                HostHeader("original.example.com")
+                CustomHeader(name: "host", value: "collided.example.com")
+                    .headerStrategy(.adding)
+                    .headerSeparator(",")
+            }
+        )
+
+        #expect(resolved.requestConfiguration.headers["Host"] == ["collided.example.com"])
+    }
+
+    @Test
+    func contentType_whenCollidingWithCustomHeaderUnderExplicitSeparator_overwritesWithoutCorrupting() async throws {
+        // Given -- the exact scenario that motivated this fix: `Payload` sets `Content-Type` via
+        // a direct `.set()`, then a colliding `CustomHeader` with a separator in scope used to
+        // splice its value directly into it, producing an unparseable single string
+        // ("application/json; charset=UTF-8,application/xml").
+        let resolved = try await resolve(
+            TestProperty {
+                Payload(verbatim: "test", contentType: .json)
+
+                CustomHeader(name: "content-type", value: "application/xml")
+                    .headerStrategy(.adding)
+                    .headerSeparator(",")
+            }
+        )
+
+        // Then -- one valid value, not a garbled concatenation of both.
+        #expect(resolved.requestConfiguration.headers["Content-Type"] == ["application/xml"])
+    }
+}

--- a/Tests/RequestDLTests/Properties/Sources/Headers/Headers/User Agent/UserAgentHeaderTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Headers/Headers/User Agent/UserAgentHeaderTests.swift
@@ -163,7 +163,7 @@ struct UserAgentHeaderTests {
         // `CustomHeader` defaults to `headerSeparator == nil`, unlike `UserAgentHeader`'s own
         // hardcoded `" "` -- so this is stored as two separate values on one logical entry, not
         // joined into a single string the way `UserAgentHeader(_:)` combining is. See
-        // `RawTaskExecutorDispatchTests.dataTask_withDefaultUserAgentCombinedWithDifferentlyCasedCustomHeaderOverURLSession_mergesBothOntoTheWire`
+        // `RawTaskExecutorDispatchTests.dataTask_defaultUserAgentCollidesWithCustomHeaderOverURLSession_mergesOntoTheWire`
         // for how `URLRequest` itself coalesces this into one comma-joined header on the wire.
         #expect(resolved.requestConfiguration.headers["User-Agent"] == [ProcessInfo.processInfo.userAgent, "ABC"])
     }

--- a/Tests/RequestDLTests/Properties/Sources/Headers/Headers/User Agent/UserAgentHeaderTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Headers/Headers/User Agent/UserAgentHeaderTests.swift
@@ -142,6 +142,33 @@ struct UserAgentHeaderTests {
     }
 
     @Test
+    func hasDefaultUserAgent_whenDefaultIsCombinedWithCustomHeaderUnderDifferentCasing() async throws {
+        // Given -- a plain `CustomHeader`, not `UserAgentHeader(_:)`, and lowercased, unlike
+        // `UserAgentHeader`'s own hardcoded "User-Agent" key.
+        let resolved = try await resolve(
+            TestProperty {
+                HeaderGroup {
+                    UserAgentHeader()
+                    CustomHeader(name: "user-agent", value: "ABC")
+                }
+                .headerStrategy(.adding)
+            }
+        )
+
+        // Then -- `HeaderNode.make(_:)` matches "User-Agent" case-insensitively, so this still
+        // counts as a second write and disqualifies the marker, exactly like combining with
+        // another `UserAgentHeader(_:)` does above.
+        #expect(!resolved.requestConfiguration.hasDefaultUserAgent)
+
+        // `CustomHeader` defaults to `headerSeparator == nil`, unlike `UserAgentHeader`'s own
+        // hardcoded `" "` -- so this is stored as two separate values on one logical entry, not
+        // joined into a single string the way `UserAgentHeader(_:)` combining is. See
+        // `RawTaskExecutorDispatchTests.dataTask_withDefaultUserAgentCombinedWithDifferentlyCasedCustomHeaderOverURLSession_mergesBothOntoTheWire`
+        // for how `URLRequest` itself coalesces this into one comma-joined header on the wire.
+        #expect(resolved.requestConfiguration.headers["User-Agent"] == [ProcessInfo.processInfo.userAgent, "ABC"])
+    }
+
+    @Test
     func dropDefaultUserAgentForNativeReporting_removesOnlyTheUntouchedDefault() async throws {
         // Given
         var withDefault = try await resolve(

--- a/Tests/RequestDLTests/Properties/Sources/Headers/Headers/User Agent/UserAgentHeaderTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Headers/Headers/User Agent/UserAgentHeaderTests.swift
@@ -81,6 +81,89 @@ struct UserAgentHeaderTests {
     }
 
     @Test
+    func hasDefaultUserAgent_whenUsingDefaultValue() async throws {
+        // Given
+        let property = TestProperty {
+            UserAgentHeader()
+        }
+
+        // When
+        let resolved = try await resolve(property)
+
+        // Then
+        #expect(resolved.requestConfiguration.hasDefaultUserAgent)
+    }
+
+    @Test
+    func hasDefaultUserAgent_whenValueIsCustom() async throws {
+        // Given
+        let property = TestProperty {
+            UserAgentHeader("CustomAgent")
+        }
+
+        // When
+        let resolved = try await resolve(property)
+
+        // Then
+        #expect(!resolved.requestConfiguration.hasDefaultUserAgent)
+    }
+
+    @Test
+    func hasDefaultUserAgent_whenNoValueIsSet() async throws {
+        // Given
+        let property = TestProperty(EmptyProperty())
+
+        // When
+        let resolved = try await resolve(property)
+
+        // Then
+        #expect(!resolved.requestConfiguration.hasDefaultUserAgent)
+    }
+
+    @Test
+    func hasDefaultUserAgent_whenDefaultIsCombinedWithCustomAgent() async throws {
+        // Given
+        let userAgent = "CustomAgent"
+
+        // When
+        let resolved = try await resolve(
+            TestProperty {
+                HeaderGroup {
+                    UserAgentHeader()
+                    UserAgentHeader(userAgent)
+                }
+                .headerStrategy(.adding)
+            }
+        )
+
+        // Then -- once a custom value is folded in too, the header is no longer purely
+        // RequestDL's untouched default, so it must not be reported as such.
+        #expect(!resolved.requestConfiguration.hasDefaultUserAgent)
+    }
+
+    @Test
+    func dropDefaultUserAgentForNativeReporting_removesOnlyTheUntouchedDefault() async throws {
+        // Given
+        var withDefault = try await resolve(
+            TestProperty { UserAgentHeader() }
+        ).requestConfiguration
+
+        var withCustom = try await resolve(
+            TestProperty { UserAgentHeader("CustomAgent") }
+        ).requestConfiguration
+
+        // When
+        withDefault.dropDefaultUserAgentForNativeReporting()
+        withCustom.dropDefaultUserAgentForNativeReporting()
+
+        // Then -- URLSession synthesizes its own accurate User-Agent only when the request
+        // carries none, so the untouched default is removed to let it do that, while a value
+        // the caller actually asked for must reach the wire untouched.
+        #expect(withDefault.headers["User-Agent"] == nil)
+        #expect(withCustom.headers["User-Agent"] == ["CustomAgent"])
+    }
+
+    @Test
     func neverBody() async throws {
         // Given
         let property = UserAgentHeader("CustomAgent/1.0.0")

--- a/Tests/RequestDLTests/Tasks/Sources/Modifiers/Progress/ModifiersProgressTests.swift
+++ b/Tests/RequestDLTests/Tasks/Sources/Modifiers/Progress/ModifiersProgressTests.swift
@@ -208,11 +208,6 @@ struct ModifiersProgressTests {
 
         localServer.insert(response, at: testState.uri)
 
-        let expectingData = try HTTPResult(
-            receivedBytes: .zero,
-            response: message
-        ).encode()
-
         // When
         let data = try await UploadTask {
             BaseURL(localServer.baseURL)
@@ -235,8 +230,11 @@ struct ModifiersProgressTests {
 
         let result = try HTTPResult<String>(data)
 
-        // Then
-        #expect(expectingData.count == data.count)
+        // Then -- decoded-content equality, not a byte-count comparison against a hand-built
+        // envelope: the server's JSON response can grow additional optional fields over time
+        // (e.g. `receivedUserAgentHeader`), which would throw off a raw size comparison without
+        // actually reflecting anything wrong with the response itself.
+        #expect(result.response == message)
         #expect(downloadMonitor.totalSize == data.count)
         #expect(result.receivedBytes == .zero)
 

--- a/Tests/RequestDLTests/Tasks/Sources/Raw Task/Raw/RawTaskExecutorDispatchTests.swift
+++ b/Tests/RequestDLTests/Tasks/Sources/Raw Task/Raw/RawTaskExecutorDispatchTests.swift
@@ -316,7 +316,7 @@ struct RawTaskExecutorDispatchTests {
     /// stored value, and `URLRequest` itself -- confirmed against a live instance, not assumed --
     /// coalesces same-name fields (case-insensitively) into one comma-joined header, no space.
     @Test
-    func dataTask_withDefaultUserAgentCombinedWithDifferentlyCasedCustomHeaderOverURLSession_mergesBothOntoTheWire() async throws {
+    func dataTask_defaultUserAgentCollidesWithCustomHeaderOverURLSession_mergesOntoTheWire() async throws {
         // Given
         let localServer = try await LocalServer(.standard)
         let uri = "/" + UUID().uuidString

--- a/Tests/RequestDLTests/Tasks/Sources/Raw Task/Raw/RawTaskExecutorDispatchTests.swift
+++ b/Tests/RequestDLTests/Tasks/Sources/Raw Task/Raw/RawTaskExecutorDispatchTests.swift
@@ -305,6 +305,52 @@ struct RawTaskExecutorDispatchTests {
         #expect(result.receivedUserAgentHeader == ProcessInfo.processInfo.userAgent)
     }
 
+    /// Regression coverage for combining RequestDL's default with a plain `CustomHeader(name:
+    /// "user-agent", ...)`, not `UserAgentHeader(_:)`. `HeaderNode.make(_:)` matches "User-Agent"
+    /// case-insensitively, so this still disqualifies `hasDefaultUserAgent` -- see
+    /// `UserAgentHeaderTests.hasDefaultUserAgent_whenDefaultIsCombinedWithCustomHeaderUnderDifferentCasing`
+    /// for that check at the graph-resolve level, where the two values are still stored
+    /// separately (`CustomHeader` defaults to `headerSeparator == nil`, unlike `UserAgentHeader`'s
+    /// own hardcoded `" "`). This proves what actually reaches the wire once `URLRequest` gets
+    /// involved: `buildURLRequestWithoutBody()` calls `addValue(_:forHTTPHeaderField:)` once per
+    /// stored value, and `URLRequest` itself -- confirmed against a live instance, not assumed --
+    /// coalesces same-name fields (case-insensitively) into one comma-joined header, no space.
+    @Test
+    func dataTask_withDefaultUserAgentCombinedWithDifferentlyCasedCustomHeaderOverURLSession_mergesBothOntoTheWire() async throws {
+        // Given
+        let localServer = try await LocalServer(.standard)
+        let uri = "/" + UUID().uuidString
+        let certificate = Certificates().server()
+
+        let response = try LocalServer.ResponseConfiguration(jsonObject: "Hello World")
+        localServer.cleanup(at: uri)
+        localServer.insert(response, at: uri)
+        defer { localServer.cleanup(at: uri) }
+
+        let content = TestProperty {
+            BaseURL(localServer.baseURL)
+            Path(uri)
+
+            Session("com.requestdl.tests.useragent-urlsession-merge.\(UUID())")
+                .requiredExecutor(.urlSession)
+
+            SecureConnection {
+                TrustRoots(certificate.certificateURL.absolutePath(percentEncoded: false))
+            }
+
+            UserAgentHeader()
+            CustomHeader(name: "user-agent", value: "ABC")
+        }
+
+        // When
+        let data = try await DataTask { content }.extractPayload().result()
+        let result = try HTTPResult<String>(data)
+
+        // Then -- neither value was dropped (a second write already disqualified
+        // `hasDefaultUserAgent`), and both landed on the wire merged into one header.
+        #expect(result.receivedUserAgentHeader == "\(ProcessInfo.processInfo.userAgent),ABC")
+    }
+
     /// Cancellation, validated for real. `Internals.TaskSeed` (transport-agnostic) cancels when
     /// the response is *dropped*, not when the
     /// awaiting `_Concurrency.Task` is marked cancelled -- nothing in the iteration path

--- a/Tests/RequestDLTests/Tasks/Sources/Raw Task/Raw/RawTaskExecutorDispatchTests.swift
+++ b/Tests/RequestDLTests/Tasks/Sources/Raw Task/Raw/RawTaskExecutorDispatchTests.swift
@@ -17,6 +17,7 @@ import FoundationEssentials
 #else
 import struct Foundation.UUID
 import struct Foundation.Data
+import class Foundation.ProcessInfo
 #endif
 
 /// `RawTask.result()` dispatches through `Internals.Session.resolvedClient()` (backed by
@@ -185,6 +186,123 @@ struct RawTaskExecutorDispatchTests {
             Issue.record("Expected the DataTask call above to have dispatched over .urlSession")
             return
         }
+    }
+
+    /// Regression coverage for the design decision that `.urlSession` should drop RequestDL's own
+    /// default `User-Agent` and let URLSession synthesize its native `AppName/version
+    /// Darwin/version CFNetwork/version` report instead of RequestDL's neutral one, since claiming
+    /// that format under a different executor (`.nio`) would misrepresent a network stack that
+    /// never actually ran the request. See `RequestConfiguration.dropDefaultUserAgentForNativeReporting()`.
+    @Test
+    func dataTask_withDefaultUserAgentOverURLSession_defersToURLSessionsNativeReport() async throws {
+        // Given
+        let localServer = try await LocalServer(.standard)
+        let uri = "/" + UUID().uuidString
+        let certificate = Certificates().server()
+
+        let response = try LocalServer.ResponseConfiguration(jsonObject: "Hello World")
+        localServer.cleanup(at: uri)
+        localServer.insert(response, at: uri)
+        defer { localServer.cleanup(at: uri) }
+
+        let content = TestProperty {
+            BaseURL(localServer.baseURL)
+            Path(uri)
+
+            Session("com.requestdl.tests.useragent-urlsession.\(UUID())")
+                .requiredExecutor(.urlSession)
+
+            SecureConnection {
+                TrustRoots(certificate.certificateURL.absolutePath(percentEncoded: false))
+            }
+
+            UserAgentHeader()
+        }
+
+        // When
+        let data = try await DataTask { content }.extractPayload().result()
+        let result = try HTTPResult<String>(data)
+
+        // Then -- URLSession synthesizes its own accurate report once RequestDL's own default is
+        // dropped, so the server sees *something*, just not RequestDL's neutral
+        // `AppID/version OS/version` string.
+        let receivedUserAgent = try #require(result.receivedUserAgentHeader)
+        #expect(receivedUserAgent != ProcessInfo.processInfo.userAgent)
+    }
+
+    /// Companion to the test above: a caller-supplied `User-Agent` is never RequestDL's untouched
+    /// default, so `dropDefaultUserAgentForNativeReporting()` must leave it alone even under
+    /// `.urlSession`.
+    @Test
+    func dataTask_withCustomUserAgentOverURLSession_reachesTheWireUntouched() async throws {
+        // Given
+        let localServer = try await LocalServer(.standard)
+        let uri = "/" + UUID().uuidString
+        let certificate = Certificates().server()
+        let customUserAgent = "CustomAgent/1.0.0"
+
+        let response = try LocalServer.ResponseConfiguration(jsonObject: "Hello World")
+        localServer.cleanup(at: uri)
+        localServer.insert(response, at: uri)
+        defer { localServer.cleanup(at: uri) }
+
+        let content = TestProperty {
+            BaseURL(localServer.baseURL)
+            Path(uri)
+
+            Session("com.requestdl.tests.useragent-urlsession.\(UUID())")
+                .requiredExecutor(.urlSession)
+
+            SecureConnection {
+                TrustRoots(certificate.certificateURL.absolutePath(percentEncoded: false))
+            }
+
+            UserAgentHeader(customUserAgent)
+        }
+
+        // When
+        let data = try await DataTask { content }.extractPayload().result()
+        let result = try HTTPResult<String>(data)
+
+        // Then
+        #expect(result.receivedUserAgentHeader == customUserAgent)
+    }
+
+    /// Companion to both tests above: NIO never synthesizes its own `User-Agent`, so dropping
+    /// RequestDL's default there -- the way `.urlSession` does -- would just send the request
+    /// with none. RequestDL's neutral default must survive under `.nio`.
+    @Test
+    func dataTask_withDefaultUserAgentOverNIO_keepsRequestDLsNeutralDefault() async throws {
+        // Given
+        let localServer = try await LocalServer(.standard)
+        let uri = "/" + UUID().uuidString
+        let certificate = Certificates().server()
+
+        let response = try LocalServer.ResponseConfiguration(jsonObject: "Hello World")
+        localServer.cleanup(at: uri)
+        localServer.insert(response, at: uri)
+        defer { localServer.cleanup(at: uri) }
+
+        let content = TestProperty {
+            BaseURL(localServer.baseURL)
+            Path(uri)
+
+            Session("com.requestdl.tests.useragent-nio.\(UUID())")
+                .requiredExecutor(.nio)
+
+            SecureConnection {
+                TrustRoots(certificate.certificateURL.absolutePath(percentEncoded: false))
+            }
+
+            UserAgentHeader()
+        }
+
+        // When
+        let data = try await DataTask { content }.extractPayload().result()
+        let result = try HTTPResult<String>(data)
+
+        // Then
+        #expect(result.receivedUserAgentHeader == ProcessInfo.processInfo.userAgent)
     }
 
     /// Cancellation, validated for real. `Internals.TaskSeed` (transport-agnostic) cancels when


### PR DESCRIPTION
## Summary

**User-Agent**
- Drops RequestDL's own default `User-Agent` right before dispatch when the resolved executor is `.urlSession`, letting URLSession report its native `AppName/version Darwin/version CFNetwork/version` value instead of RequestDL's neutral `AppID/version OS/version` one — the previous default silently suppressed that native, more accurate report. `.nio`/`.nioTransportServices` are unaffected (neither synthesizes its own `User-Agent`), and any caller-supplied `UserAgentHeader(_:)` value is always left untouched, on every executor.
- `HeaderNode`/`RequestConfiguration` gained a marker (`hasDefaultUserAgent`) tracking whether the current `User-Agent` is exactly RequestDL's untouched default, so the drop only ever applies to that value.
- The default value is now memoized per process (`ProcessInfo.processInfo.userAgent`'s Bundle/OS lookups no longer re-run on every request).

**Header combining correctness** (RFC 9110/9111 audit)
- `Host`, `Origin`, `Referer`, `Authorization`, `Content-Type`, and `Content-Length` now always overwrite instead of combining — previously, any header funneling through `HeaderNode`'s generic multi-value machinery could duplicate a field the spec requires singular (RFC 9110 §7.2: a server MUST 400 a request with more than one `Host`), or — worse, when a separator was in scope — splice a colliding value directly into an existing one, corrupting it into a single unparseable string (reproduced with `Payload(contentType: .json)` followed by a colliding `CustomHeader` under `.headerSeparator(",")`).
- `Accept`, `Accept-Charset`, `Accept-Encoding`, `Accept-Language`, and `Cache-Control` now always combine with `,` regardless of `.headerSeparator(_:)` — these are RFC-defined comma-separated lists, and anything else either fails to parse (`Cache-Control`'s `1#cache-directive`) or actively misparses (`;` already attaches a `q` parameter to the *previous* `Accept-*` element). `CacheHeader` also had its own internal directive-list join independently vulnerable to the same override; fixed separately.
- `CustomHeader` is deliberately left alone in both cases — RequestDL can't know the semantics of an arbitrary header name.

**Other**
- Deprecates `AcceptCharsetHeader`: a legacy header the WHATWG Fetch Standard forbids browsers from sending at all, and most servers already ignore.
- Documents `HeaderGroup(_ dictionary:)`'s non-deterministic combining order when the dictionary carries keys that only differ by case.
- Fixes two pre-existing DocC symbol-link warnings (`TaskDescriptor`, `SPKIHash`) found while verifying this PR introduced none of its own.
- Bumps `swift-nio` (2.101.3 → 2.102.0), `swift-nio-extras` (1.34.3 → 1.35.1), `swift-nio-ssl` (2.37.2 → 2.37.4), and `swift-crypto` (4.5.1 → 4.5.2).

## Test plan
- [x] `swift build` and full `swift test` (1199 RequestDLTests + 500 RequestDLInternalsTests, all green)
- [x] `xcodebuild docbuild` — zero new DocC warnings, two pre-existing ones fixed
- [x] End-to-end coverage in `RawTaskExecutorDispatchTests` against a real `LocalServer`: default UA differs from RequestDL's neutral string under `.urlSession`, a custom value reaches the wire untouched, the neutral default survives under `.nio`, and a UA/CustomHeader collision merges onto the wire as expected
- [x] `HeaderNodeSingleValuedNamesTests` / `HeaderNodeCommaSeparatedNamesTests`: same-property-twice and cross-type `CustomHeader` collisions, with and without an explicit separator, for every protected header name

🤖 Generated with [Claude Code](https://claude.com/claude-code)