### PR TITLE
Flag maximum TLS version / ALPN as URLSession-incompatible, document ATS for the rest

### DIFF
--- a/Sources/RequestDL/Documentation.docc/Advanced/Configuring-App-Transport-Security-for-URLSession.md
+++ b/Sources/RequestDL/Documentation.docc/Advanced/Configuring-App-Transport-Security-for-URLSession.md
@@ -1,0 +1,90 @@
+# Configuring App Transport Security for the URLSession Executor
+
+Adjust your app's Info.plist when a ``SecureConnection`` TLS policy needs to run over the `.urlSession` executor.
+
+## Overview
+
+`SecureConnection`'s TLS-version and ALPN modifiers — ``SecureConnection/version(minimum:)``, ``SecureConnection/version(maximum:)``, `version(_:)`, and ``SecureConnection/applicationProtocols(_:)`` — configure real, enforced behavior when a request runs over ``Session/Executor/nioTransportServices`` or the default non-Darwin executor: they're handed straight to SwiftNIO's TLS stack.
+
+None of them have a programmatic equivalent under ``Session/Executor/urlSession``. `URLSessionConfiguration` exposes no API to set a minimum/maximum TLS version or an ALPN protocol list — that policy is instead owned by the OS itself, through **App Transport Security (ATS)**, which your app declares once in its `Info.plist`, not per-request.
+
+RequestDL reacts differently to each of these, because only one of them has an ATS equivalent to fall back on:
+
+- ``SecureConnection/version(maximum:)`` and ``SecureConnection/applicationProtocols(_:)`` — like `cipherSuites(_:)` — are treated as incompatible with `.urlSession`: automatic executor resolution skips `.urlSession` in favor of a NIO-based executor when either is set, and pinning to `.urlSession` explicitly throws ``ExecutorRequirementError`` instead of silently dropping it. Neither has any ATS key at all, so there's no Info.plist fix for these — see [What ATS cannot do](#What-ATS-cannot-do).
+- ``SecureConnection/version(minimum:)`` is the exception: it's *not* flagged as incompatible, because App Transport Security offers a real, working equivalent for it (`NSExceptionMinimumTLSVersion`). It has no effect at all under `.urlSession` and RequestDL doesn't warn you — this article's [What you need to do](#What-you-need-to-do) section is what replaces it.
+
+`.urlSession` is also RequestDL's own default executor preference on Darwin whenever the rest of a session's configuration is compatible with it, so a request using ``SecureConnection`` with no executor modifier at all may already be running over `.urlSession`.
+
+### Why this is needed at all
+
+ATS is a system-wide policy, enforced by the OS before your app's TLS preferences ever come into play: by default it already requires TLS 1.2 or later and forward-secrecy cipher suites for every connection `URLSession` makes, and it blocks anything weaker outright rather than letting the request attempt a weaker handshake. RequestDL cannot lower or relax that policy on your behalf at request-construction time — there is no API surface for it. The only way to change what `URLSession` will allow is the same way any other Apple-platform app does it: an `NSAppTransportSecurity` dictionary in `Info.plist`, per Apple's [Cocoa Keys reference](https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CocoaKeys.html#//apple_ref/doc/uid/TP40009251-SW35).
+
+This cuts both ways. ATS's defaults are already at or above what `SecureConnection`'s own defaults require, so most requests need no Info.plist changes at all. Info.plist only comes into play when your `SecureConnection` configuration — or the server you're calling — needs something *outside* ATS's defaults, most commonly a minimum TLS version below 1.2, or a plain-HTTP endpoint.
+
+## What you need to do
+
+If a request's server needs a relaxed TLS policy and that request may run over `.urlSession`, add an ATS exception for that server's domain to your app's `Info.plist`:
+
+```xml
+<key>NSAppTransportSecurity</key>
+<dict>
+    <key>NSExceptionDomains</key>
+    <dict>
+        <key>example.com</key>
+        <dict>
+            <key>NSExceptionMinimumTLSVersion</key>
+            <string>TLSv1.1</string>
+            <key>NSIncludesSubdomains</key>
+            <true/>
+        </dict>
+    </dict>
+</dict>
+```
+
+The keys that map onto `SecureConnection`'s own modifiers:
+
+| `SecureConnection` modifier | ATS `Info.plist` key | Scope |
+| --- | --- | --- |
+| ``SecureConnection/version(minimum:)`` | `NSExceptionMinimumTLSVersion` | Per exception domain |
+| Plain HTTP instead of HTTPS | `NSExceptionAllowsInsecureHTTPLoads` (or `NSAllowsArbitraryLoads` app-wide) | Per exception domain, or global |
+
+Set `NSIncludesSubdomains` to match whichever domains the request actually targets, and scope the exception as narrowly as possible — App Store review, and your own users' security, are both better served by a domain-specific exception than a blanket `NSAllowsArbitraryLoads`.
+
+## What ATS cannot do
+
+Two `SecureConnection` modifiers have **no** ATS equivalent at all, under any Info.plist configuration — which is exactly why RequestDL flags both as incompatible with `.urlSession` instead of leaving them to fail silently:
+
+- ``SecureConnection/version(maximum:)`` — ATS only offers a *minimum* TLS version per exception domain; there's no key to cap the maximum.
+- ``SecureConnection/applicationProtocols(_:)`` (ALPN) — `URLSession` negotiates ALPN automatically (HTTP/2 vs. HTTP/1.1) and Info.plist has no key to override the protocol list it offers.
+
+If a request depends on either of these, it needs an executor that actually enforces them — ``Session/preferredExecutor(_:)`` or ``Session/requiredExecutor(_:)`` with ``Session/Executor/nioTransportServices`` (or the default non-Darwin executor) instead of `.urlSession`. Under automatic resolution (no executor pinned) this already happens for you; pinning to `.urlSession` anyway makes the conflict explicit via ``ExecutorRequirementError`` rather than silently dropping the setting.
+
+## What you do not need to do
+
+- No changes to your `SecureConnection` code — the same modifiers are still what non-`.urlSession` executors read.
+- No per-request Info.plist manipulation — ATS exceptions are declared once, at the app level.
+- No Info.plist changes at all for requests whose TLS requirements already sit within ATS's defaults (TLS 1.2+, forward secrecy) — which is the common case.
+
+## Platforms
+
+ATS applies to `URLSession` on iOS, iPadOS, tvOS, watchOS, and macOS alike. It does not apply to the non-`.urlSession` executors (``Session/Executor/nioTransportServices``, the default non-Darwin executor), which read `SecureConnection`'s TLS-policy modifiers directly instead.
+
+## Troubleshooting
+
+A request that needs a lower minimum TLS version (or plain HTTP) than ATS's defaults, running over `.urlSession` without a matching exception, fails at the transport level rather than reaching the server — commonly surfaced as an `NSURLErrorDomain` error with code `-1022` (`NSURLErrorAppTransportSecurityRequiresSecureConnection`), or a TLS handshake failure logged by the OS mentioning ATS. That failure happens below RequestDL, so no ``SecureConnection`` setting can catch or translate it — check the console log for the ATS-specific message, then add the matching exception domain above.
+
+A request that sets `version(maximum:)` or ``SecureConnection/applicationProtocols(_:)`` never gets this far: RequestDL routes it away from `.urlSession` on its own (or throws ``ExecutorRequirementError`` if you pinned `.urlSession` explicitly), well before any ATS-level failure could occur. See [What ATS cannot do](#What-ATS-cannot-do).
+
+## Topics
+
+### Configuring TLS policy
+
+- ``SecureConnection/version(minimum:)``
+- ``SecureConnection/version(maximum:)``
+- ``SecureConnection/applicationProtocols(_:)``
+
+### Choosing an executor
+
+- ``Session/preferredExecutor(_:)``
+- ``Session/requiredExecutor(_:)``
+- ``ExecutorRequirementError``

--- a/Sources/RequestDL/Documentation.docc/RequestDL.md
+++ b/Sources/RequestDL/Documentation.docc/RequestDL.md
@@ -101,4 +101,5 @@ We are excited to expand this list with many other features. Start by making you
 
 - <doc:Request-Customization>
 - <doc:Using-a-Client-Certificate-with-URLSession>
+- <doc:Configuring-App-Transport-Security-for-URLSession>
 - <doc:Downloading-in-the-Background>

--- a/Sources/RequestDL/Properties/Sources/Secure Connection/Secure Connection/SecureConnection.swift
+++ b/Sources/RequestDL/Properties/Sources/Secure Connection/Secure Connection/SecureConnection.swift
@@ -12,6 +12,16 @@ import RequestDLInternals
 /// each creates the underlying secure connection configuration on its own the first time it's
 /// needed. Nest them here only when also configuring settings that live directly on
 /// `SecureConnection` (`version`, `cipherSuites`, `keyLogger`, ...).
+///
+/// > Important: `URLSessionConfiguration` has no API for TLS version or ALPN policy.
+/// `version(maximum:)` and ``applicationProtocols(_:)`` are treated as incompatible with
+/// ``Session/Executor/urlSession`` — like `cipherSuites(_:)`, automatic executor resolution skips
+/// `.urlSession` when either is set, and pinning to it throws ``ExecutorRequirementError``.
+/// `version(minimum:)` is the one exception: it has no effect under `.urlSession` but isn't
+/// flagged, because App Transport Security offers a real equivalent — an
+/// `NSExceptionMinimumTLSVersion` entry in your app's `Info.plist` — that `version(maximum:)` and
+/// ``applicationProtocols(_:)`` don't have. See
+/// <doc:Configuring-App-Transport-Security-for-URLSession>.
 public struct SecureConnection<Content: Property>: Property {
 
     private struct Node: SecureConnectionPropertyNode {
@@ -118,6 +128,10 @@ public struct SecureConnection<Content: Property>: Property {
 
     /// Sets the minimum TLS version for the secure connection.
     ///
+    /// > Important: Has no effect under ``Session/Executor/urlSession`` — configure an
+    /// `NSExceptionMinimumTLSVersion` ATS exception in `Info.plist` instead. See
+    /// <doc:Configuring-App-Transport-Security-for-URLSession>.
+    ///
     /// - Parameter minimum: The minimum TLS version to use.
     /// - Returns: A modified `SecureConnection` with the minimum TLS version set.
     public func version(minimum: TLSVersion) -> Self {
@@ -125,6 +139,12 @@ public struct SecureConnection<Content: Property>: Property {
     }
 
     /// Sets the maximum TLS version for the secure connection.
+    ///
+    /// > Important: `URLSessionConfiguration` has no maximum-TLS-version API, and App Transport
+    /// Security has no `Info.plist` key for one either, so this is treated as incompatible with
+    /// ``Session/Executor/urlSession``: automatic executor resolution skips it in favor of a
+    /// NIO-based executor, and pinning to `.urlSession` via ``Session/requiredExecutor(_:)``
+    /// throws ``ExecutorRequirementError``. See <doc:Configuring-App-Transport-Security-for-URLSession>.
     ///
     /// - Parameter maximum: The maximum TLS version to use.
     /// - Returns: A modified `SecureConnection` with the maximum TLS version set.
@@ -224,6 +244,12 @@ public struct SecureConnection<Content: Property>: Property {
 
     /// Sets the application protocols for the secure connection.
     ///
+    /// > Important: `URLSession` negotiates ALPN automatically and `Info.plist` has no key to
+    /// override it, so this is treated as incompatible with ``Session/Executor/urlSession``:
+    /// automatic executor resolution skips it in favor of a NIO-based executor, and pinning to
+    /// `.urlSession` via ``Session/requiredExecutor(_:)`` throws ``ExecutorRequirementError``.
+    /// See <doc:Configuring-App-Transport-Security-for-URLSession>.
+    ///
     /// - Parameter protocols: The application protocols to use.
     /// - Returns: A modified `SecureConnection` with the application protocols set.
     public func applicationProtocols(_ protocols: String...) -> Self {
@@ -240,6 +266,12 @@ public struct SecureConnection<Content: Property>: Property {
 
     /// Sets the cipher suites for the secure connection using string representations.
     ///
+    /// > Important: `URLSessionConfiguration` has no cipher suite list API, so this is already
+    /// treated as incompatible with ``Session/Executor/urlSession``: automatic executor
+    /// resolution skips it in favor of a NIO-based executor, and pinning to `.urlSession` via
+    /// ``Session/requiredExecutor(_:)`` throws ``ExecutorRequirementError`` instead of silently
+    /// dropping it.
+    ///
     /// - Parameter suites: The cipher suites to use as string representations.
     /// - Returns: A modified `SecureConnection` with the cipher suites set.
     public func cipherSuites(_ suites: String...) -> Self {
@@ -250,6 +282,12 @@ public struct SecureConnection<Content: Property>: Property {
     }
 
     /// Sets the cipher suites for the secure connection using `TLSCipher` values.
+    ///
+    /// > Important: `URLSessionConfiguration` has no cipher suite list API, so this is already
+    /// treated as incompatible with ``Session/Executor/urlSession``: automatic executor
+    /// resolution skips it in favor of a NIO-based executor, and pinning to `.urlSession` via
+    /// ``Session/requiredExecutor(_:)`` throws ``ExecutorRequirementError`` instead of silently
+    /// dropping it.
     ///
     /// - Parameter suites: The cipher suites to use as `TLSCipher` values.
     /// - Returns: A modified `SecureConnection` with the cipher suites set.

--- a/Sources/RequestDL/Properties/Sources/Session/Session/Models/ExecutorRequirementError.swift
+++ b/Sources/RequestDL/Properties/Sources/Session/Session/Models/ExecutorRequirementError.swift
@@ -34,6 +34,8 @@ public struct ExecutorRequirementError: Error, Sendable {
         case proxyConnectHeadersUnderURLSession
         case proxyBearerAuthorizationUnderURLSession
         case decompressionDisabledUnderURLSession
+        case maximumTLSVersionUnderURLSession
+        case applicationProtocolsUnderURLSession
 
         // MARK: - Inits
 
@@ -79,6 +81,10 @@ public struct ExecutorRequirementError: Error, Sendable {
                 self = .proxyBearerAuthorizationUnderURLSession
             case .decompressionDisabledUnderURLSession:
                 self = .decompressionDisabledUnderURLSession
+            case .maximumTLSVersionUnderURLSession:
+                self = .maximumTLSVersionUnderURLSession
+            case .applicationProtocolsUnderURLSession:
+                self = .applicationProtocolsUnderURLSession
             }
         }
     }
@@ -159,6 +165,10 @@ extension ExecutorRequirementError.Reason: CustomStringConvertible {
             return "a bearer-token proxy authorization (unsupported under URLSession)"
         case .decompressionDisabledUnderURLSession:
             return "explicitly disabled decompression (unsupported under URLSession)"
+        case .maximumTLSVersionUnderURLSession:
+            return "a maximum TLS version (unsupported under URLSession)"
+        case .applicationProtocolsUnderURLSession:
+            return "an ALPN application protocol list (unsupported under URLSession)"
         }
     }
 }

--- a/Sources/RequestDL/Properties/Sources/Session/Session/Session.swift
+++ b/Sources/RequestDL/Properties/Sources/Session/Session/Session.swift
@@ -229,6 +229,14 @@ public struct Session: Property {
     /// is already ``preferredExecutor(_:)``'s own default choice on Darwin whenever the rest of
     /// the configuration supports it.
     ///
+    /// Pinning to `.urlSession` does **not** catch a `SecureConnection` minimum TLS version —
+    /// `ExecutorRequirementError` isn't thrown for it, it simply has no effect, because
+    /// `URLSessionConfiguration` has no API for it at all. That policy instead lives in your
+    /// app's `Info.plist`, via App Transport Security — see
+    /// <doc:Configuring-App-Transport-Security-for-URLSession>. A maximum TLS version or an ALPN
+    /// protocol list, which have no `Info.plist` equivalent at all, *are* caught: they throw
+    /// `ExecutorRequirementError` like any other incompatible field.
+    ///
     /// ```swift
     /// struct MyRequest: Property {
     ///     var body: some Property {

--- a/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.SecureConnection.swift
+++ b/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.SecureConnection.swift
@@ -97,6 +97,13 @@ extension Internals {
         /// Keychain Sharing entitlement the identity round-trip needs is a runtime fact this
         /// static check cannot see; a missing entitlement surfaces at identity-build time as its
         /// own runtime error, not as a reason in this list.
+        ///
+        /// Also deliberately does *not* check `minimumTLSVersion`, unlike its sibling
+        /// `maximumTLSVersion` right below -- `minimumTLSVersion` has a real, reachable equivalent
+        /// under URLSession (an ATS `NSExceptionMinimumTLSVersion` entry in the app's Info.plist),
+        /// so flagging it here would push callers off `.urlSession` even when they have a working
+        /// alternative. `maximumTLSVersion` and `applicationProtocols` have no such alternative --
+        /// there is no ATS key for either -- so those *are* flagged.
         package func urlSessionIncompatibilityReasons() -> [Internals.ExecutorIncompatibilityReason] {
             var reasons: [Internals.ExecutorIncompatibilityReason] = []
 
@@ -110,6 +117,8 @@ extension Internals {
             if keyLogger != nil { reasons.append(.keyLogger) }
             if cipherSuites != nil { reasons.append(.cipherSuites) }
             if cipherSuiteValues != nil { reasons.append(.cipherSuiteValues) }
+            if maximumTLSVersion != nil { reasons.append(.maximumTLSVersionUnderURLSession) }
+            if applicationProtocols != nil { reasons.append(.applicationProtocolsUnderURLSession) }
 
             return reasons
         }

--- a/Sources/RequestDLInternals/Sources/Session/Session Configuration/Models/Internals.ExecutorIncompatibilityReason.swift
+++ b/Sources/RequestDLInternals/Sources/Session/Session Configuration/Models/Internals.ExecutorIncompatibilityReason.swift
@@ -36,5 +36,13 @@ extension Internals {
         /// proxy authentication challenge delegate regardless of platform.
         case proxyBearerAuthorizationUnderURLSession
         case decompressionDisabledUnderURLSession
+        /// `URLSessionConfiguration` has no maximum-TLS-version API, and unlike
+        /// `minimumTLSVersion` (achievable under URLSession via an ATS `NSExceptionMinimumTLSVersion`
+        /// entry in Info.plist), there is no App Transport Security key for a maximum either --
+        /// so this has no reachable equivalent under URLSession at all.
+        case maximumTLSVersionUnderURLSession
+        /// `URLSession` negotiates ALPN automatically and Info.plist has no key to override the
+        /// protocol list it offers, so this has no reachable equivalent under URLSession at all.
+        case applicationProtocolsUnderURLSession
     }
 }

--- a/Tests/RequestDLInternalsTests/Sources/Secure Connection/Secure Connection/InternalsSecureConnectionTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Secure Connection/Secure Connection/InternalsSecureConnectionTests.swift
@@ -469,6 +469,12 @@ extension InternalsSecureConnectionTests {
             { (secureConnection: inout Internals.SecureConnection) in
                 secureConnection.cipherSuites = "DEFAULT"
             },
+            { (secureConnection: inout Internals.SecureConnection) in
+                secureConnection.maximumTLSVersion = .tlsv12
+            },
+            { (secureConnection: inout Internals.SecureConnection) in
+                secureConnection.applicationProtocols = ["h2"]
+            },
         ] as [@Sendable (inout Internals.SecureConnection) -> Void]
     )
     func secureConnection_whenURLSessionUnsupportedFieldSet_isIncompatible(
@@ -520,5 +526,39 @@ extension InternalsSecureConnectionTests {
 
         // Then
         #expect(secureConnection.urlSessionIncompatibilityReasons().contains(.keyLogger))
+    }
+
+    @Test
+    func secureConnection_whenMaximumTLSVersionSet_urlSessionIncompatibilityReasonsContainsIt() async throws {
+        // Given
+        var secureConnection = Internals.SecureConnection()
+        secureConnection.maximumTLSVersion = .tlsv12
+
+        // Then
+        #expect(secureConnection.urlSessionIncompatibilityReasons().contains(.maximumTLSVersionUnderURLSession))
+    }
+
+    @Test
+    func secureConnection_whenApplicationProtocolsSet_urlSessionIncompatibilityReasonsContainsIt() async throws {
+        // Given
+        var secureConnection = Internals.SecureConnection()
+        secureConnection.applicationProtocols = ["h2"]
+
+        // Then
+        #expect(secureConnection.urlSessionIncompatibilityReasons().contains(.applicationProtocolsUnderURLSession))
+    }
+
+    /// `minimumTLSVersion` is deliberately excluded from `urlSessionIncompatibilityReasons()`,
+    /// unlike its sibling `maximumTLSVersion` above -- it has a real, reachable equivalent under
+    /// URLSession (an ATS `NSExceptionMinimumTLSVersion` entry in the app's Info.plist), so it
+    /// must never force a fallback away from `.urlSession` or trip `requiredExecutor(.urlSession)`.
+    @Test
+    func secureConnection_whenMinimumTLSVersionSet_remainsCompatibleWithURLSession() async throws {
+        // Given
+        var secureConnection = Internals.SecureConnection()
+        secureConnection.minimumTLSVersion = .tlsv12
+
+        // Then
+        #expect(secureConnection.urlSessionIncompatibilityReasons().isEmpty)
     }
 }

--- a/Tests/RequestDLInternalsTests/Sources/Session/Session Configuration/InternalsSessionConfigurationExecutorTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Session/Session Configuration/InternalsSessionConfigurationExecutorTests.swift
@@ -3,6 +3,7 @@
 //
 
 import NIOHTTP1
+import NIOSSL
 import Testing
 
 @testable import RequestDLInternals
@@ -269,6 +270,54 @@ struct InternalsSessionConfigurationExecutorTests {
 
         var secureConnection = Internals.SecureConnection()
         secureConnection.additionalTrustRoots = [.file("/dev/null")]
+        configuration.secureConnection = secureConnection
+
+        // When
+        let sut = configuration.resolveExecutor()
+
+        // Then
+        #if canImport(Darwin)
+        #expect(sut == .urlSession)
+        #else
+        #expect(sut == .nio)
+        #endif
+    }
+
+    /// Mirrors `resolveExecutor_whenAdditionalTrustRootsSet_resolvesToURLSessionOnDarwin` above,
+    /// but for a field that has *no* URLSession-reachable equivalent (no ATS `Info.plist` key for
+    /// a maximum TLS version), so it must fall back away from `.urlSession` instead.
+    @Test
+    func resolveExecutor_whenMaximumTLSVersionSet_resolvesToNIOTransportServicesOnDarwin() async throws {
+        // Given -- fine under NIOTransportServices, unsupported under URLSession
+        var configuration = Internals.Session.Configuration()
+        configuration.decompression = .enabled(.none)
+
+        var secureConnection = Internals.SecureConnection()
+        secureConnection.maximumTLSVersion = .tlsv12
+        configuration.secureConnection = secureConnection
+
+        // When
+        let sut = configuration.resolveExecutor()
+
+        // Then
+        #if canImport(Darwin)
+        #expect(sut == .nioTransportServices)
+        #else
+        #expect(sut == .nio)
+        #endif
+    }
+
+    /// `minimumTLSVersion` is the deliberate exception: it has a real equivalent under URLSession
+    /// (an ATS `NSExceptionMinimumTLSVersion` entry in the app's Info.plist), so -- unlike
+    /// `maximumTLSVersion` above -- it must never force a fallback away from `.urlSession`.
+    @Test
+    func resolveExecutor_whenMinimumTLSVersionSet_resolvesToURLSessionOnDarwin() async throws {
+        // Given
+        var configuration = Internals.Session.Configuration()
+        configuration.decompression = .enabled(.none)
+
+        var secureConnection = Internals.SecureConnection()
+        secureConnection.minimumTLSVersion = .tlsv12
         configuration.secureConnection = secureConnection
 
         // When

--- a/Tests/RequestDLTests/Properties/Sources/Session/Session/Models/ExecutorRequirementErrorTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Session/Session/Models/ExecutorRequirementErrorTests.swift
@@ -64,6 +64,8 @@ struct ExecutorRequirementErrorTests {
             .proxyConnectHeadersUnderURLSession,
             .proxyBearerAuthorizationUnderURLSession,
             .decompressionDisabledUnderURLSession,
+            .maximumTLSVersionUnderURLSession,
+            .applicationProtocolsUnderURLSession,
         ]
     )
     func reason_whenEveryInternalCaseMapped_hasNonEmptyDescription(


### PR DESCRIPTION
## Summary

- `SecureConnection.version(maximum:)` and `applicationProtocols(_:)` (ALPN) are now treated as incompatible with `.urlSession`, alongside the already-flagged `cipherSuites(_:)`: automatic executor resolution skips `.urlSession` when either is set, and `requiredExecutor(.urlSession)` throws `ExecutorRequirementError` instead of silently dropping the setting. Neither has any App Transport Security (Info.plist) equivalent, so there's nothing to fall back to besides a different executor.
- `version(minimum:)` stays deliberately unflagged — it *does* have a working equivalent under `.urlSession`, via an `NSExceptionMinimumTLSVersion` entry in the app's Info.plist (per [Apple's Cocoa Keys reference](https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CocoaKeys.html#//apple_ref/doc/uid/TP40009251-SW35)). A new DocC article, [Configuring-App-Transport-Security-for-URLSession.md](Sources/RequestDL/Documentation.docc/Advanced/Configuring-App-Transport-Security-for-URLSession.md), walks through setting that up, and is linked from `SecureConnection`'s and `Session`'s doc comments.

## Test plan

- [x] `swift build`
- [x] `swift test` — full suite (505 tests, 3 pre-existing known issues, none related)
- [x] New regression tests: `urlSessionIncompatibilityReasons()` now flags `maximumTLSVersion`/`applicationProtocols` but not `minimumTLSVersion`; `resolveExecutor()` falls back away from `.urlSession` for the former but not the latter; `ExecutorRequirementError.Reason` maps and describes both new cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)