### PR TITLE
ci: retrigger Swift CI on ready-for-review and allow manual dispatch

### DIFF
--- a/.github/workflows/swift-ci.yaml
+++ b/.github/workflows/swift-ci.yaml
@@ -9,6 +9,7 @@ on:
       - 'Tests/**'
       - '.swift-format'
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [main]
     paths:
       - 'Package.swift'
@@ -16,6 +17,7 @@ on:
       - 'Tests/**'
       - '.swift-format'
       - '.github/workflows/swift-ci.yaml'
+  workflow_dispatch: {}
 
 # Cancel any in-progress or queued run for the same ref when a new run is
 # triggered (e.g. new push), so stale xcodebuild/swift test processes don't


### PR DESCRIPTION
## Summary
- Add `ready_for_review` to the `pull_request` trigger types so CI runs when a draft PR is marked ready, not only on `opened`/`synchronize`/`reopened` (the job already skips drafts via its `if` condition, but nothing re-triggered the workflow on the draft→ready transition itself)
- Add `workflow_dispatch` to allow manually running the workflow from the Actions UI/CLI

## Test plan
- [ ] Open this PR as a draft, verify CI does not run
- [ ] Mark it ready for review, verify CI runs
- [ ] Trigger the workflow manually via `gh workflow run` / Actions UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)