### PR TITLE
Update async-http-client to 1.38.1; own SPKI pinning, mTLS trust evaluation, and secure-connection observability

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -96,6 +96,7 @@ let package = Package(
                 .product(name: "Logging", package: "swift-log"),
                 .product(name: "Tracing", package: "swift-distributed-tracing"),
                 .product(name: "Crypto", package: "swift-crypto"),
+                .product(name: "_CryptoExtras", package: "swift-crypto"),
                 .product(name: "X509", package: "swift-certificates"),
             ],
             swiftSettings: [.defaultIsolation(nil)],

--- a/Package.swift
+++ b/Package.swift
@@ -73,7 +73,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/apple/swift-certificates.git",
-            from: "1.0.0"
+            from: "1.20.0"
         ),
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/request-dl/async-http-client",
-            from: "1.37.0"
+            from: "1.38.0"
         ),
         .package(
             url: "https://github.com/apple/swift-nio",
@@ -71,6 +71,10 @@ let package = Package(
             url: "https://github.com/apple/swift-crypto.git",
             from: "4.5.2"
         ),
+        .package(
+            url: "https://github.com/apple/swift-certificates.git",
+            from: "1.0.0"
+        ),
     ],
     targets: [
         .target(
@@ -92,6 +96,7 @@ let package = Package(
                 .product(name: "Logging", package: "swift-log"),
                 .product(name: "Tracing", package: "swift-distributed-tracing"),
                 .product(name: "Crypto", package: "swift-crypto"),
+                .product(name: "X509", package: "swift-certificates"),
             ],
             swiftSettings: [.defaultIsolation(nil)],
         ),

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/request-dl/async-http-client",
-            from: "1.38.0"
+            from: "1.38.1"
         ),
         .package(
             url: "https://github.com/apple/swift-nio",

--- a/Sources/RequestDL/Documentation.docc/Advanced/Configuring-App-Transport-Security-for-URLSession.md
+++ b/Sources/RequestDL/Documentation.docc/Advanced/Configuring-App-Transport-Security-for-URLSession.md
@@ -1,0 +1,90 @@
+# Configuring App Transport Security for the URLSession Executor
+
+Adjust your app's Info.plist when a ``SecureConnection`` TLS policy needs to run over the `.urlSession` executor.
+
+## Overview
+
+`SecureConnection`'s TLS-version and ALPN modifiers — ``SecureConnection/version(minimum:)``, ``SecureConnection/version(maximum:)``, `version(_:)`, and ``SecureConnection/applicationProtocols(_:)`` — configure real, enforced behavior when a request runs over ``Session/Executor/nioTransportServices`` or the default non-Darwin executor: they're handed straight to SwiftNIO's TLS stack.
+
+None of them have a programmatic equivalent under ``Session/Executor/urlSession``. `URLSessionConfiguration` exposes no API to set a minimum/maximum TLS version or an ALPN protocol list. That policy is instead owned by the OS itself, through **App Transport Security (ATS)**, which your app declares once in its `Info.plist`, not per-request.
+
+RequestDL reacts differently to each of these, because only one of them has an ATS equivalent to fall back on:
+
+- ``SecureConnection/version(maximum:)`` and ``SecureConnection/applicationProtocols(_:)``, like `cipherSuites(_:)`, are treated as incompatible with `.urlSession`: automatic executor resolution skips `.urlSession` in favor of a NIO-based executor when either is set, and pinning to `.urlSession` explicitly throws ``ExecutorRequirementError`` instead of silently dropping it. Neither has any ATS key at all, so there's no Info.plist fix for these; see [What ATS cannot do](#What-ATS-cannot-do).
+- ``SecureConnection/version(minimum:)`` is the exception: it's *not* flagged as incompatible, because App Transport Security offers a real, working equivalent for it (`NSExceptionMinimumTLSVersion`). It has no effect at all under `.urlSession`, and RequestDL doesn't warn you; this article's [What you need to do](#What-you-need-to-do) section is what replaces it.
+
+`.urlSession` is also RequestDL's own default executor preference on Darwin whenever the rest of a session's configuration is compatible with it, so a request using ``SecureConnection`` with no executor modifier at all may already be running over `.urlSession`.
+
+### Why this is needed at all
+
+ATS is a system-wide policy, enforced by the OS before your app's TLS preferences ever come into play. By default it already requires TLS 1.2 or later and forward-secrecy cipher suites for every connection `URLSession` makes, and it blocks anything weaker outright rather than letting the request attempt a weaker handshake. RequestDL cannot lower or relax that policy on your behalf at request-construction time; there is no API surface for it. The only way to change what `URLSession` will allow is the same way any other Apple-platform app does it: an `NSAppTransportSecurity` dictionary in `Info.plist`, per Apple's [Cocoa Keys reference](https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CocoaKeys.html#//apple_ref/doc/uid/TP40009251-SW35).
+
+This cuts both ways. ATS's defaults are already at or above what `SecureConnection`'s own defaults require, so most requests need no Info.plist changes at all. Info.plist only comes into play when your `SecureConnection` configuration, or the server you're calling, needs something *outside* ATS's defaults, most commonly a minimum TLS version below 1.2, or a plain-HTTP endpoint.
+
+## What you need to do
+
+If a request's server needs a relaxed TLS policy and that request may run over `.urlSession`, add an ATS exception for that server's domain to your app's `Info.plist`:
+
+```xml
+<key>NSAppTransportSecurity</key>
+<dict>
+    <key>NSExceptionDomains</key>
+    <dict>
+        <key>example.com</key>
+        <dict>
+            <key>NSExceptionMinimumTLSVersion</key>
+            <string>TLSv1.1</string>
+            <key>NSIncludesSubdomains</key>
+            <true/>
+        </dict>
+    </dict>
+</dict>
+```
+
+The keys that map onto `SecureConnection`'s own modifiers:
+
+| `SecureConnection` modifier | ATS `Info.plist` key | Scope |
+| --- | --- | --- |
+| ``SecureConnection/version(minimum:)`` | `NSExceptionMinimumTLSVersion` | Per exception domain |
+| Plain HTTP instead of HTTPS | `NSExceptionAllowsInsecureHTTPLoads` (or `NSAllowsArbitraryLoads` app-wide) | Per exception domain, or global |
+
+Set `NSIncludesSubdomains` to match whichever domains the request actually targets, and scope the exception as narrowly as possible. App Store review, and your own users' security, are both better served by a domain-specific exception than a blanket `NSAllowsArbitraryLoads`.
+
+## What ATS cannot do
+
+Two `SecureConnection` modifiers have **no** ATS equivalent at all, under any Info.plist configuration. This is exactly why RequestDL flags both as incompatible with `.urlSession` instead of leaving them to fail silently:
+
+- ``SecureConnection/version(maximum:)``: ATS only offers a *minimum* TLS version per exception domain; there's no key to cap the maximum.
+- ``SecureConnection/applicationProtocols(_:)`` (ALPN): `URLSession` negotiates ALPN automatically (HTTP/2 vs. HTTP/1.1) and Info.plist has no key to override the protocol list it offers.
+
+If a request depends on either of these, it needs an executor that actually enforces them: ``Session/preferredExecutor(_:)`` or ``Session/requiredExecutor(_:)`` with ``Session/Executor/nioTransportServices`` (or the default non-Darwin executor) instead of `.urlSession`. Under automatic resolution (no executor pinned) this already happens for you; pinning to `.urlSession` anyway makes the conflict explicit via ``ExecutorRequirementError`` rather than silently dropping the setting.
+
+## What you do not need to do
+
+- No changes to your `SecureConnection` code. The same modifiers are still what non-`.urlSession` executors read.
+- No per-request Info.plist manipulation. ATS exceptions are declared once, at the app level.
+- No Info.plist changes at all for requests whose TLS requirements already sit within ATS's defaults (TLS 1.2+, forward secrecy), which is the common case.
+
+## Platforms
+
+ATS applies to `URLSession` on iOS, iPadOS, tvOS, watchOS, and macOS alike. It does not apply to the non-`.urlSession` executors (``Session/Executor/nioTransportServices``, the default non-Darwin executor), which read `SecureConnection`'s TLS-policy modifiers directly instead.
+
+## Troubleshooting
+
+A request that needs a lower minimum TLS version (or plain HTTP) than ATS's defaults, running over `.urlSession` without a matching exception, fails at the transport level rather than reaching the server. This is commonly surfaced as an `NSURLErrorDomain` error with code `-1022` (`NSURLErrorAppTransportSecurityRequiresSecureConnection`), or a TLS handshake failure logged by the OS mentioning ATS. That failure happens below RequestDL, so no ``SecureConnection`` setting can catch or translate it; check the console log for the ATS-specific message, then add the matching exception domain above.
+
+A request that sets `version(maximum:)` or ``SecureConnection/applicationProtocols(_:)`` never gets this far: RequestDL routes it away from `.urlSession` on its own (or throws ``ExecutorRequirementError`` if you pinned `.urlSession` explicitly), well before any ATS-level failure could occur. See [What ATS cannot do](#What-ATS-cannot-do).
+
+## Topics
+
+### Configuring TLS policy
+
+- ``SecureConnection/version(minimum:)``
+- ``SecureConnection/version(maximum:)``
+- ``SecureConnection/applicationProtocols(_:)``
+
+### Choosing an executor
+
+- ``Session/preferredExecutor(_:)``
+- ``Session/requiredExecutor(_:)``
+- ``ExecutorRequirementError``

--- a/Sources/RequestDL/Documentation.docc/Essentials/Building the Request/Making your request secure/Secure-connection.md
+++ b/Sources/RequestDL/Documentation.docc/Essentials/Building the Request/Making your request secure/Secure-connection.md
@@ -180,3 +180,8 @@ Although ``RequestDL/Property/body-swift.property`` executes per request, Reques
 - ``RequestDL/CertificateVerification``
 - ``RequestDL/SignatureAlgorithm``
 - ``RequestDL/RenegotiationSupport``
+- ``RequestDL/RevocationPolicy``
+
+### Trust decision observability
+- ``RequestDL/TrustDecisionObserver``
+- ``RequestDL/TrustDecision``

--- a/Sources/RequestDL/Documentation.docc/RequestDL.md
+++ b/Sources/RequestDL/Documentation.docc/RequestDL.md
@@ -101,4 +101,5 @@ We are excited to expand this list with many other features. Start by making you
 
 - <doc:Request-Customization>
 - <doc:Using-a-Client-Certificate-with-URLSession>
+- <doc:Configuring-App-Transport-Security-for-URLSession>
 - <doc:Downloading-in-the-Background>

--- a/Sources/RequestDL/Properties/Sources/Secure Connection/Private Key/PrivateKey.swift
+++ b/Sources/RequestDL/Properties/Sources/Secure Connection/Private Key/PrivateKey.swift
@@ -94,6 +94,7 @@ public struct PrivateKey: Property {
     /// decrypts the key itself, straight from this password. Under
     /// ``Session/Executor/urlSession``/``Session/Executor/nioTransportServices``, mTLS needs a
     /// Keychain `SecIdentity`, which needs the key material already decrypted to build one.
+    ///
     /// This package can decrypt a traditional PKCS#1 RSA PEM key itself to get there
     /// (`format: .pem`, `"-----BEGIN RSA PRIVATE KEY-----"` with `Proc-Type`/`DEK-Info` headers),
     /// but has no decryption path at all for a PKCS#8-encrypted key or any EC key (P-256/P-384/

--- a/Sources/RequestDL/Properties/Sources/Secure Connection/Private Key/PrivateKey.swift
+++ b/Sources/RequestDL/Properties/Sources/Secure Connection/Private Key/PrivateKey.swift
@@ -90,14 +90,15 @@ public struct PrivateKey: Property {
     /// Creates a private key from a file with the specified format, and allows for providing a
     /// `NIOSSLSecureBytes` password..
     ///
-    /// - Important: Reachable under ``Session/Executor/nio`` unconditionally. Under
-    /// ``Session/Executor/urlSession``/``Session/Executor/nioTransportServices``, only a
-    /// traditional PKCS#1 RSA PEM key (`format: .pem`, `"-----BEGIN RSA PRIVATE KEY-----"` with
-    /// `Proc-Type`/`DEK-Info` headers) can actually be decrypted -- both executors need mTLS
-    /// identity as a Keychain `SecIdentity`, which needs the key already decrypted, and no
-    /// decryption entry point in this package's dependencies covers PKCS#8-encrypted or EC
-    /// (P-256/P-384/P-521) keys. A password-protected key outside that shape throws when the
-    /// session actually resolves to one of those two executors.
+    /// - Important: Reachable under ``Session/Executor/nio`` unconditionally -- NIOSSL/BoringSSL
+    /// decrypts the key itself, straight from this password. Under
+    /// ``Session/Executor/urlSession``/``Session/Executor/nioTransportServices``, mTLS needs a
+    /// Keychain `SecIdentity`, which needs the key material already decrypted to build one --
+    /// this package can decrypt a traditional PKCS#1 RSA PEM key itself to get there
+    /// (`format: .pem`, `"-----BEGIN RSA PRIVATE KEY-----"` with `Proc-Type`/`DEK-Info` headers),
+    /// but has no decryption path at all for a PKCS#8-encrypted key or any EC key (P-256/P-384/
+    /// P-521). A password-protected key outside that one decryptable shape throws once the
+    /// session actually resolves to either of those two executors.
     ///
     /// - Parameters:
     ///   - file: The path to the file containing the private key.

--- a/Sources/RequestDL/Properties/Sources/Secure Connection/Private Key/PrivateKey.swift
+++ b/Sources/RequestDL/Properties/Sources/Secure Connection/Private Key/PrivateKey.swift
@@ -90,6 +90,15 @@ public struct PrivateKey: Property {
     /// Creates a private key from a file with the specified format, and allows for providing a
     /// `NIOSSLSecureBytes` password..
     ///
+    /// - Important: Reachable under ``Session/Executor/nio`` unconditionally. Under
+    /// ``Session/Executor/urlSession``/``Session/Executor/nioTransportServices``, only a
+    /// traditional PKCS#1 RSA PEM key (`format: .pem`, `"-----BEGIN RSA PRIVATE KEY-----"` with
+    /// `Proc-Type`/`DEK-Info` headers) can actually be decrypted -- both executors need mTLS
+    /// identity as a Keychain `SecIdentity`, which needs the key already decrypted, and no
+    /// decryption entry point in this package's dependencies covers PKCS#8-encrypted or EC
+    /// (P-256/P-384/P-521) keys. A password-protected key outside that shape throws when the
+    /// session actually resolves to one of those two executors.
+    ///
     /// - Parameters:
     ///   - file: The path to the file containing the private key.
     ///   - format: The format of the private key file. Default is `.pem`.
@@ -112,6 +121,11 @@ public struct PrivateKey: Property {
 
     /// Creates a private key from bytes with the specified format, and allows for providing a
     /// `NIOSSLSecureBytes` password.
+    ///
+    /// - Important: See the `file:format:password:` initializer's own doc comment for exactly
+    /// which password-protected key shapes are reachable under
+    /// ``Session/Executor/urlSession``/``Session/Executor/nioTransportServices`` -- it's not
+    /// every format ``Certificate/Format`` otherwise accepts.
     ///
     /// - Parameters:
     ///   - bytes: The bytes representing the private key.

--- a/Sources/RequestDL/Properties/Sources/Secure Connection/Private Key/PrivateKey.swift
+++ b/Sources/RequestDL/Properties/Sources/Secure Connection/Private Key/PrivateKey.swift
@@ -90,11 +90,11 @@ public struct PrivateKey: Property {
     /// Creates a private key from a file with the specified format, and allows for providing a
     /// `NIOSSLSecureBytes` password..
     ///
-    /// - Important: Reachable under ``Session/Executor/nio`` unconditionally -- NIOSSL/BoringSSL
+    /// - Important: Reachable under ``Session/Executor/nio`` unconditionally: NIOSSL/BoringSSL
     /// decrypts the key itself, straight from this password. Under
     /// ``Session/Executor/urlSession``/``Session/Executor/nioTransportServices``, mTLS needs a
-    /// Keychain `SecIdentity`, which needs the key material already decrypted to build one --
-    /// this package can decrypt a traditional PKCS#1 RSA PEM key itself to get there
+    /// Keychain `SecIdentity`, which needs the key material already decrypted to build one.
+    /// This package can decrypt a traditional PKCS#1 RSA PEM key itself to get there
     /// (`format: .pem`, `"-----BEGIN RSA PRIVATE KEY-----"` with `Proc-Type`/`DEK-Info` headers),
     /// but has no decryption path at all for a PKCS#8-encrypted key or any EC key (P-256/P-384/
     /// P-521). A password-protected key outside that one decryptable shape throws once the
@@ -125,7 +125,7 @@ public struct PrivateKey: Property {
     ///
     /// - Important: See the `file:format:password:` initializer's own doc comment for exactly
     /// which password-protected key shapes are reachable under
-    /// ``Session/Executor/urlSession``/``Session/Executor/nioTransportServices`` -- it's not
+    /// ``Session/Executor/urlSession``/``Session/Executor/nioTransportServices``; it's not
     /// every format ``Certificate/Format`` otherwise accepts.
     ///
     /// - Parameters:

--- a/Sources/RequestDL/Properties/Sources/Secure Connection/SPKI Pinning/Models/SPKIPinningPolicy.swift
+++ b/Sources/RequestDL/Properties/Sources/Secure Connection/SPKI Pinning/Models/SPKIPinningPolicy.swift
@@ -1,0 +1,29 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+import RequestDLInternals
+
+/// Failure behavior for ``SPKIPinning`` when a peer's certificate doesn't match any configured pin.
+public enum SPKIPinningPolicy: Sendable, Hashable {
+
+    /// Terminate the connection immediately on a pin mismatch. Use in production.
+    case strict
+
+    /// Permit the connection on a pin mismatch, for observability only.
+    ///
+    /// - Warning: Never use in production -- it effectively disables pinning while keeping audit
+    /// visibility (e.g. logging) for debugging, testing, or migration windows.
+    case audit
+
+    // MARK: - Internal methods
+
+    func build() -> Internals.SPKIPinningPolicy {
+        switch self {
+        case .strict:
+            return .strict
+        case .audit:
+            return .audit
+        }
+    }
+}

--- a/Sources/RequestDL/Properties/Sources/Secure Connection/SPKI Pinning/Models/SPKIPinningPolicy.swift
+++ b/Sources/RequestDL/Properties/Sources/Secure Connection/SPKI Pinning/Models/SPKIPinningPolicy.swift
@@ -12,7 +12,7 @@ public enum SPKIPinningPolicy: Sendable, Hashable {
 
     /// Permit the connection on a pin mismatch, for observability only.
     ///
-    /// - Warning: Never use in production -- it effectively disables pinning while keeping audit
+    /// - Warning: Never use in production. It effectively disables pinning while keeping audit
     /// visibility (e.g. logging) for debugging, testing, or migration windows.
     case audit
 

--- a/Sources/RequestDL/Properties/Sources/Secure Connection/SPKI Pinning/SPKIPinning.swift
+++ b/Sources/RequestDL/Properties/Sources/Secure Connection/SPKI Pinning/SPKIPinning.swift
@@ -2,7 +2,6 @@
 // See LICENSE for this package's licensing information.
 //
 
-import AsyncHTTPClient
 import RequestDLInternals
 
 /// SPKI-based certificate pinning configuration for secure connections.
@@ -31,7 +30,7 @@ public struct SPKIPinning<Content: Property>: Property {
         let nodes: [LeafNode<SPKIHashNode>]
 
         func make(_ secureConnection: inout Internals.SecureConnection) throws {
-            secureConnection.tlsPinningPolicy = policy
+            secureConnection.tlsPinningPolicy = policy.build()
             secureConnection.tlsPins = nodes.map(\.hash)
         }
     }

--- a/Sources/RequestDL/Properties/Sources/Secure Connection/Secure Connection/Models/RevocationPolicy.swift
+++ b/Sources/RequestDL/Properties/Sources/Secure Connection/Secure Connection/Models/RevocationPolicy.swift
@@ -1,0 +1,38 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+import RequestDLInternals
+
+/// How strictly a peer certificate's revocation status (OCSP/CRL) is checked during the TLS
+/// handshake.
+///
+/// - Important: Reachable under ``Session/Executor/nio``, ``Session/Executor/nioTransportServices``,
+/// and ``Session/Executor/urlSession`` on Apple platforms only -- NIOSSL/BoringSSL implements no
+/// revocation checking of its own, so setting this has no effect at all on Linux.
+public enum RevocationPolicy: Sendable, Hashable {
+
+    /// Requires a definitive, verified positive response from OCSP or CRL before trusting the
+    /// certificate -- fails the handshake outright if that can't be obtained, including when the
+    /// revocation responder is simply unreachable.
+    case strict
+
+    /// Skips network-based revocation checking (OCSP/CRL fetches) entirely, consulting only
+    /// locally cached responses if any -- never fails a handshake over revocation status.
+    ///
+    /// - Warning: Also disallows network access for intermediate CA issuer (AIA) fetching, not
+    /// only revocation checking itself -- a chain that depends on that to complete may fail to
+    /// validate at all under this policy, independent of revocation status.
+    case disabled
+
+    // MARK: - Internal methods
+
+    func build() -> Internals.RevocationPolicy {
+        switch self {
+        case .strict:
+            return .strict
+        case .disabled:
+            return .disabled
+        }
+    }
+}

--- a/Sources/RequestDL/Properties/Sources/Secure Connection/Secure Connection/Models/RevocationPolicy.swift
+++ b/Sources/RequestDL/Properties/Sources/Secure Connection/Secure Connection/Models/RevocationPolicy.swift
@@ -8,20 +8,20 @@ import RequestDLInternals
 /// handshake.
 ///
 /// - Important: Reachable under ``Session/Executor/nio``, ``Session/Executor/nioTransportServices``,
-/// and ``Session/Executor/urlSession`` on Apple platforms only -- NIOSSL/BoringSSL implements no
+/// and ``Session/Executor/urlSession`` on Apple platforms only. NIOSSL/BoringSSL implements no
 /// revocation checking of its own, so setting this has no effect at all on Linux.
 public enum RevocationPolicy: Sendable, Hashable {
 
     /// Requires a definitive, verified positive response from OCSP or CRL before trusting the
-    /// certificate -- fails the handshake outright if that can't be obtained, including when the
+    /// certificate, failing the handshake outright if that can't be obtained, including when the
     /// revocation responder is simply unreachable.
     case strict
 
     /// Skips network-based revocation checking (OCSP/CRL fetches) entirely, consulting only
-    /// locally cached responses if any -- never fails a handshake over revocation status.
+    /// locally cached responses if any, and never fails a handshake over revocation status.
     ///
     /// - Warning: Also disallows network access for intermediate CA issuer (AIA) fetching, not
-    /// only revocation checking itself -- a chain that depends on that to complete may fail to
+    /// only revocation checking itself. A chain that depends on that to complete may fail to
     /// validate at all under this policy, independent of revocation status.
     case disabled
 

--- a/Sources/RequestDL/Properties/Sources/Secure Connection/Secure Connection/Models/TrustDecision.swift
+++ b/Sources/RequestDL/Properties/Sources/Secure Connection/Secure Connection/Models/TrustDecision.swift
@@ -1,0 +1,9 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+import RequestDLInternals
+
+/// A snapshot of one TLS trust evaluation's outcome, handed to a configured
+/// ``TrustDecisionObserver`` right after a peer certificate chain has been evaluated.
+public typealias TrustDecision = RequestDLInternals.TrustDecision

--- a/Sources/RequestDL/Properties/Sources/Secure Connection/Secure Connection/Models/TrustDecisionObserver.swift
+++ b/Sources/RequestDL/Properties/Sources/Secure Connection/Secure Connection/Models/TrustDecisionObserver.swift
@@ -1,0 +1,12 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+import RequestDLInternals
+
+/// Observes each TLS trust-evaluation decision a secure connection makes -- for observability or
+/// security-audit logging.
+///
+/// ``TrustDecisionObserver`` is purely informational: a ``TrustDecision`` has already been
+/// decided by the time it's called, and nothing it does can change the outcome.
+public typealias TrustDecisionObserver = RequestDLInternals.TrustDecisionObserver

--- a/Sources/RequestDL/Properties/Sources/Secure Connection/Secure Connection/Models/TrustDecisionObserver.swift
+++ b/Sources/RequestDL/Properties/Sources/Secure Connection/Secure Connection/Models/TrustDecisionObserver.swift
@@ -4,7 +4,7 @@
 
 import RequestDLInternals
 
-/// Observes each TLS trust-evaluation decision a secure connection makes -- for observability or
+/// Observes each TLS trust-evaluation decision a secure connection makes, for observability or
 /// security-audit logging.
 ///
 /// ``TrustDecisionObserver`` is purely informational: a ``TrustDecision`` has already been

--- a/Sources/RequestDL/Properties/Sources/Secure Connection/Secure Connection/SecureConnection.swift
+++ b/Sources/RequestDL/Properties/Sources/Secure Connection/Secure Connection/SecureConnection.swift
@@ -166,6 +166,14 @@ public struct SecureConnection<Content: Property>: Property {
 
     /// Sets the key log object for the secure connection.
     ///
+    /// - Important: Reachable under ``Session/Executor/nio`` only -- this is a **permanent**
+    /// limitation of the underlying platforms, not a gap awaiting a fix. Neither Network.framework
+    /// nor `URLSession` exposes any public API for observing per-session TLS secrets, so
+    /// ``Session/requiredExecutor(_:)``/``Session/preferredExecutor(_:)`` steer a session with a
+    /// key logger configured away from both ``Session/Executor/nioTransportServices`` and
+    /// ``Session/Executor/urlSession`` -- letting that combination reach the OS layer at all would
+    /// crash the process outright under Network.framework.
+    ///
     /// - Parameter keyLogger: The `SSLKeyLogger` object.
     /// - Returns: A modified `SecureConnection` with the key logger set.
     public func keyLogger(_ keyLogger: SSLKeyLogger) -> Self {

--- a/Sources/RequestDL/Properties/Sources/Secure Connection/Secure Connection/SecureConnection.swift
+++ b/Sources/RequestDL/Properties/Sources/Secure Connection/Secure Connection/SecureConnection.swift
@@ -168,7 +168,8 @@ public struct SecureConnection<Content: Property>: Property {
     ///
     /// - Important: Reachable under ``Session/Executor/nio`` only. This is a **permanent**
     /// limitation of the underlying platforms, not a gap awaiting a fix. Neither Network.framework
-    /// nor `URLSession` exposes any public API for observing per-session TLS secrets, so
+    /// nor `URLSession` exposes any public API for observing per-session TLS secrets.
+    ///
     /// ``Session/requiredExecutor(_:)``/``Session/preferredExecutor(_:)`` steer a session with a
     /// key logger configured away from both ``Session/Executor/nioTransportServices`` and
     /// ``Session/Executor/urlSession``. Letting that combination reach the OS layer at all would

--- a/Sources/RequestDL/Properties/Sources/Secure Connection/Secure Connection/SecureConnection.swift
+++ b/Sources/RequestDL/Properties/Sources/Secure Connection/Secure Connection/SecureConnection.swift
@@ -243,6 +243,18 @@ public struct SecureConnection<Content: Property>: Property {
         edit { $0.secureConnection.revocationPolicy = policy.build() }
     }
 
+    /// Sets an observer that's notified of each TLS trust-evaluation decision this secure
+    /// connection makes -- for observability or security-audit logging, purely informational.
+    ///
+    /// - Important: See ``TrustDecisionObserver``'s own doc comment for exactly when this fires
+    /// under each executor -- it's not every connection.
+    ///
+    /// - Parameter observer: The observer to notify of each trust decision.
+    /// - Returns: A modified `SecureConnection` with the trust decision observer set.
+    public func trustDecisionObserver(_ observer: TrustDecisionObserver) -> Self {
+        edit { $0.secureConnection.trustDecisionObserver = observer }
+    }
+
     /// Sets the application protocols for the secure connection.
     ///
     /// - Parameter protocols: The application protocols to use.

--- a/Sources/RequestDL/Properties/Sources/Secure Connection/Secure Connection/SecureConnection.swift
+++ b/Sources/RequestDL/Properties/Sources/Secure Connection/Secure Connection/SecureConnection.swift
@@ -230,6 +230,19 @@ public struct SecureConnection<Content: Property>: Property {
         edit { $0.secureConnection.certificateVerification = verification.build() }
     }
 
+    /// Sets the revocation-checking policy for the secure connection.
+    ///
+    /// - Important: Reachable on Apple platforms only (``Session/Executor/nio``,
+    /// ``Session/Executor/nioTransportServices``, ``Session/Executor/urlSession``) -- NIOSSL/
+    /// BoringSSL implements no revocation checking of its own, so this has no effect at all on
+    /// Linux.
+    ///
+    /// - Parameter policy: The revocation-checking policy to use.
+    /// - Returns: A modified `SecureConnection` with the revocation policy set.
+    public func revocationPolicy(_ policy: RevocationPolicy) -> Self {
+        edit { $0.secureConnection.revocationPolicy = policy.build() }
+    }
+
     /// Sets the application protocols for the secure connection.
     ///
     /// - Parameter protocols: The application protocols to use.

--- a/Sources/RequestDL/Properties/Sources/Secure Connection/Secure Connection/SecureConnection.swift
+++ b/Sources/RequestDL/Properties/Sources/Secure Connection/Secure Connection/SecureConnection.swift
@@ -12,6 +12,16 @@ import RequestDLInternals
 /// each creates the underlying secure connection configuration on its own the first time it's
 /// needed. Nest them here only when also configuring settings that live directly on
 /// `SecureConnection` (`version`, `cipherSuites`, `keyLogger`, ...).
+///
+/// > Important: `URLSessionConfiguration` has no API for TLS version or ALPN policy.
+/// `version(maximum:)` and ``applicationProtocols(_:)`` are treated as incompatible with
+/// ``Session/Executor/urlSession``, like `cipherSuites(_:)`: automatic executor resolution skips
+/// `.urlSession` when either is set, and pinning to it throws ``ExecutorRequirementError``.
+/// `version(minimum:)` is the one exception: it has no effect under `.urlSession` but isn't
+/// flagged, because App Transport Security offers a real equivalent, an
+/// `NSExceptionMinimumTLSVersion` entry in your app's `Info.plist`, that `version(maximum:)` and
+/// ``applicationProtocols(_:)`` don't have. See
+/// <doc:Configuring-App-Transport-Security-for-URLSession>.
 public struct SecureConnection<Content: Property>: Property {
 
     private struct Node: SecureConnectionPropertyNode {
@@ -118,6 +128,10 @@ public struct SecureConnection<Content: Property>: Property {
 
     /// Sets the minimum TLS version for the secure connection.
     ///
+    /// > Important: Has no effect under ``Session/Executor/urlSession``. Configure an
+    /// `NSExceptionMinimumTLSVersion` ATS exception in `Info.plist` instead. See
+    /// <doc:Configuring-App-Transport-Security-for-URLSession>.
+    ///
     /// - Parameter minimum: The minimum TLS version to use.
     /// - Returns: A modified `SecureConnection` with the minimum TLS version set.
     public func version(minimum: TLSVersion) -> Self {
@@ -125,6 +139,13 @@ public struct SecureConnection<Content: Property>: Property {
     }
 
     /// Sets the maximum TLS version for the secure connection.
+    ///
+    /// > Important: `URLSessionConfiguration` has no maximum-TLS-version API, and App Transport
+    /// Security has no `Info.plist` key for one either, so this is treated as incompatible with
+    /// ``Session/Executor/urlSession``: automatic executor resolution skips it in favor of a
+    /// NIO-based executor, and pinning to `.urlSession` via ``Session/requiredExecutor(_:)``
+    /// throws ``ExecutorRequirementError``. See
+    /// <doc:Configuring-App-Transport-Security-for-URLSession>.
     ///
     /// - Parameter maximum: The maximum TLS version to use.
     /// - Returns: A modified `SecureConnection` with the maximum TLS version set.
@@ -258,6 +279,12 @@ public struct SecureConnection<Content: Property>: Property {
 
     /// Sets the application protocols for the secure connection.
     ///
+    /// > Important: `URLSession` negotiates ALPN automatically and `Info.plist` has no key to
+    /// override it, so this is treated as incompatible with ``Session/Executor/urlSession``:
+    /// automatic executor resolution skips it in favor of a NIO-based executor, and pinning to
+    /// `.urlSession` via ``Session/requiredExecutor(_:)`` throws ``ExecutorRequirementError``.
+    /// See <doc:Configuring-App-Transport-Security-for-URLSession>.
+    ///
     /// - Parameter protocols: The application protocols to use.
     /// - Returns: A modified `SecureConnection` with the application protocols set.
     public func applicationProtocols(_ protocols: String...) -> Self {
@@ -274,6 +301,12 @@ public struct SecureConnection<Content: Property>: Property {
 
     /// Sets the cipher suites for the secure connection using string representations.
     ///
+    /// > Important: `URLSessionConfiguration` has no cipher suite list API, so this is treated as
+    /// incompatible with ``Session/Executor/urlSession``: automatic executor resolution skips it
+    /// in favor of a NIO-based executor, and pinning to `.urlSession` via
+    /// ``Session/requiredExecutor(_:)`` throws ``ExecutorRequirementError`` instead of silently
+    /// dropping it.
+    ///
     /// - Parameter suites: The cipher suites to use as string representations.
     /// - Returns: A modified `SecureConnection` with the cipher suites set.
     public func cipherSuites(_ suites: String...) -> Self {
@@ -284,6 +317,12 @@ public struct SecureConnection<Content: Property>: Property {
     }
 
     /// Sets the cipher suites for the secure connection using `TLSCipher` values.
+    ///
+    /// > Important: `URLSessionConfiguration` has no cipher suite list API, so this is treated as
+    /// incompatible with ``Session/Executor/urlSession``: automatic executor resolution skips it
+    /// in favor of a NIO-based executor, and pinning to `.urlSession` via
+    /// ``Session/requiredExecutor(_:)`` throws ``ExecutorRequirementError`` instead of silently
+    /// dropping it.
     ///
     /// - Parameter suites: The cipher suites to use as `TLSCipher` values.
     /// - Returns: A modified `SecureConnection` with the cipher suites set.

--- a/Sources/RequestDL/Properties/Sources/Secure Connection/Secure Connection/SecureConnection.swift
+++ b/Sources/RequestDL/Properties/Sources/Secure Connection/Secure Connection/SecureConnection.swift
@@ -166,12 +166,12 @@ public struct SecureConnection<Content: Property>: Property {
 
     /// Sets the key log object for the secure connection.
     ///
-    /// - Important: Reachable under ``Session/Executor/nio`` only -- this is a **permanent**
+    /// - Important: Reachable under ``Session/Executor/nio`` only. This is a **permanent**
     /// limitation of the underlying platforms, not a gap awaiting a fix. Neither Network.framework
     /// nor `URLSession` exposes any public API for observing per-session TLS secrets, so
     /// ``Session/requiredExecutor(_:)``/``Session/preferredExecutor(_:)`` steer a session with a
     /// key logger configured away from both ``Session/Executor/nioTransportServices`` and
-    /// ``Session/Executor/urlSession`` -- letting that combination reach the OS layer at all would
+    /// ``Session/Executor/urlSession``. Letting that combination reach the OS layer at all would
     /// crash the process outright under Network.framework.
     ///
     /// - Parameter keyLogger: The `SSLKeyLogger` object.
@@ -233,7 +233,7 @@ public struct SecureConnection<Content: Property>: Property {
     /// Sets the revocation-checking policy for the secure connection.
     ///
     /// - Important: Reachable on Apple platforms only (``Session/Executor/nio``,
-    /// ``Session/Executor/nioTransportServices``, ``Session/Executor/urlSession``) -- NIOSSL/
+    /// ``Session/Executor/nioTransportServices``, ``Session/Executor/urlSession``). NIOSSL/
     /// BoringSSL implements no revocation checking of its own, so this has no effect at all on
     /// Linux.
     ///
@@ -244,10 +244,10 @@ public struct SecureConnection<Content: Property>: Property {
     }
 
     /// Sets an observer that's notified of each TLS trust-evaluation decision this secure
-    /// connection makes -- for observability or security-audit logging, purely informational.
+    /// connection makes, for observability or security-audit logging, purely informational.
     ///
     /// - Important: See ``TrustDecisionObserver``'s own doc comment for exactly when this fires
-    /// under each executor -- it's not every connection.
+    /// under each executor; it's not every connection.
     ///
     /// - Parameter observer: The observer to notify of each trust decision.
     /// - Returns: A modified `SecureConnection` with the trust decision observer set.

--- a/Sources/RequestDL/Properties/Sources/Session/Session/Models/ExecutorRequirementError.swift
+++ b/Sources/RequestDL/Properties/Sources/Session/Session/Models/ExecutorRequirementError.swift
@@ -29,6 +29,8 @@ public struct ExecutorRequirementError: Error, Sendable {
         case proxyConnectHeadersUnderURLSession
         case proxyBearerAuthorizationUnderURLSession
         case decompressionRequiresURLSession
+        case maximumTLSVersionUnderURLSession
+        case applicationProtocolsUnderURLSession
 
         // MARK: - Inits
 
@@ -64,6 +66,10 @@ public struct ExecutorRequirementError: Error, Sendable {
                 self = .proxyBearerAuthorizationUnderURLSession
             case .decompressionRequiresURLSession:
                 self = .decompressionRequiresURLSession
+            case .maximumTLSVersionUnderURLSession:
+                self = .maximumTLSVersionUnderURLSession
+            case .applicationProtocolsUnderURLSession:
+                self = .applicationProtocolsUnderURLSession
             }
         }
     }
@@ -135,6 +141,10 @@ extension ExecutorRequirementError.Reason: CustomStringConvertible {
         case .decompressionRequiresURLSession:
             return
                 "a decompression algorithm that only works under URLSession (unsupported under NIO/NIOTransportServices)"
+        case .maximumTLSVersionUnderURLSession:
+            return "a maximum TLS version (unsupported under URLSession)"
+        case .applicationProtocolsUnderURLSession:
+            return "an ALPN application protocol list (unsupported under URLSession)"
         }
     }
 }

--- a/Sources/RequestDL/Properties/Sources/Session/Session/Models/ExecutorRequirementError.swift
+++ b/Sources/RequestDL/Properties/Sources/Session/Session/Models/ExecutorRequirementError.swift
@@ -24,16 +24,6 @@ public struct ExecutorRequirementError: Error, Sendable {
         case shutdownTimeout
         case pskHint
         case pskIdentityResolver
-        /// No longer produced: disabled hostname verification is reachable under Network.framework
-        /// now, via `Internals.NIOTrustEvaluator` swapping in a hostname-less trust policy. Kept,
-        /// rather than removed, for source compatibility with any exhaustive `switch` over `Reason`
-        /// written before this case stopped being thrown.
-        case noHostnameVerificationUnderNetworkFramework
-        /// No longer produced: `additionalTrustRoots` alone (no SPKI pinning) is reachable under
-        /// Network.framework now, via `Internals.NIOTrustEvaluator`. Kept, rather than removed, for
-        /// source compatibility with any exhaustive `switch` over `Reason` written before this
-        /// case stopped being thrown.
-        case additionalTrustRootsUnderNetworkFramework
         case dnsOverrideUnderURLSession
         case http1OnlyUnderURLSession
         case proxyConnectHeadersUnderURLSession
@@ -134,14 +124,6 @@ extension ExecutorRequirementError.Reason: CustomStringConvertible {
             return "a PSK hint"
         case .pskIdentityResolver:
             return "a PSK identity resolver"
-        case .noHostnameVerificationUnderNetworkFramework:
-            // Unreachable -- see this case's own doc comment. Kept only so `description` stays
-            // exhaustive without a `default:` swallowing future genuinely-new cases by accident.
-            return "disabled hostname verification (unsupported under Network.framework)"
-        case .additionalTrustRootsUnderNetworkFramework:
-            // Unreachable -- see this case's own doc comment. Kept only so `description` stays
-            // exhaustive without a `default:` swallowing future genuinely-new cases by accident.
-            return "additional trust roots without also configuring SPKI pinning (unsupported under Network.framework)"
         case .dnsOverrideUnderURLSession:
             return "a DNS override (unsupported under URLSession)"
         case .http1OnlyUnderURLSession:

--- a/Sources/RequestDL/Properties/Sources/Session/Session/Models/ExecutorRequirementError.swift
+++ b/Sources/RequestDL/Properties/Sources/Session/Session/Models/ExecutorRequirementError.swift
@@ -14,8 +14,6 @@ public struct ExecutorRequirementError: Error, Sendable {
 
     /// One configuration field that keeps a session off the required executor.
     public enum Reason: Sendable, Hashable {
-        case certificateChain
-        case privateKey
         case keyLogger
         case cipherSuites
         case cipherSuiteValues
@@ -28,7 +26,6 @@ public struct ExecutorRequirementError: Error, Sendable {
         case pskIdentityResolver
         case noHostnameVerificationUnderNetworkFramework
         case additionalTrustRootsUnderNetworkFramework
-        case tlsPinning
         case dnsOverrideUnderURLSession
         case http1OnlyUnderURLSession
         case proxyConnectHeadersUnderURLSession
@@ -39,10 +36,6 @@ public struct ExecutorRequirementError: Error, Sendable {
 
         init(_ reason: Internals.ExecutorIncompatibilityReason) {
             switch reason {
-            case .certificateChain:
-                self = .certificateChain
-            case .privateKey:
-                self = .privateKey
             case .keyLogger:
                 self = .keyLogger
             case .cipherSuites:
@@ -67,8 +60,6 @@ public struct ExecutorRequirementError: Error, Sendable {
                 self = .noHostnameVerificationUnderNetworkFramework
             case .additionalTrustRootsUnderNetworkFramework:
                 self = .additionalTrustRootsUnderNetworkFramework
-            case .tlsPinning:
-                self = .tlsPinning
             case .dnsOverrideUnderURLSession:
                 self = .dnsOverrideUnderURLSession
             case .http1OnlyUnderURLSession:
@@ -119,10 +110,6 @@ extension ExecutorRequirementError.Reason: CustomStringConvertible {
 
     public var description: String {
         switch self {
-        case .certificateChain:
-            return "a client certificate chain"
-        case .privateKey:
-            return "a client private key"
         case .keyLogger:
             return "a TLS key logger"
         case .cipherSuites:
@@ -146,9 +133,7 @@ extension ExecutorRequirementError.Reason: CustomStringConvertible {
         case .noHostnameVerificationUnderNetworkFramework:
             return "disabled hostname verification (unsupported under Network.framework)"
         case .additionalTrustRootsUnderNetworkFramework:
-            return "additional trust roots (unsupported under Network.framework)"
-        case .tlsPinning:
-            return "SPKI certificate pinning"
+            return "additional trust roots without also configuring SPKI pinning (unsupported under Network.framework)"
         case .dnsOverrideUnderURLSession:
             return "a DNS override (unsupported under URLSession)"
         case .http1OnlyUnderURLSession:

--- a/Sources/RequestDL/Properties/Sources/Session/Session/Models/ExecutorRequirementError.swift
+++ b/Sources/RequestDL/Properties/Sources/Session/Session/Models/ExecutorRequirementError.swift
@@ -24,6 +24,10 @@ public struct ExecutorRequirementError: Error, Sendable {
         case shutdownTimeout
         case pskHint
         case pskIdentityResolver
+        /// No longer produced: disabled hostname verification is reachable under Network.framework
+        /// now, via `Internals.NIOTrustEvaluator` swapping in a hostname-less trust policy. Kept,
+        /// rather than removed, for source compatibility with any exhaustive `switch` over `Reason`
+        /// written before this case stopped being thrown.
         case noHostnameVerificationUnderNetworkFramework
         /// No longer produced: `additionalTrustRoots` alone (no SPKI pinning) is reachable under
         /// Network.framework now, via `Internals.NIOTrustEvaluator`. Kept, rather than removed, for
@@ -60,8 +64,6 @@ public struct ExecutorRequirementError: Error, Sendable {
                 self = .pskHint
             case .pskIdentityResolver:
                 self = .pskIdentityResolver
-            case .noHostnameVerificationUnderNetworkFramework:
-                self = .noHostnameVerificationUnderNetworkFramework
             case .dnsOverrideUnderURLSession:
                 self = .dnsOverrideUnderURLSession
             case .http1OnlyUnderURLSession:
@@ -133,6 +135,8 @@ extension ExecutorRequirementError.Reason: CustomStringConvertible {
         case .pskIdentityResolver:
             return "a PSK identity resolver"
         case .noHostnameVerificationUnderNetworkFramework:
+            // Unreachable -- see this case's own doc comment. Kept only so `description` stays
+            // exhaustive without a `default:` swallowing future genuinely-new cases by accident.
             return "disabled hostname verification (unsupported under Network.framework)"
         case .additionalTrustRootsUnderNetworkFramework:
             // Unreachable -- see this case's own doc comment. Kept only so `description` stays

--- a/Sources/RequestDL/Properties/Sources/Session/Session/Models/ExecutorRequirementError.swift
+++ b/Sources/RequestDL/Properties/Sources/Session/Session/Models/ExecutorRequirementError.swift
@@ -25,6 +25,10 @@ public struct ExecutorRequirementError: Error, Sendable {
         case pskHint
         case pskIdentityResolver
         case noHostnameVerificationUnderNetworkFramework
+        /// No longer produced: `additionalTrustRoots` alone (no SPKI pinning) is reachable under
+        /// Network.framework now, via `Internals.NIOTrustEvaluator`. Kept, rather than removed, for
+        /// source compatibility with any exhaustive `switch` over `Reason` written before this
+        /// case stopped being thrown.
         case additionalTrustRootsUnderNetworkFramework
         case dnsOverrideUnderURLSession
         case http1OnlyUnderURLSession
@@ -58,8 +62,6 @@ public struct ExecutorRequirementError: Error, Sendable {
                 self = .pskIdentityResolver
             case .noHostnameVerificationUnderNetworkFramework:
                 self = .noHostnameVerificationUnderNetworkFramework
-            case .additionalTrustRootsUnderNetworkFramework:
-                self = .additionalTrustRootsUnderNetworkFramework
             case .dnsOverrideUnderURLSession:
                 self = .dnsOverrideUnderURLSession
             case .http1OnlyUnderURLSession:
@@ -133,6 +135,8 @@ extension ExecutorRequirementError.Reason: CustomStringConvertible {
         case .noHostnameVerificationUnderNetworkFramework:
             return "disabled hostname verification (unsupported under Network.framework)"
         case .additionalTrustRootsUnderNetworkFramework:
+            // Unreachable -- see this case's own doc comment. Kept only so `description` stays
+            // exhaustive without a `default:` swallowing future genuinely-new cases by accident.
             return "additional trust roots without also configuring SPKI pinning (unsupported under Network.framework)"
         case .dnsOverrideUnderURLSession:
             return "a DNS override (unsupported under URLSession)"

--- a/Sources/RequestDL/Properties/Sources/Session/Session/Session.swift
+++ b/Sources/RequestDL/Properties/Sources/Session/Session/Session.swift
@@ -229,6 +229,14 @@ public struct Session: Property {
     /// is already ``preferredExecutor(_:)``'s own default choice on Darwin whenever the rest of
     /// the configuration supports it.
     ///
+    /// Pinning to `.urlSession` does **not** catch a `SecureConnection` minimum TLS version.
+    /// `ExecutorRequirementError` isn't thrown for it; it simply has no effect, because
+    /// `URLSessionConfiguration` has no API for it at all. That policy instead lives in your
+    /// app's `Info.plist`, via App Transport Security. See
+    /// <doc:Configuring-App-Transport-Security-for-URLSession>. A maximum TLS version or an ALPN
+    /// protocol list, which have no `Info.plist` equivalent at all, *are* caught: they throw
+    /// `ExecutorRequirementError` like any other incompatible field.
+    ///
     /// ```swift
     /// struct MyRequest: Property {
     ///     var body: some Property {

--- a/Sources/RequestDL/Tasks/Sources/Background Download/Models/BackgroundDownloads.Session.swift
+++ b/Sources/RequestDL/Tasks/Sources/Background Download/Models/BackgroundDownloads.Session.swift
@@ -166,18 +166,19 @@ extension BackgroundDownloads {
                 .handle(challenge: challenge, completionHandler: completionHandler)
         }
 
-        /// Rebuilds the identity fresh from disk for this one challenge -- no identity is cached
+        /// Rebuilds the identity fresh from disk for this one challenge. No identity is cached
         /// across calls, so there's nothing to invalidate if the same task is challenged again
         /// later (a redirect to a new host, for instance): it's simply rebuilt again, from the
         /// same file, the same way.
         ///
-        /// `handle` isn't retained past this method, so it deinitializes (and, if no other live
-        /// `Internals.IdentityHandle` shares this exact certificate/key pair, removes the
-        /// Keychain items backing it) right after `completionHandler` returns -- safe even then:
-        /// once `SecItemCopyMatching` has handed back a `SecIdentity`, the in-memory object
-        /// doesn't stop working just because the Keychain entry backing it is deleted afterward,
-        /// the same assumption `Internals.URLSessionIdentityPolicy` already relies on, just at a
-        /// smaller grain here.
+        /// `handle` isn't retained past this method, so it deinitializes right after
+        /// `completionHandler` returns, removing the Keychain items backing it unless some other
+        /// live `Internals.IdentityHandle` shares this exact certificate/key pair.
+        ///
+        /// That's safe even then: once `SecItemCopyMatching` has handed back a `SecIdentity`, the
+        /// in-memory object doesn't stop working just because the Keychain entry backing it is
+        /// deleted afterward, the same assumption `Internals.URLSessionIdentityPolicy` already
+        /// relies on, just at a smaller grain here.
         private func handleClientCertificateChallenge(
             task: URLSessionTask,
             completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void

--- a/Sources/RequestDL/Tasks/Sources/Background Download/Models/BackgroundDownloads.Session.swift
+++ b/Sources/RequestDL/Tasks/Sources/Background Download/Models/BackgroundDownloads.Session.swift
@@ -166,15 +166,18 @@ extension BackgroundDownloads {
                 .handle(challenge: challenge, completionHandler: completionHandler)
         }
 
-        /// Rebuilds the identity fresh from disk for this one challenge and removes it again
-        /// right after handing the credential over -- no identity is cached across calls, so
-        /// there's nothing to invalidate if the same task is challenged again later (a redirect
-        /// to a new host, for instance): it's simply rebuilt again, from the same file, the same
-        /// way. Safe to remove immediately: once `SecItemCopyMatching` has handed back a
-        /// `SecIdentity`, the in-memory object doesn't stop working just because the Keychain
-        /// entry backing it is deleted afterward, the same assumption
-        /// `Internals.URLSessionIdentityPolicy.deinit` already relies on, just at a smaller grain
-        /// here.
+        /// Rebuilds the identity fresh from disk for this one challenge -- no identity is cached
+        /// across calls, so there's nothing to invalidate if the same task is challenged again
+        /// later (a redirect to a new host, for instance): it's simply rebuilt again, from the
+        /// same file, the same way.
+        ///
+        /// `handle` isn't retained past this method, so it deinitializes (and, if no other live
+        /// `Internals.IdentityHandle` shares this exact certificate/key pair, removes the
+        /// Keychain items backing it) right after `completionHandler` returns -- safe even then:
+        /// once `SecItemCopyMatching` has handed back a `SecIdentity`, the in-memory object
+        /// doesn't stop working just because the Keychain entry backing it is deleted afterward,
+        /// the same assumption `Internals.URLSessionIdentityPolicy` already relies on, just at a
+        /// smaller grain here.
         private func handleClientCertificateChallenge(
             task: URLSessionTask,
             completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
@@ -197,8 +200,6 @@ extension BackgroundDownloads {
                     persistence: .forSession
                 )
             )
-
-            Internals.RawBytesIdentityBuilder.remove(handle)
         }
 
         // MARK: - URLSessionDownloadDelegate

--- a/Sources/RequestDLInternals/Sources/Client/Client Manager/Internals.ClientManager.swift
+++ b/Sources/RequestDLInternals/Sources/Client/Client Manager/Internals.ClientManager.swift
@@ -300,11 +300,21 @@ extension Internals {
             eventLoopGroup: EventLoopGroup,
             sessionConfiguration: Internals.Session.Configuration
         ) throws -> Internals.Client {
+            let output = try sessionConfiguration.build()
+            #if canImport(Darwin)
             let client = Internals.Client(
                 eventLoopGroupProvider: .shared(eventLoopGroup),
-                configuration: try sessionConfiguration.build(),
+                configuration: output.httpClientConfiguration,
+                localIdentityHandle: output.localIdentityHandle,
                 maximumConcurrentConnections: sessionConfiguration.maximumConcurrentConnections
             )
+            #else
+            let client = Internals.Client(
+                eventLoopGroupProvider: .shared(eventLoopGroup),
+                configuration: output.httpClientConfiguration,
+                maximumConcurrentConnections: sessionConfiguration.maximumConcurrentConnections
+            )
+            #endif
 
             tableLock.withLock {
                 var items = _table[id] ?? []

--- a/Sources/RequestDLInternals/Sources/Client/Client Manager/Internals.ClientManager.swift
+++ b/Sources/RequestDLInternals/Sources/Client/Client Manager/Internals.ClientManager.swift
@@ -174,7 +174,8 @@ extension Internals {
                 return try _createNewClient(
                     id: sessionProviderID,
                     eventLoopGroup: eventLoopGroup,
-                    sessionConfiguration: sessionConfiguration
+                    sessionConfiguration: sessionConfiguration,
+                    isCompatibleWithNetworkFramework: isCompatibleWithNetworkFramework
                 )
             }
         }
@@ -298,9 +299,12 @@ extension Internals {
         private func _createNewClient(
             id: String,
             eventLoopGroup: EventLoopGroup,
-            sessionConfiguration: Internals.Session.Configuration
+            sessionConfiguration: Internals.Session.Configuration,
+            isCompatibleWithNetworkFramework: Bool
         ) throws -> Internals.Client {
-            let output = try sessionConfiguration.build()
+            let output = try sessionConfiguration.build(
+                isCompatibleWithNetworkFramework: isCompatibleWithNetworkFramework
+            )
             #if canImport(Darwin)
             let client = Internals.Client(
                 eventLoopGroupProvider: .shared(eventLoopGroup),

--- a/Sources/RequestDLInternals/Sources/Client/Client/Internals.Client.swift
+++ b/Sources/RequestDLInternals/Sources/Client/Client/Internals.Client.swift
@@ -54,7 +54,7 @@ extension Internals {
 
         #if canImport(Darwin)
         /// The mTLS client identity's Keychain-item handle, when `SecureConnection.certificateChain`/
-        /// `.privateKey` were configured for a Network.framework connection -- held for as long as
+        /// `.privateKey` were configured for a Network.framework connection. Held for as long as
         /// this `Client` (and so this client's underlying `HTTPClient`) is alive, and released in
         /// `deinit`, mirroring `Internals.URLSessionIdentityPolicy`'s own identity lifecycle exactly.
         private let localIdentityHandle: Internals.RawBytesIdentityBuilder.Handle?

--- a/Sources/RequestDLInternals/Sources/Client/Client/Internals.Client.swift
+++ b/Sources/RequestDLInternals/Sources/Client/Client/Internals.Client.swift
@@ -105,7 +105,7 @@ extension Internals {
 
         deinit {
             // Removing the mTLS identity's Keychain items (if any) doesn't depend on whether the
-            // client was already closed -- unlike shutting down `_client` below, doing this twice
+            // client was already closed. Unlike shutting down `_client` below, doing this twice
             // isn't an error, and there's no other owner racing to do it first.
             #if canImport(Darwin)
             if let localIdentityHandle {

--- a/Sources/RequestDLInternals/Sources/Client/Client/Internals.Client.swift
+++ b/Sources/RequestDLInternals/Sources/Client/Client/Internals.Client.swift
@@ -55,11 +55,12 @@ extension Internals {
         #if canImport(Darwin)
         /// The mTLS client identity's Keychain-item handle, when `SecureConnection.certificateChain`/
         /// `.privateKey` were configured for a Network.framework connection. Held for as long as
-        /// this `Client` (and so this client's underlying `HTTPClient`) is alive; released
-        /// automatically through `IdentityHandle`'s own `deinit` once this property is torn down,
-        /// mirroring `Internals.URLSessionIdentityPolicy`'s own identity lifecycle exactly, and
-        /// only actually deleting the underlying Keychain items once every other live
-        /// `Internals.IdentityHandle` for that same certificate/key pair has gone away too.
+        /// this `Client` (and so this client's underlying `HTTPClient`) is alive.
+        ///
+        /// Released automatically through `IdentityHandle`'s own `deinit` once this property is
+        /// torn down, mirroring `Internals.URLSessionIdentityPolicy`'s own identity lifecycle
+        /// exactly, and only actually deleting the underlying Keychain items once every other
+        /// live `Internals.IdentityHandle` for that same certificate/key pair has gone away too.
         private let localIdentityHandle: Internals.IdentityHandle?
         #endif
 
@@ -109,7 +110,7 @@ extension Internals {
         deinit {
             // The mTLS identity's Keychain items (if any) are released through
             // `localIdentityHandle`'s own `deinit`, automatically, once this stored property is
-            // torn down below -- no explicit call needed here.
+            // torn down below. No explicit call needed here.
 
             // Shutting down from here is a last resort, so it is guarded by the same flag the
             // explicit path sets. Without the guard this shut down a client the manager had

--- a/Sources/RequestDLInternals/Sources/Client/Client/Internals.Client.swift
+++ b/Sources/RequestDLInternals/Sources/Client/Client/Internals.Client.swift
@@ -55,9 +55,12 @@ extension Internals {
         #if canImport(Darwin)
         /// The mTLS client identity's Keychain-item handle, when `SecureConnection.certificateChain`/
         /// `.privateKey` were configured for a Network.framework connection. Held for as long as
-        /// this `Client` (and so this client's underlying `HTTPClient`) is alive, and released in
-        /// `deinit`, mirroring `Internals.URLSessionIdentityPolicy`'s own identity lifecycle exactly.
-        private let localIdentityHandle: Internals.RawBytesIdentityBuilder.Handle?
+        /// this `Client` (and so this client's underlying `HTTPClient`) is alive; released
+        /// automatically through `IdentityHandle`'s own `deinit` once this property is torn down,
+        /// mirroring `Internals.URLSessionIdentityPolicy`'s own identity lifecycle exactly, and
+        /// only actually deleting the underlying Keychain items once every other live
+        /// `Internals.IdentityHandle` for that same certificate/key pair has gone away too.
+        private let localIdentityHandle: Internals.IdentityHandle?
         #endif
 
         // MARK: - Unsafe properties
@@ -73,7 +76,7 @@ extension Internals {
         package init(
             eventLoopGroupProvider: HTTPClient.EventLoopGroupProvider,
             configuration: HTTPClient.Configuration,
-            localIdentityHandle: Internals.RawBytesIdentityBuilder.Handle? = nil,
+            localIdentityHandle: Internals.IdentityHandle? = nil,
             maximumConcurrentConnections: Int? = nil
         ) {
             _isClosed = false
@@ -104,14 +107,9 @@ extension Internals {
         #endif
 
         deinit {
-            // Removing the mTLS identity's Keychain items (if any) doesn't depend on whether the
-            // client was already closed. Unlike shutting down `_client` below, doing this twice
-            // isn't an error, and there's no other owner racing to do it first.
-            #if canImport(Darwin)
-            if let localIdentityHandle {
-                RawBytesIdentityBuilder.remove(localIdentityHandle)
-            }
-            #endif
+            // The mTLS identity's Keychain items (if any) are released through
+            // `localIdentityHandle`'s own `deinit`, automatically, once this stored property is
+            // torn down below -- no explicit call needed here.
 
             // Shutting down from here is a last resort, so it is guarded by the same flag the
             // explicit path sets. Without the guard this shut down a client the manager had

--- a/Sources/RequestDLInternals/Sources/Client/Client/Internals.Client.swift
+++ b/Sources/RequestDLInternals/Sources/Client/Client/Internals.Client.swift
@@ -52,12 +52,41 @@ extension Internals {
         /// request is asked to execute until it completes, is cancelled, or is released.
         private let throttledExecutor: Internals.ThrottledExecutor
 
+        #if canImport(Darwin)
+        /// The mTLS client identity's Keychain-item handle, when `SecureConnection.certificateChain`/
+        /// `.privateKey` were configured for a Network.framework connection -- held for as long as
+        /// this `Client` (and so this client's underlying `HTTPClient`) is alive, and released in
+        /// `deinit`, mirroring `Internals.URLSessionIdentityPolicy`'s own identity lifecycle exactly.
+        private let localIdentityHandle: Internals.RawBytesIdentityBuilder.Handle?
+        #endif
+
         // MARK: - Unsafe properties
 
         private var _isClosed: Bool
 
         // MARK: - Inits
 
+        // Swift doesn't reliably parse a parameter conditionally included in the middle of a
+        // parameter list (as opposed to a whole declaration), so this is two complete inits
+        // rather than one with a `#if`-guarded parameter.
+        #if canImport(Darwin)
+        package init(
+            eventLoopGroupProvider: HTTPClient.EventLoopGroupProvider,
+            configuration: HTTPClient.Configuration,
+            localIdentityHandle: Internals.RawBytesIdentityBuilder.Handle? = nil,
+            maximumConcurrentConnections: Int? = nil
+        ) {
+            _isClosed = false
+            _client = .init(
+                eventLoopGroupProvider: eventLoopGroupProvider,
+                configuration: configuration
+            )
+            throttledExecutor = Internals.ThrottledExecutor(
+                maximumConcurrentConnections: maximumConcurrentConnections
+            )
+            self.localIdentityHandle = localIdentityHandle
+        }
+        #else
         package init(
             eventLoopGroupProvider: HTTPClient.EventLoopGroupProvider,
             configuration: HTTPClient.Configuration,
@@ -72,8 +101,18 @@ extension Internals {
                 maximumConcurrentConnections: maximumConcurrentConnections
             )
         }
+        #endif
 
         deinit {
+            // Removing the mTLS identity's Keychain items (if any) doesn't depend on whether the
+            // client was already closed -- unlike shutting down `_client` below, doing this twice
+            // isn't an error, and there's no other owner racing to do it first.
+            #if canImport(Darwin)
+            if let localIdentityHandle {
+                RawBytesIdentityBuilder.remove(localIdentityHandle)
+            }
+            #endif
+
             // Shutting down from here is a last resort, so it is guarded by the same flag the
             // explicit path sets. Without the guard this shut down a client the manager had
             // already closed, and the second call is an error nobody was positioned to see.

--- a/Sources/RequestDLInternals/Sources/Client/URLSession Client/Identity/Internals.ClientIdentityDescriptor.swift
+++ b/Sources/RequestDLInternals/Sources/Client/URLSession Client/Identity/Internals.ClientIdentityDescriptor.swift
@@ -96,12 +96,12 @@ extension Internals {
         }
 
         /// Rebuilds a `SecIdentity` from disk, via the same Keychain round-trip
-        /// `Internals.URLSessionIdentityPolicy` uses -- safe to call repeatedly (the Keychain
+        /// `Internals.URLSessionIdentityPolicy` uses. Safe to call repeatedly (the Keychain
         /// label is content-derived, so re-adding the same identity is a no-op success, not a
         /// duplicate), and expected to be: this runs fresh on every client-certificate challenge,
         /// live or after a relaunch alike.
         ///
-        /// The caller doesn't need to remove the returned handle explicitly -- just don't retain
+        /// The caller doesn't need to remove the returned handle explicitly; just don't retain
         /// it past the point it's done answering. `Internals.IdentityHandle`'s own `deinit`
         /// releases it, deleting the underlying Keychain items only once every other live handle
         /// for this same certificate/key pair has gone away too.

--- a/Sources/RequestDLInternals/Sources/Client/URLSession Client/Identity/Internals.ClientIdentityDescriptor.swift
+++ b/Sources/RequestDLInternals/Sources/Client/URLSession Client/Identity/Internals.ClientIdentityDescriptor.swift
@@ -99,10 +99,14 @@ extension Internals {
         /// `Internals.URLSessionIdentityPolicy` uses -- safe to call repeatedly (the Keychain
         /// label is content-derived, so re-adding the same identity is a no-op success, not a
         /// duplicate), and expected to be: this runs fresh on every client-certificate challenge,
-        /// live or after a relaunch alike, with the caller removing the handle again once it's
-        /// done answering.
+        /// live or after a relaunch alike.
+        ///
+        /// The caller doesn't need to remove the returned handle explicitly -- just don't retain
+        /// it past the point it's done answering. `Internals.IdentityHandle`'s own `deinit`
+        /// releases it, deleting the underlying Keychain items only once every other live handle
+        /// for this same certificate/key pair has gone away too.
         package func makeIdentity() throws -> (
-            handle: Internals.RawBytesIdentityBuilder.Handle, intermediates: [SecCertificate]
+            handle: Internals.IdentityHandle, intermediates: [SecCertificate]
         ) {
             let derCertificates = try Internals.CertificateChain.file(certificateChainFilePath).build().map {
                 source -> Data in

--- a/Sources/RequestDLInternals/Sources/Client/URLSession Client/Identity/Internals.IdentityManager.swift
+++ b/Sources/RequestDLInternals/Sources/Client/URLSession Client/Identity/Internals.IdentityManager.swift
@@ -1,0 +1,105 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+#if canImport(Darwin)
+
+import Security
+import SwiftAsyncStream
+
+extension Internals {
+
+    /// One `SecIdentity` built by
+    /// `Internals.RawBytesIdentityBuilder.makeIdentity(certificateDER:privateKeyDER:)`,
+    /// reference-counted against every other `IdentityHandle` built for the same certificate/key
+    /// pair. Multiple independently-built `Internals.Client`/`Internals.URLSessionIdentityPolicy`
+    /// instances configured with the same mTLS identity share one Keychain-backed `SecIdentity`
+    /// and one pair of Keychain items, rather than the first to deallocate deleting items the
+    /// others still depend on.
+    ///
+    /// The underlying Keychain items are removed only once every live `IdentityHandle` for that
+    /// pair has deinitialized -- see ``IdentityManager``.
+    package final class IdentityHandle: @unchecked Sendable {
+        package let identity: SecIdentity
+        fileprivate let label: String
+
+        fileprivate init(identity: SecIdentity, label: String) {
+            self.identity = identity
+            self.label = label
+        }
+
+        deinit {
+            IdentityManager.shared.release(label: label)
+        }
+    }
+
+    /// Deduplicates ``IdentityHandle``s by their content-derived Keychain label, process-wide.
+    /// `Internals.RawBytesIdentityBuilder.makeIdentity(certificateDER:privateKeyDER:)` and
+    /// `IdentityHandle.deinit` are this type's only two callers, and both take the same lock --
+    /// so a build for a label and the teardown of that label's last surviving handle can never
+    /// interleave: one Keychain round trip (add or delete) always finishes before the next
+    /// begins.
+    package final class IdentityManager: @unchecked Sendable {
+        package static let shared = IdentityManager()
+
+        private let lock = Lock()
+        private var live: [String: Weak<IdentityHandle>] = [:]
+
+        private init() {}
+
+        /// Returns the already-live handle for `label`, if some other caller still holds a
+        /// strong reference to one, without touching the Keychain again. Otherwise runs `build`
+        /// (the actual Keychain round trip) and registers its result.
+        package func handle(
+            for label: String,
+            build: () throws -> SecIdentity
+        ) throws -> IdentityHandle {
+            try lock.withLock {
+                if let existing = live[label]?.value {
+                    return existing
+                }
+
+                let identity = try build()
+                let handle = IdentityHandle(identity: identity, label: label)
+                live[label] = Weak(handle)
+                return handle
+            }
+        }
+
+        /// Called once per `IdentityHandle.deinit`. Drops the (by now stale) registry entry and
+        /// removes both Keychain items `label` was built from.
+        fileprivate func release(label: String) {
+            lock.withLock {
+                live[label] = nil
+
+                #if os(macOS)
+                let useDataProtectionKeychain = false
+                #else
+                let useDataProtectionKeychain = true
+                #endif
+
+                for itemClass in [kSecClassKey, kSecClassCertificate] {
+                    let query: [CFString: Any] = [
+                        kSecClass: itemClass,
+                        kSecAttrLabel: label,
+                        kSecUseDataProtectionKeychain: useDataProtectionKeychain,
+                    ]
+                    SecItemDelete(query as CFDictionary)
+                }
+            }
+        }
+    }
+}
+
+/// A weak reference to a class instance, usable as a dictionary value -- `weak var` isn't allowed
+/// directly on a dictionary's `Value` generic parameter, so `Internals.IdentityManager` stores
+/// one of these per label instead.
+private struct Weak<Value: AnyObject> {
+    weak var value: Value?
+
+    init(_ value: Value) {
+        self.value = value
+    }
+}
+
+#endif

--- a/Sources/RequestDLInternals/Sources/Client/URLSession Client/Identity/Internals.IdentityManager.swift
+++ b/Sources/RequestDLInternals/Sources/Client/URLSession Client/Identity/Internals.IdentityManager.swift
@@ -12,13 +12,15 @@ extension Internals {
     /// One `SecIdentity` built by
     /// `Internals.RawBytesIdentityBuilder.makeIdentity(certificateDER:privateKeyDER:)`,
     /// reference-counted against every other `IdentityHandle` built for the same certificate/key
-    /// pair. Multiple independently-built `Internals.Client`/`Internals.URLSessionIdentityPolicy`
+    /// pair.
+    ///
+    /// Multiple independently-built `Internals.Client`/`Internals.URLSessionIdentityPolicy`
     /// instances configured with the same mTLS identity share one Keychain-backed `SecIdentity`
     /// and one pair of Keychain items, rather than the first to deallocate deleting items the
     /// others still depend on.
     ///
     /// The underlying Keychain items are removed only once every live `IdentityHandle` for that
-    /// pair has deinitialized -- see ``IdentityManager``.
+    /// pair has deinitialized; see ``IdentityManager``.
     package final class IdentityHandle: @unchecked Sendable {
         package let identity: SecIdentity
         fileprivate let label: String
@@ -35,9 +37,10 @@ extension Internals {
 
     /// Deduplicates ``IdentityHandle``s by their content-derived Keychain label, process-wide.
     /// `Internals.RawBytesIdentityBuilder.makeIdentity(certificateDER:privateKeyDER:)` and
-    /// `IdentityHandle.deinit` are this type's only two callers, and both take the same lock --
-    /// so a build for a label and the teardown of that label's last surviving handle can never
-    /// interleave: one Keychain round trip (add or delete) always finishes before the next
+    /// `IdentityHandle.deinit` are this type's only two callers, and both take the same lock.
+    ///
+    /// A build for a label and the teardown of that label's last surviving handle can therefore
+    /// never interleave: one Keychain round trip (add or delete) always finishes before the next
     /// begins.
     package final class IdentityManager: @unchecked Sendable {
         package static let shared = IdentityManager()
@@ -91,7 +94,7 @@ extension Internals {
     }
 }
 
-/// A weak reference to a class instance, usable as a dictionary value -- `weak var` isn't allowed
+/// A weak reference to a class instance, usable as a dictionary value. `weak var` isn't allowed
 /// directly on a dictionary's `Value` generic parameter, so `Internals.IdentityManager` stores
 /// one of these per label instead.
 private struct Weak<Value: AnyObject> {

--- a/Sources/RequestDLInternals/Sources/Client/URLSession Client/Identity/Internals.RawBytesIdentityBuilder.swift
+++ b/Sources/RequestDLInternals/Sources/Client/URLSession Client/Identity/Internals.RawBytesIdentityBuilder.swift
@@ -49,7 +49,7 @@ extension Internals {
                         "-----BEGIN EC PRIVATE KEY-----" or PKCS#8 \
                         "-----BEGIN PRIVATE KEY-----"), unencrypted. A password-protected key is \
                         only supported for traditional PKCS#1 RSA PEM \
-                        ("-----BEGIN RSA PRIVATE KEY-----" with "Proc-Type"/"DEK-Info" headers) -- \
+                        ("-----BEGIN RSA PRIVATE KEY-----" with "Proc-Type"/"DEK-Info" headers), \
                         not PKCS#8's "-----BEGIN ENCRYPTED PRIVATE KEY-----", and not any \
                         password-protected EC key.
                         """

--- a/Sources/RequestDLInternals/Sources/Client/URLSession Client/Identity/Internals.RawBytesIdentityBuilder.swift
+++ b/Sources/RequestDLInternals/Sources/Client/URLSession Client/Identity/Internals.RawBytesIdentityBuilder.swift
@@ -5,7 +5,7 @@
 // Promoted from the URLSession Executor Spike (formerly
 // `Tests/RequestDLTests/URLSession Executor Spike/RawBytesIdentityBuilder.swift`) for
 // request-dl-nio#287. Supports RSA (PKCS#1 or PKCS#8) and EC P-256/P-384/P-521 (SEC1 or
-// PKCS#8) private keys, unencrypted -- plus password-protected traditional PKCS#1 RSA PEM
+// PKCS#8) private keys, unencrypted, plus password-protected traditional PKCS#1 RSA PEM
 // keys specifically, decrypted via `_CryptoExtras` (see `privateKeyDER(from:)`).
 
 #if canImport(Darwin)
@@ -84,7 +84,7 @@ extension Internals {
         // MARK: - Identity sources (CertificateChain/PrivateKeySource -> raw DER bytes)
         //
         // Shared by every executor that needs a `SecIdentity` built from an
-        // `Internals.SecureConnection`'s `certificateChain`/`privateKey` -- `.urlSession`
+        // `Internals.SecureConnection`'s `certificateChain`/`privateKey`: `.urlSession`
         // (`Internals.URLSessionIdentityPolicy`) and `.nio` under Network.framework
         // (`Internals.SecureConnection.makeLocalIdentityForNetworkFramework()`) alike.
 

--- a/Sources/RequestDLInternals/Sources/Client/URLSession Client/Identity/Internals.RawBytesIdentityBuilder.swift
+++ b/Sources/RequestDLInternals/Sources/Client/URLSession Client/Identity/Internals.RawBytesIdentityBuilder.swift
@@ -74,13 +74,6 @@ extension Internals {
             }
         }
 
-        /// One identity built by ``makeIdentity(certificateDER:privateKeyDER:)``, together with
-        /// everything needed to remove it from the Keychain again.
-        package struct Handle {
-            package let identity: SecIdentity
-            fileprivate let label: String
-        }
-
         // MARK: - Identity sources (CertificateChain/PrivateKeySource -> raw DER bytes)
         //
         // Shared by every executor that needs a `SecIdentity` built from an
@@ -326,132 +319,120 @@ extension Internals {
         package static func makeIdentity(
             certificateDER: Data,
             privateKeyDER: Data
-        ) throws -> Handle {
+        ) throws -> Internals.IdentityHandle {
             let certificate = try certificate(fromDER: certificateDER)
             let secKey = try Self.secKey(fromDER: privateKeyDER)
 
             // Deterministic (content-derived, not random) so that rebuilding an identity for the
-            // same certificate -- a repeated test run, or an app relaunching with the same
-            // configured client certificate after a previous run's `deinit`-triggered `remove(_:)`
-            // never got to run -- reliably finds and clears its own leftovers below instead of
-            // hitting errSecDuplicateItem. `kSecValueRef`-based matching (delete "whatever item
-            // has this exact key/certificate value") looked like the more direct way to express
-            // that and is what the original spike did, but empirically did not reliably match an
-            // existing item across process runs; label-based matching does.
-            let label = "RequestDL.mtls." + Self.hexDigest(certificateDER)
+            // same certificate+key -- a repeated test run, an app relaunching with the same
+            // configured client certificate after a previous run's Keychain items never got
+            // cleaned up, or a second `Internals.IdentityHandle` for the same pair sharing this
+            // one -- reliably finds and reuses (or, on a fresh process, clears) its own leftovers
+            // below instead of hitting errSecDuplicateItem. Folds in the private key, not just
+            // the certificate, so two different keys accidentally paired with the same
+            // certificate never collide under one Keychain item. `kSecValueRef`-based matching
+            // (delete "whatever item has this exact key/certificate value") looked like the more
+            // direct way to express that and is what the original spike did, but empirically did
+            // not reliably match an existing item across process runs; label-based matching does.
+            let label = "RequestDL.mtls." + Self.hexDigest(certificateDER) + "." + Self.hexDigest(privateKeyDER)
 
-            // `swift test` (and any unsigned command-line process) has no `keychain-access-groups`
-            // entitlement, which the data-protection keychain requires -- forcing the legacy
-            // file-based keychain is a macOS-only accommodation for that. Not present on
-            // iOS/tvOS/watchOS, where there is only the data-protection keychain and a properly
-            // signed/provisioned app already carries the entitlement it needs.
-            #if os(macOS)
-            let useDataProtectionKeychain = false
-            #else
-            let useDataProtectionKeychain = true
-            #endif
+            return try Internals.IdentityManager.shared.handle(for: label) {
+                // `swift test` (and any unsigned command-line process) has no
+                // `keychain-access-groups` entitlement, which the data-protection keychain
+                // requires -- forcing the legacy file-based keychain is a macOS-only
+                // accommodation for that. Not present on iOS/tvOS/watchOS, where there is only
+                // the data-protection keychain and a properly signed/provisioned app already
+                // carries the entitlement it needs.
+                #if os(macOS)
+                let useDataProtectionKeychain = false
+                #else
+                let useDataProtectionKeychain = true
+                #endif
 
-            SecItemDelete(
-                [
-                    kSecClass: kSecClassKey,
-                    kSecAttrLabel: label,
-                    kSecUseDataProtectionKeychain: useDataProtectionKeychain,
-                ] as CFDictionary
-            )
-            SecItemDelete(
-                [
-                    kSecClass: kSecClassCertificate,
-                    kSecAttrLabel: label,
-                    kSecUseDataProtectionKeychain: useDataProtectionKeychain,
-                ] as CFDictionary
-            )
+                SecItemDelete(
+                    [
+                        kSecClass: kSecClassKey,
+                        kSecAttrLabel: label,
+                        kSecUseDataProtectionKeychain: useDataProtectionKeychain,
+                    ] as CFDictionary
+                )
+                SecItemDelete(
+                    [
+                        kSecClass: kSecClassCertificate,
+                        kSecAttrLabel: label,
+                        kSecUseDataProtectionKeychain: useDataProtectionKeychain,
+                    ] as CFDictionary
+                )
 
-            try addToKeychain(
-                query: [
-                    kSecClass: kSecClassKey,
-                    kSecValueRef: secKey,
-                    kSecAttrLabel: label,
-                    // This device only, not iCloud Keychain -- the key only needs to survive this
-                    // process's lifetime, not sync anywhere.
-                    kSecAttrAccessible: kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
-                    kSecUseDataProtectionKeychain: useDataProtectionKeychain,
-                ],
-                operation: "SecItemAdd(key)"
-            )
+                try addToKeychain(
+                    query: [
+                        kSecClass: kSecClassKey,
+                        kSecValueRef: secKey,
+                        kSecAttrLabel: label,
+                        // This device only, not iCloud Keychain -- the key only needs to survive
+                        // this process's lifetime, not sync anywhere.
+                        kSecAttrAccessible: kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
+                        kSecUseDataProtectionKeychain: useDataProtectionKeychain,
+                    ],
+                    operation: "SecItemAdd(key)"
+                )
 
-            try addToKeychain(
-                query: [
-                    kSecClass: kSecClassCertificate,
-                    kSecValueRef: certificate,
-                    kSecAttrLabel: label,
-                    kSecUseDataProtectionKeychain: useDataProtectionKeychain,
-                ],
-                operation: "SecItemAdd(certificate)"
-            )
+                try addToKeychain(
+                    query: [
+                        kSecClass: kSecClassCertificate,
+                        kSecValueRef: certificate,
+                        kSecAttrLabel: label,
+                        kSecUseDataProtectionKeychain: useDataProtectionKeychain,
+                    ],
+                    operation: "SecItemAdd(certificate)"
+                )
 
-            // `kSecClassIdentity` queries do not reliably honor `kSecAttrLabel` as a filter -- an
-            // identity is a synthetic pairing of a certificate and a key by matching public key,
-            // not an item with its own attributes, so the label set on the certificate/key above
-            // isn't necessarily inherited by it. Fetching every identity currently in this
-            // keychain and matching by certificate bytes is the approach that reliably works in
-            // practice.
-            let identityQuery: [CFString: Any] = [
-                kSecClass: kSecClassIdentity,
-                kSecMatchLimit: kSecMatchLimitAll,
-                kSecReturnRef: true,
-                kSecUseDataProtectionKeychain: useDataProtectionKeychain,
-            ]
-
-            var identitiesResult: CFTypeRef?
-            let identityStatus = SecItemCopyMatching(identityQuery as CFDictionary, &identitiesResult)
-
-            guard identityStatus == errSecSuccess else {
-                throw Error.keychainOperationFailed(identityStatus, operation: "SecItemCopyMatching(identity)")
-            }
-
-            guard let identities = identitiesResult as? [SecIdentity] else {
-                throw Error.identityLookupReturnedWrongType
-            }
-
-            let wantedCertificateData = SecCertificateCopyData(certificate) as Data
-
-            let matchingIdentity = identities.first { identity in
-                var identityCertificate: SecCertificate?
-                guard
-                    SecIdentityCopyCertificate(identity, &identityCertificate) == errSecSuccess,
-                    let identityCertificate
-                else {
-                    return false
-                }
-
-                return (SecCertificateCopyData(identityCertificate) as Data) == wantedCertificateData
-            }
-
-            guard let matchingIdentity else {
-                throw Error.keychainOperationFailed(errSecItemNotFound, operation: "matching identity by certificate")
-            }
-
-            return Handle(identity: matchingIdentity, label: label)
-        }
-
-        /// Removes both Keychain items an identity built by
-        /// ``makeIdentity(certificateDER:privateKeyDER:)`` was built from.
-        /// `Internals.URLSessionIdentityPolicy` calls this from `deinit`, once the identity is no
-        /// longer needed, not after every request.
-        package static func remove(_ handle: Handle) {
-            #if os(macOS)
-            let useDataProtectionKeychain = false
-            #else
-            let useDataProtectionKeychain = true
-            #endif
-
-            for itemClass in [kSecClassKey, kSecClassCertificate] {
-                let query: [CFString: Any] = [
-                    kSecClass: itemClass,
-                    kSecAttrLabel: handle.label,
+                // `kSecClassIdentity` queries do not reliably honor `kSecAttrLabel` as a filter --
+                // an identity is a synthetic pairing of a certificate and a key by matching
+                // public key, not an item with its own attributes, so the label set on the
+                // certificate/key above isn't necessarily inherited by it. Fetching every
+                // identity currently in this keychain and matching by certificate bytes is the
+                // approach that reliably works in practice.
+                let identityQuery: [CFString: Any] = [
+                    kSecClass: kSecClassIdentity,
+                    kSecMatchLimit: kSecMatchLimitAll,
+                    kSecReturnRef: true,
                     kSecUseDataProtectionKeychain: useDataProtectionKeychain,
                 ]
-                SecItemDelete(query as CFDictionary)
+
+                var identitiesResult: CFTypeRef?
+                let identityStatus = SecItemCopyMatching(identityQuery as CFDictionary, &identitiesResult)
+
+                guard identityStatus == errSecSuccess else {
+                    throw Error.keychainOperationFailed(identityStatus, operation: "SecItemCopyMatching(identity)")
+                }
+
+                guard let identities = identitiesResult as? [SecIdentity] else {
+                    throw Error.identityLookupReturnedWrongType
+                }
+
+                let wantedCertificateData = SecCertificateCopyData(certificate) as Data
+
+                let matchingIdentity = identities.first { identity in
+                    var identityCertificate: SecCertificate?
+                    guard
+                        SecIdentityCopyCertificate(identity, &identityCertificate) == errSecSuccess,
+                        let identityCertificate
+                    else {
+                        return false
+                    }
+
+                    return (SecCertificateCopyData(identityCertificate) as Data) == wantedCertificateData
+                }
+
+                guard let matchingIdentity else {
+                    throw Error.keychainOperationFailed(
+                        errSecItemNotFound,
+                        operation: "matching identity by certificate"
+                    )
+                }
+
+                return matchingIdentity
             }
         }
 

--- a/Sources/RequestDLInternals/Sources/Client/URLSession Client/Identity/Internals.RawBytesIdentityBuilder.swift
+++ b/Sources/RequestDLInternals/Sources/Client/URLSession Client/Identity/Internals.RawBytesIdentityBuilder.swift
@@ -12,6 +12,7 @@
 import CryptoKit
 import NIOSSL
 import Security
+import _CryptoExtras
 
 #if canImport(FoundationEssentials)
 import FoundationEssentials
@@ -45,7 +46,11 @@ extension Internals {
                         URLSession executor: RSA (PKCS#1 "-----BEGIN RSA PRIVATE KEY-----" or \
                         PKCS#8 "-----BEGIN PRIVATE KEY-----") and EC P-256/P-384/P-521 (SEC1 \
                         "-----BEGIN EC PRIVATE KEY-----" or PKCS#8 \
-                        "-----BEGIN PRIVATE KEY-----").
+                        "-----BEGIN PRIVATE KEY-----"), unencrypted. A password-protected key is \
+                        only supported for traditional PKCS#1 RSA PEM \
+                        ("-----BEGIN RSA PRIVATE KEY-----" with "Proc-Type"/"DEK-Info" headers) -- \
+                        not PKCS#8's "-----BEGIN ENCRYPTED PRIVATE KEY-----", and not any \
+                        password-protected EC key.
                         """
                 case .secKeyCreationFailed(let message):
                     return "SecKeyCreateWithData failed: \(message)."
@@ -98,15 +103,19 @@ extension Internals {
         }
 
         /// Loads the configured private key's raw bytes and, for `.pem`, strips the PEM armor
-        /// down to DER. A password-protected key is rejected outright, since there is no public
-        /// API to export a decrypted key back out to DER once NIOSSL has parsed it.
+        /// down to DER -- or, when a password is set, decrypts it first. Only traditional PKCS#1
+        /// RSA PEM (`-----BEGIN RSA PRIVATE KEY-----` with `Proc-Type`/`DEK-Info` headers) can
+        /// actually be decrypted here, via `_RSA.Signing.PrivateKey(encryptedPEMRepresentation:
+        /// passphraseCallback:)` -- the only encrypted-key entry point anywhere in this package's
+        /// dependency graph. `swift-certificates` has none at all (its own private-key parsing
+        /// only understands unencrypted PKCS#8 `PrivateKeyInfo`, for its own CSR/cert-signing
+        /// needs). PKCS#8's `EncryptedPrivateKeyInfo` and every encrypted EC key (P-256/P-384/
+        /// P-521 -- `Crypto`'s own types have no passphrase-protected PEM import at all) still
+        /// throw `Error/unsupportedKeyFormat(_:)`, same as a `.der`-sourced password-protected key
+        /// (BoringSSL's own decryption call here only takes a PEM string, never raw DER).
         package static func privateKeyDER(from privateKeySource: Internals.PrivateKeySource) throws -> Data {
             switch privateKeySource {
             case .privateKey(let privateKey):
-                guard privateKey.password == nil else {
-                    throw Error.unsupportedKeyFormat("password-protected key")
-                }
-
                 let rawBytes: Data
                 switch privateKey.source {
                 case .bytes(let bytes):
@@ -119,12 +128,44 @@ extension Internals {
                     }
                 }
 
+                if let password = privateKey.password {
+                    guard privateKey.format == .pem else {
+                        throw Error.unsupportedKeyFormat("password-protected key in DER format")
+                    }
+                    return try Self.decryptedRSAPrivateKeyDER(fromEncryptedPEM: rawBytes, password: password)
+                }
+
                 switch privateKey.format {
                 case .der:
                     return rawBytes
                 case .pem:
                     return try Self.privateKeyDER(fromPEM: rawBytes)
                 }
+            }
+        }
+
+        /// Decrypts a password-protected traditional PKCS#1 RSA PEM key via BoringSSL
+        /// (`_RSA.Signing.PrivateKey(encryptedPEMRepresentation:passphraseCallback:)`, from
+        /// `_CryptoExtras`) and returns its plain DER -- ready for `secKey(fromDER:)`'s own
+        /// PKCS#1/PKCS#8 cascade exactly like any other RSA key. Fails closed on anything that
+        /// entry point can't parse: a wrong passphrase, an EC key, or a PKCS#8-encrypted one.
+        private static func decryptedRSAPrivateKeyDER(
+            fromEncryptedPEM pemData: Data,
+            password: NIOSSLSecureBytes
+        ) throws -> Data {
+            guard let pemString = String(data: pemData, encoding: .utf8) else {
+                throw Error.unsupportedKeyFormat("non-UTF8 input")
+            }
+
+            do {
+                let key = try _RSA.Signing.PrivateKey(encryptedPEMRepresentation: pemString) { setPassphrase in
+                    setPassphrase(Array(password))
+                }
+                return key.derRepresentation
+            } catch {
+                throw Error.unsupportedKeyFormat(
+                    "password-protected key that isn't a decryptable traditional PKCS#1 RSA PEM key"
+                )
             }
         }
 

--- a/Sources/RequestDLInternals/Sources/Client/URLSession Client/Identity/Internals.RawBytesIdentityBuilder.swift
+++ b/Sources/RequestDLInternals/Sources/Client/URLSession Client/Identity/Internals.RawBytesIdentityBuilder.swift
@@ -5,7 +5,8 @@
 // Promoted from the URLSession Executor Spike (formerly
 // `Tests/RequestDLTests/URLSession Executor Spike/RawBytesIdentityBuilder.swift`) for
 // request-dl-nio#287. Supports RSA (PKCS#1 or PKCS#8) and EC P-256/P-384/P-521 (SEC1 or
-// PKCS#8) private keys.
+// PKCS#8) private keys, unencrypted -- plus password-protected traditional PKCS#1 RSA PEM
+// keys specifically, decrypted via `_CryptoExtras` (see `privateKeyDER(from:)`).
 
 #if canImport(Darwin)
 

--- a/Sources/RequestDLInternals/Sources/Client/URLSession Client/Identity/Internals.RawBytesIdentityBuilder.swift
+++ b/Sources/RequestDLInternals/Sources/Client/URLSession Client/Identity/Internals.RawBytesIdentityBuilder.swift
@@ -110,7 +110,9 @@ extension Internals {
         /// passphraseCallback:)`, the only encrypted-key entry point anywhere in this package's
         /// dependency graph. `swift-certificates` has none at all (its own private-key parsing
         /// only understands unencrypted PKCS#8 `PrivateKeyInfo`, for its own CSR/cert-signing
-        /// needs). PKCS#8's `EncryptedPrivateKeyInfo` and every encrypted EC key (P-256/P-384/
+        /// needs).
+        ///
+        /// PKCS#8's `EncryptedPrivateKeyInfo` and every encrypted EC key (P-256/P-384/
         /// P-521, since `Crypto`'s own types have no passphrase-protected PEM import at all) still
         /// throw `Error/unsupportedKeyFormat(_:)`, same as a `.der`-sourced password-protected key:
         /// BoringSSL's own decryption call here only takes a PEM string, never raw DER.

--- a/Sources/RequestDLInternals/Sources/Client/URLSession Client/Identity/Internals.RawBytesIdentityBuilder.swift
+++ b/Sources/RequestDLInternals/Sources/Client/URLSession Client/Identity/Internals.RawBytesIdentityBuilder.swift
@@ -10,12 +10,13 @@
 #if canImport(Darwin)
 
 import CryptoKit
+import NIOSSL
 import Security
 
 #if canImport(FoundationEssentials)
 import FoundationEssentials
 #else
-import struct Foundation.Data
+import Foundation
 #endif
 
 extension Internals {
@@ -72,6 +73,59 @@ extension Internals {
         package struct Handle {
             package let identity: SecIdentity
             fileprivate let label: String
+        }
+
+        // MARK: - Identity sources (CertificateChain/PrivateKeySource -> raw DER bytes)
+        //
+        // Shared by every executor that needs a `SecIdentity` built from an
+        // `Internals.SecureConnection`'s `certificateChain`/`privateKey` -- `.urlSession`
+        // (`Internals.URLSessionIdentityPolicy`) and `.nio` under Network.framework
+        // (`Internals.SecureConnection.makeLocalIdentityForNetworkFramework()`) alike.
+
+        /// The leaf certificate (index 0) plus any intermediates, as DER bytes.
+        /// `Internals.CertificateChain.build()` always resolves to `.certificate` sources
+        /// regardless of how it was configured (bytes, file, or pre-built certificates), so this
+        /// never hits its own `preconditionFailure`.
+        package static func certificateDERs(from certificateChain: Internals.CertificateChain) throws -> [Data] {
+            try certificateChain.build().map { source in
+                guard case .certificate(let certificate) = source else {
+                    preconditionFailure(
+                        "Internals.CertificateChain.build() unexpectedly produced a non-certificate source"
+                    )
+                }
+                return Data(try certificate.toDERBytes())
+            }
+        }
+
+        /// Loads the configured private key's raw bytes and, for `.pem`, strips the PEM armor
+        /// down to DER. A password-protected key is rejected outright, since there is no public
+        /// API to export a decrypted key back out to DER once NIOSSL has parsed it.
+        package static func privateKeyDER(from privateKeySource: Internals.PrivateKeySource) throws -> Data {
+            switch privateKeySource {
+            case .privateKey(let privateKey):
+                guard privateKey.password == nil else {
+                    throw Error.unsupportedKeyFormat("password-protected key")
+                }
+
+                let rawBytes: Data
+                switch privateKey.source {
+                case .bytes(let bytes):
+                    rawBytes = Data(bytes)
+                case .file(let file):
+                    do {
+                        rawBytes = try Data(contentsOf: URL(fileURLWithPath: file))
+                    } catch {
+                        throw SecureFileLoadError(resource: .privateKey, path: file, underlying: error)
+                    }
+                }
+
+                switch privateKey.format {
+                case .der:
+                    return rawBytes
+                case .pem:
+                    return try Self.privateKeyDER(fromPEM: rawBytes)
+                }
+            }
         }
 
         // MARK: - Certificate (DER bytes -> SecCertificate, no Keychain involved)

--- a/Sources/RequestDLInternals/Sources/Client/URLSession Client/Identity/Internals.RawBytesIdentityBuilder.swift
+++ b/Sources/RequestDLInternals/Sources/Client/URLSession Client/Identity/Internals.RawBytesIdentityBuilder.swift
@@ -104,16 +104,16 @@ extension Internals {
         }
 
         /// Loads the configured private key's raw bytes and, for `.pem`, strips the PEM armor
-        /// down to DER -- or, when a password is set, decrypts it first. Only traditional PKCS#1
+        /// down to DER, or, when a password is set, decrypts it first. Only traditional PKCS#1
         /// RSA PEM (`-----BEGIN RSA PRIVATE KEY-----` with `Proc-Type`/`DEK-Info` headers) can
         /// actually be decrypted here, via `_RSA.Signing.PrivateKey(encryptedPEMRepresentation:
-        /// passphraseCallback:)` -- the only encrypted-key entry point anywhere in this package's
+        /// passphraseCallback:)`, the only encrypted-key entry point anywhere in this package's
         /// dependency graph. `swift-certificates` has none at all (its own private-key parsing
         /// only understands unencrypted PKCS#8 `PrivateKeyInfo`, for its own CSR/cert-signing
         /// needs). PKCS#8's `EncryptedPrivateKeyInfo` and every encrypted EC key (P-256/P-384/
-        /// P-521 -- `Crypto`'s own types have no passphrase-protected PEM import at all) still
-        /// throw `Error/unsupportedKeyFormat(_:)`, same as a `.der`-sourced password-protected key
-        /// (BoringSSL's own decryption call here only takes a PEM string, never raw DER).
+        /// P-521, since `Crypto`'s own types have no passphrase-protected PEM import at all) still
+        /// throw `Error/unsupportedKeyFormat(_:)`, same as a `.der`-sourced password-protected key:
+        /// BoringSSL's own decryption call here only takes a PEM string, never raw DER.
         package static func privateKeyDER(from privateKeySource: Internals.PrivateKeySource) throws -> Data {
             switch privateKeySource {
             case .privateKey(let privateKey):
@@ -147,7 +147,7 @@ extension Internals {
 
         /// Decrypts a password-protected traditional PKCS#1 RSA PEM key via BoringSSL
         /// (`_RSA.Signing.PrivateKey(encryptedPEMRepresentation:passphraseCallback:)`, from
-        /// `_CryptoExtras`) and returns its plain DER -- ready for `secKey(fromDER:)`'s own
+        /// `_CryptoExtras`) and returns its plain DER, ready for `secKey(fromDER:)`'s own
         /// PKCS#1/PKCS#8 cascade exactly like any other RSA key. Fails closed on anything that
         /// entry point can't parse: a wrong passphrase, an EC key, or a PKCS#8-encrypted one.
         private static func decryptedRSAPrivateKeyDER(
@@ -184,7 +184,7 @@ extension Internals {
         /// Strips PEM armor down to the base64-decoded DER payload, for any of the three headers
         /// this executor recognizes for a private key: PKCS#1 RSA (`RSA PRIVATE KEY`), SEC1 EC
         /// (`EC PRIVATE KEY`), and PKCS#8 (`PRIVATE KEY`, itself wrapping either RSA or EC). Which
-        /// header matched doesn't change what happens next -- ``secKey(fromDER:)`` classifies the
+        /// header matched doesn't change what happens next: ``secKey(fromDER:)`` classifies the
         /// DER content itself, not the PEM label around it.
         package static func privateKeyDER(fromPEM pemData: Data) throws -> Data {
             guard let pemString = String(data: pemData, encoding: .utf8) else {
@@ -220,14 +220,14 @@ extension Internals {
         /// Builds a `SecKey` from DER-encoded private key bytes of unknown shape, trying each
         /// interpretation Security/CryptoKit can actually consume, in order:
         ///
-        /// 1. Bare PKCS#1 (`RSAPrivateKey`) -- what `SecKeyCreateWithData` wants for RSA directly.
-        /// 2. EC, either bare SEC1 (`ECPrivateKey`) or PKCS#8-wrapped -- CryptoKit's DER
+        /// 1. Bare PKCS#1 (`RSAPrivateKey`): what `SecKeyCreateWithData` wants for RSA directly.
+        /// 2. EC, either bare SEC1 (`ECPrivateKey`) or PKCS#8-wrapped. CryptoKit's DER
         ///    initializer accepts both shapes for whichever curve it is (P-256/P-384/P-521 tried
         ///    in that order, since nothing here is told the curve ahead of time), and its
         ///    `x963Representation` (`04 || X || Y || private scalar`) is what `SecKeyCreateWithData`
-        ///    wants for EC -- there is no direct entry point for SEC1/PKCS#8 DER the way there is
+        ///    wants for EC. There is no direct entry point for SEC1/PKCS#8 DER the way there is
         ///    for RSA's PKCS#1.
-        /// 3. PKCS#8-wrapped RSA -- the one shape Security has no direct entry point for at all,
+        /// 3. PKCS#8-wrapped RSA: the one shape Security has no direct entry point for at all,
         ///    so the inner PKCS#1 payload is unwrapped by hand first.
         ///
         /// Anything else (Ed25519, X25519, malformed input, ...) is rejected.
@@ -279,7 +279,7 @@ extension Internals {
         }
 
         /// Tries `der` as a bare SEC1 `ECPrivateKey` or a PKCS#8 envelope wrapping one, one curve
-        /// size at a time -- CryptoKit's DER initializer accepts both shapes for the same call, so
+        /// size at a time. CryptoKit's DER initializer accepts both shapes for the same call, so
         /// there's no need to distinguish them here, and it derives the public point from the
         /// private scalar when SEC1's own (optional) public-key field is absent, which
         /// `SecKeyCreateWithData` has no way to do on its own.
@@ -298,7 +298,7 @@ extension Internals {
 
         /// Unwraps PKCS#8's `PrivateKeyInfo ::= SEQUENCE { version INTEGER, algorithm SEQUENCE,
         /// privateKey OCTET STRING, ... }` down to its `privateKey` field. Doesn't check
-        /// `algorithm`'s OID -- the caller only keeps the result if it goes on to parse as PKCS#1
+        /// `algorithm`'s OID: the caller only keeps the result if it goes on to parse as PKCS#1
         /// RSA, so a PKCS#8-wrapped EC key (already handled by reading the *outer* PKCS#8 bytes
         /// directly in `ecX963Representation(fromDER:)`) or anything else simply fails that
         /// caller's own `SecKeyCreateWithData` check instead of being misidentified here.
@@ -318,7 +318,7 @@ extension Internals {
         /// There is no public API on iOS to pair a certificate and a private key into a
         /// `SecIdentity` purely in memory (`SecIdentityCreateWithCertificate` is macOS-only). The
         /// only public path is a Keychain round-trip: add both items, then query them back
-        /// together as a single `kSecClassIdentity` match -- which is exactly what this does,
+        /// together as a single `kSecClassIdentity` match. That's exactly what this does,
         /// deliberately avoiding the macOS-only shortcut so the result generalizes to iOS/tvOS/
         /// watchOS.
         package static func makeIdentity(
@@ -435,7 +435,7 @@ extension Internals {
         /// Removes both Keychain items an identity built by
         /// ``makeIdentity(certificateDER:privateKeyDER:)`` was built from.
         /// `Internals.URLSessionIdentityPolicy` calls this from `deinit`, once the identity is no
-        /// longer needed -- not after every request.
+        /// longer needed, not after every request.
         package static func remove(_ handle: Handle) {
             #if os(macOS)
             let useDataProtectionKeychain = false
@@ -477,7 +477,7 @@ extension Internals {
             }
         }
 
-        /// Lowercase hex SHA-256 of `data` -- deterministic Keychain item labeling only, not a
+        /// Lowercase hex SHA-256 of `data`, for deterministic Keychain item labeling only, not a
         /// security boundary, so `CryptoKit` (always available on Darwin) is enough; no need for
         /// a constant-time comparison anywhere this is used.
         private static func hexDigest(_ data: Data) -> String {
@@ -489,7 +489,7 @@ extension Internals {
     }
 }
 
-/// Minimal DER TLV (tag-length-value) reader -- only as much as unwrapping a PKCS#8
+/// Minimal DER TLV (tag-length-value) reader, only as much as unwrapping a PKCS#8
 /// `PrivateKeyInfo` envelope needs, not a general-purpose ASN.1 parser. Bounds-checked
 /// throughout: malformed input throws rather than trapping.
 private struct DERReader {
@@ -507,8 +507,8 @@ private struct DERReader {
     }
 
     /// Reads one TLV whose tag must match `tag` and returns its content bytes. Supports both
-    /// short-form and long-form DER lengths -- PKCS#8 envelopes routinely exceed the 127-byte
-    /// short-form limit once a real RSA key is inside.
+    /// short-form and long-form DER lengths, since PKCS#8 envelopes routinely exceed the
+    /// 127-byte short-form limit once a real RSA key is inside.
     mutating func read(tag: UInt8) throws -> [UInt8] {
         guard offset < bytes.count, bytes[offset] == tag else {
             throw MalformedDERError()

--- a/Sources/RequestDLInternals/Sources/Client/URLSession Client/Identity/Internals.RawBytesIdentityBuilder.swift
+++ b/Sources/RequestDLInternals/Sources/Client/URLSession Client/Identity/Internals.RawBytesIdentityBuilder.swift
@@ -324,25 +324,27 @@ extension Internals {
             let secKey = try Self.secKey(fromDER: privateKeyDER)
 
             // Deterministic (content-derived, not random) so that rebuilding an identity for the
-            // same certificate+key -- a repeated test run, an app relaunching with the same
-            // configured client certificate after a previous run's Keychain items never got
-            // cleaned up, or a second `Internals.IdentityHandle` for the same pair sharing this
-            // one -- reliably finds and reuses (or, on a fresh process, clears) its own leftovers
-            // below instead of hitting errSecDuplicateItem. Folds in the private key, not just
-            // the certificate, so two different keys accidentally paired with the same
-            // certificate never collide under one Keychain item. `kSecValueRef`-based matching
-            // (delete "whatever item has this exact key/certificate value") looked like the more
-            // direct way to express that and is what the original spike did, but empirically did
-            // not reliably match an existing item across process runs; label-based matching does.
+            // same certificate+key reliably finds and reuses (or, on a fresh process, clears) its
+            // own leftovers below instead of hitting errSecDuplicateItem. That covers a repeated
+            // test run, an app relaunching with the same configured client certificate after a
+            // previous run's Keychain items never got cleaned up, and a second
+            // `Internals.IdentityHandle` for the same pair sharing this one.
+            //
+            // Folds in the private key, not just the certificate, so two different keys
+            // accidentally paired with the same certificate never collide under one Keychain
+            // item. `kSecValueRef`-based matching (delete "whatever item has this exact
+            // key/certificate value") looked like the more direct way to express that and is what
+            // the original spike did, but empirically did not reliably match an existing item
+            // across process runs; label-based matching does.
             let label = "RequestDL.mtls." + Self.hexDigest(certificateDER) + "." + Self.hexDigest(privateKeyDER)
 
             return try Internals.IdentityManager.shared.handle(for: label) {
                 // `swift test` (and any unsigned command-line process) has no
                 // `keychain-access-groups` entitlement, which the data-protection keychain
-                // requires -- forcing the legacy file-based keychain is a macOS-only
-                // accommodation for that. Not present on iOS/tvOS/watchOS, where there is only
-                // the data-protection keychain and a properly signed/provisioned app already
-                // carries the entitlement it needs.
+                // requires; forcing the legacy file-based keychain is a macOS-only accommodation
+                // for that. Not present on iOS/tvOS/watchOS, where there is only the
+                // data-protection keychain and a properly signed/provisioned app already carries
+                // the entitlement it needs.
                 #if os(macOS)
                 let useDataProtectionKeychain = false
                 #else
@@ -369,7 +371,7 @@ extension Internals {
                         kSecClass: kSecClassKey,
                         kSecValueRef: secKey,
                         kSecAttrLabel: label,
-                        // This device only, not iCloud Keychain -- the key only needs to survive
+                        // This device only, not iCloud Keychain: the key only needs to survive
                         // this process's lifetime, not sync anywhere.
                         kSecAttrAccessible: kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
                         kSecUseDataProtectionKeychain: useDataProtectionKeychain,
@@ -387,7 +389,7 @@ extension Internals {
                     operation: "SecItemAdd(certificate)"
                 )
 
-                // `kSecClassIdentity` queries do not reliably honor `kSecAttrLabel` as a filter --
+                // `kSecClassIdentity` queries do not reliably honor `kSecAttrLabel` as a filter:
                 // an identity is a synthetic pairing of a certificate and a key by matching
                 // public key, not an item with its own attributes, so the label set on the
                 // certificate/key above isn't necessarily inherited by it. Fetching every

--- a/Sources/RequestDLInternals/Sources/Client/URLSession Client/Identity/Internals.ServerTrustPolicy.swift
+++ b/Sources/RequestDLInternals/Sources/Client/URLSession Client/Identity/Internals.ServerTrustPolicy.swift
@@ -122,21 +122,13 @@ extension Internals {
             }
         }
 
-        // MARK: - Private types
-
-        /// One pin, normalized to a same-process matcher regardless of whether it came from a
-        /// live `Internals.SPKIHash` (`resolve(from:)`) or a rebuilt `Descriptor.SPKIPinning.Pin`
-        /// (`init(descriptor:)`) -- `handle(challenge:)` doesn't need to know which.
-        private struct ResolvedSPKIPin: @unchecked Sendable {
-            let matches: @Sendable (Data) -> Bool
-        }
-
         // MARK: - Private properties
 
-        private let trustedRootCertificates: [SecCertificate]
+        /// The trust-root/SPKI pin decision itself, shared with `Internals.NIOTrustEvaluator` --
+        /// this type only owns what's specific to a `URLAuthenticationChallenge`: the `.none`
+        /// bypass, and `Descriptor` persistence for `BackgroundDownloadTask`.
+        private let evaluation: Internals.DarwinTrustEvaluation
         private let certificateVerification: NIOSSL.CertificateVerification
-        private let spkiPins: [ResolvedSPKIPin]
-        private let spkiPinningIsStrict: Bool
         private let spkiPinningDescriptor: Descriptor.SPKIPinning?
 
         // MARK: - Inits
@@ -144,14 +136,16 @@ extension Internals {
         private init(
             trustedRootCertificates: [SecCertificate],
             certificateVerification: NIOSSL.CertificateVerification,
-            spkiPins: [ResolvedSPKIPin],
+            spkiPins: [Internals.ResolvedSPKIPin],
             spkiPinningIsStrict: Bool,
             spkiPinningDescriptor: Descriptor.SPKIPinning?
         ) {
-            self.trustedRootCertificates = trustedRootCertificates
+            self.evaluation = Internals.DarwinTrustEvaluation(
+                trustRootCertificates: trustedRootCertificates,
+                pins: spkiPins,
+                isStrict: spkiPinningIsStrict
+            )
             self.certificateVerification = certificateVerification
-            self.spkiPins = spkiPins
-            self.spkiPinningIsStrict = spkiPinningIsStrict
             self.spkiPinningDescriptor = spkiPinningDescriptor
         }
 
@@ -168,7 +162,7 @@ extension Internals {
                 },
                 certificateVerification: descriptor.verification.nioSSLValue,
                 spkiPins: (descriptor.spkiPinning?.pins ?? []).map { pin in
-                    ResolvedSPKIPin { spkiDERBytes in
+                    Internals.ResolvedSPKIPin { spkiDERBytes in
                         Self.digest(spkiDERBytes, algorithm: pin.algorithm) == pin.digest
                     }
                 },
@@ -185,7 +179,7 @@ extension Internals {
         /// - Throws: ``DescriptorError/unpersistableAlgorithm`` if `resolve(from:)` was given SPKI
         /// pins built with a `Crypto.HashFunction` other than SHA-256/384/512.
         package func descriptor() throws -> Descriptor {
-            if spkiPinningDescriptor == nil, !spkiPins.isEmpty {
+            if spkiPinningDescriptor == nil, !evaluation.pins.isEmpty {
                 // Only reachable via `resolve(from:)`, whose SPKI pins never populated
                 // `spkiPinningDescriptor` because at least one used an unnameable algorithm --
                 // `init(descriptor:)` always sets `spkiPinningDescriptor` when `spkiPins` is
@@ -194,7 +188,7 @@ extension Internals {
             }
 
             return Descriptor(
-                trustedRootCertificatesDER: trustedRootCertificates.map { SecCertificateCopyData($0) as Data },
+                trustedRootCertificatesDER: evaluation.trustRootCertificates.map { SecCertificateCopyData($0) as Data },
                 verification: Descriptor.Verification(certificateVerification),
                 spkiPinning: spkiPinningDescriptor
             )
@@ -236,7 +230,7 @@ extension Internals {
             }
 
             let spkiPins = resolvedPins.map { resolved in
-                ResolvedSPKIPin { spkiDERBytes in
+                Internals.ResolvedSPKIPin { spkiDERBytes in
                     (try? resolved.pin.matchesSPKI(spkiDERBytes)) ?? false
                 }
             }
@@ -290,15 +284,10 @@ extension Internals {
                 return
             }
 
-            if certificateVerification == .noHostnameVerification {
-                let policy = SecPolicyCreateSSL(true, nil)
-                _ = SecTrustSetPolicies(serverTrust, policy as CFTypeRef)
-            }
-
-            if !trustedRootCertificates.isEmpty {
-                _ = SecTrustSetAnchorCertificates(serverTrust, trustedRootCertificates as CFArray)
-                _ = SecTrustSetAnchorCertificatesOnly(serverTrust, true)
-            }
+            evaluation.prepare(
+                serverTrust,
+                skipsHostnameVerification: certificateVerification == .noHostnameVerification
+            )
 
             var evaluationError: CFError?
             let isTrusted = SecTrustEvaluateWithError(serverTrust, &evaluationError)
@@ -308,24 +297,11 @@ extension Internals {
                 return
             }
 
-            guard !spkiPins.isEmpty else {
-                completionHandler(.useCredential, URLCredential(trust: serverTrust))
-                return
-            }
-
-            // Checked against every certificate in the chain, not just the leaf: OWASP's pinning
-            // guidance recommends always deploying a backup pin so rotation doesn't lock clients
-            // out, and the common way to do that is pinning an intermediate CA alongside (or
-            // instead of) the leaf, which rotates far more often.
-            let pinsMatched = Self.chainSPKIDERBytes(of: serverTrust).contains { spkiDERBytes in
-                spkiPins.contains { $0.matches(spkiDERBytes) }
-            }
-
-            if pinsMatched || !spkiPinningIsStrict {
-                // `.audit` behaves exactly like AsyncHTTPClient's own SPKI pinning policy: a
-                // mismatch (or, here, a leaf the SPKI bytes couldn't even be extracted from) is
-                // still accepted, on the assumption this is a deliberate debugging/migration
-                // window rather than production traffic.
+            // `.audit` behaves exactly like AsyncHTTPClient's own former SPKI pinning policy: a
+            // mismatch (or a leaf the SPKI bytes couldn't even be extracted from) is still
+            // accepted, on the assumption this is a deliberate debugging/migration window rather
+            // than production traffic.
+            if evaluation.passes(chain: serverTrust) {
                 completionHandler(.useCredential, URLCredential(trust: serverTrust))
             } else {
                 completionHandler(.cancelAuthenticationChallenge, nil)
@@ -333,26 +309,6 @@ extension Internals {
         }
 
         // MARK: - Private methods
-
-        /// Every certificate's SPKI (SubjectPublicKeyInfo) structure in the chain, DER-encoded --
-        /// what an `Internals.SPKIHash` pin's digest is computed over, checked against leaf and
-        /// intermediates alike. Reuses NIOSSL's own `NIOSSLPublicKey.toSPKIBytes()` on each
-        /// certificate's DER bytes rather than reconstructing the SPKI ASN.1 wrapper from a bare
-        /// `SecKey` export by hand, so a pin configured once produces the identical digest
-        /// regardless of which executor (`URLSession` here, plain NIO/NIOTransportServices
-        /// elsewhere) ends up carrying the connection. Certificates that don't round-trip through
-        /// NIOSSL are dropped rather than failing the whole chain -- not expected in practice for
-        /// a trust that `SecTrustEvaluateWithError` already accepted moments earlier.
-        private static func chainSPKIDERBytes(of trust: SecTrust) -> [Data] {
-            guard let chain = SecTrustCopyCertificateChain(trust) as? [SecCertificate] else {
-                return []
-            }
-
-            return chain.compactMap { certificate in
-                let derBytes = [UInt8](SecCertificateCopyData(certificate) as Data)
-                return (try? NIOSSLCertificate(bytes: derBytes, format: .der))?.spkiDERBytes()
-            }
-        }
 
         private static func digest(_ data: Data, algorithm: Internals.SPKIHash.KnownAlgorithm) -> Data {
             switch algorithm {

--- a/Sources/RequestDLInternals/Sources/Client/URLSession Client/Identity/Internals.ServerTrustPolicy.swift
+++ b/Sources/RequestDLInternals/Sources/Client/URLSession Client/Identity/Internals.ServerTrustPolicy.swift
@@ -164,13 +164,15 @@ extension Internals {
             spkiPins: [Internals.ResolvedSPKIPin],
             spkiPinningIsStrict: Bool,
             spkiPinningDescriptor: Descriptor.SPKIPinning?,
-            revocationPolicy: Internals.RevocationPolicy?
+            revocationPolicy: Internals.RevocationPolicy?,
+            observer: (any TrustDecisionObserver)?
         ) {
             self.evaluation = Internals.DarwinTrustEvaluation(
                 trustRootCertificates: trustedRootCertificates,
                 pins: spkiPins,
                 isStrict: spkiPinningIsStrict,
-                revocationPolicy: revocationPolicy
+                revocationPolicy: revocationPolicy,
+                observer: observer
             )
             self.certificateVerification = certificateVerification
             self.spkiPinningDescriptor = spkiPinningDescriptor
@@ -182,6 +184,9 @@ extension Internals {
         /// else), so this is not expected to happen in practice, and failing the whole challenge
         /// over one bad anchor would be a worse outcome than trusting one fewer root than
         /// intended.
+        ///
+        /// - Note: Never carries a ``TrustDecisionObserver`` -- `Descriptor` is `Codable`-only, and
+        /// an observer is a live object reference with nothing left to reference after a relaunch.
         package convenience init(descriptor: Descriptor) {
             self.init(
                 trustedRootCertificates: descriptor.trustedRootCertificatesDER.compactMap {
@@ -195,7 +200,8 @@ extension Internals {
                 },
                 spkiPinningIsStrict: descriptor.spkiPinning?.policy == .strict,
                 spkiPinningDescriptor: descriptor.spkiPinning,
-                revocationPolicy: descriptor.revocationPolicy?.value
+                revocationPolicy: descriptor.revocationPolicy?.value,
+                observer: nil
             )
         }
 
@@ -287,7 +293,8 @@ extension Internals {
                 spkiPins: spkiPins,
                 spkiPinningIsStrict: isStrict,
                 spkiPinningDescriptor: spkiPinningDescriptor,
-                revocationPolicy: secureConnection.revocationPolicy
+                revocationPolicy: secureConnection.revocationPolicy,
+                observer: secureConnection.trustDecisionObserver
             )
         }
 
@@ -322,16 +329,11 @@ extension Internals {
             var evaluationError: CFError?
             let isTrusted = SecTrustEvaluateWithError(serverTrust, &evaluationError)
 
-            guard isTrusted else {
-                completionHandler(.cancelAuthenticationChallenge, nil)
-                return
-            }
-
             // `.audit` behaves exactly like AsyncHTTPClient's own former SPKI pinning policy: a
             // mismatch (or a leaf the SPKI bytes couldn't even be extracted from) is still
             // accepted, on the assumption this is a deliberate debugging/migration window rather
             // than production traffic.
-            if evaluation.passes(chain: serverTrust) {
+            if evaluation.evaluate(chain: serverTrust, chainIsTrusted: isTrusted) {
                 completionHandler(.useCredential, URLCredential(trust: serverTrust))
             } else {
                 completionHandler(.cancelAuthenticationChallenge, nil)

--- a/Sources/RequestDLInternals/Sources/Client/URLSession Client/Identity/Internals.ServerTrustPolicy.swift
+++ b/Sources/RequestDLInternals/Sources/Client/URLSession Client/Identity/Internals.ServerTrustPolicy.swift
@@ -33,6 +33,7 @@ extension Internals {
             package let trustedRootCertificatesDER: [Data]
             package let verification: Verification
             package let spkiPinning: SPKIPinning?
+            package let revocationPolicy: Revocation?
 
             package enum Verification: String, Codable, Equatable, Sendable {
                 case none
@@ -57,6 +58,28 @@ extension Internals {
                     case .none: return .none
                     case .fullVerification: return .fullVerification
                     case .noHostnameVerification: return .noHostnameVerification
+                    }
+                }
+            }
+
+            /// Mirrors `Internals.RevocationPolicy`'s two cases -- a separate `Codable` enum
+            /// rather than making that type itself `Codable`, the same way `SPKIPinning.Policy`
+            /// mirrors `Internals.SPKIPinningPolicy` instead of reusing it.
+            package enum Revocation: String, Codable, Equatable, Sendable {
+                case strict
+                case disabled
+
+                package init(_ revocationPolicy: Internals.RevocationPolicy) {
+                    switch revocationPolicy {
+                    case .strict: self = .strict
+                    case .disabled: self = .disabled
+                    }
+                }
+
+                package var value: Internals.RevocationPolicy {
+                    switch self {
+                    case .strict: return .strict
+                    case .disabled: return .disabled
                     }
                 }
             }
@@ -96,11 +119,13 @@ extension Internals {
             package init(
                 trustedRootCertificatesDER: [Data],
                 verification: Verification,
-                spkiPinning: SPKIPinning? = nil
+                spkiPinning: SPKIPinning? = nil,
+                revocationPolicy: Revocation? = nil
             ) {
                 self.trustedRootCertificatesDER = trustedRootCertificatesDER
                 self.verification = verification
                 self.spkiPinning = spkiPinning
+                self.revocationPolicy = revocationPolicy
             }
         }
 
@@ -138,12 +163,14 @@ extension Internals {
             certificateVerification: NIOSSL.CertificateVerification,
             spkiPins: [Internals.ResolvedSPKIPin],
             spkiPinningIsStrict: Bool,
-            spkiPinningDescriptor: Descriptor.SPKIPinning?
+            spkiPinningDescriptor: Descriptor.SPKIPinning?,
+            revocationPolicy: Internals.RevocationPolicy?
         ) {
             self.evaluation = Internals.DarwinTrustEvaluation(
                 trustRootCertificates: trustedRootCertificates,
                 pins: spkiPins,
-                isStrict: spkiPinningIsStrict
+                isStrict: spkiPinningIsStrict,
+                revocationPolicy: revocationPolicy
             )
             self.certificateVerification = certificateVerification
             self.spkiPinningDescriptor = spkiPinningDescriptor
@@ -167,7 +194,8 @@ extension Internals {
                     }
                 },
                 spkiPinningIsStrict: descriptor.spkiPinning?.policy == .strict,
-                spkiPinningDescriptor: descriptor.spkiPinning
+                spkiPinningDescriptor: descriptor.spkiPinning,
+                revocationPolicy: descriptor.revocationPolicy?.value
             )
         }
 
@@ -190,7 +218,8 @@ extension Internals {
             return Descriptor(
                 trustedRootCertificatesDER: evaluation.trustRootCertificates.map { SecCertificateCopyData($0) as Data },
                 verification: Descriptor.Verification(certificateVerification),
-                spkiPinning: spkiPinningDescriptor
+                spkiPinning: spkiPinningDescriptor,
+                revocationPolicy: evaluation.revocationPolicy.map(Descriptor.Revocation.init)
             )
         }
 
@@ -257,7 +286,8 @@ extension Internals {
                 certificateVerification: secureConnection.certificateVerification ?? .fullVerification,
                 spkiPins: spkiPins,
                 spkiPinningIsStrict: isStrict,
-                spkiPinningDescriptor: spkiPinningDescriptor
+                spkiPinningDescriptor: spkiPinningDescriptor,
+                revocationPolicy: secureConnection.revocationPolicy
             )
         }
 

--- a/Sources/RequestDLInternals/Sources/Client/URLSession Client/Identity/Internals.ServerTrustPolicy.swift
+++ b/Sources/RequestDLInternals/Sources/Client/URLSession Client/Identity/Internals.ServerTrustPolicy.swift
@@ -212,14 +212,14 @@ extension Internals {
             var trustedRootCertificates: [SecCertificate] = []
 
             if let trustRoots = secureConnection.trustRoots {
-                trustedRootCertificates += try certificates(from: trustRoots).map {
+                trustedRootCertificates += try trustRoots.resolvedCertificates().map {
                     try RawBytesIdentityBuilder.certificate(fromDER: Data($0.toDERBytes()))
                 }
             }
 
             if let additionalTrustRoots = secureConnection.additionalTrustRoots {
                 for additionalTrustRoot in additionalTrustRoots {
-                    trustedRootCertificates += try certificates(from: additionalTrustRoot).map {
+                    trustedRootCertificates += try additionalTrustRoot.resolvedCertificates().map {
                         try RawBytesIdentityBuilder.certificate(fromDER: Data($0.toDERBytes()))
                     }
                 }
@@ -313,10 +313,13 @@ extension Internals {
                 return
             }
 
-            let pinsMatched =
-                Self.leafSPKIDERBytes(of: serverTrust).map { leafSPKIDERBytes in
-                    spkiPins.contains { $0.matches(leafSPKIDERBytes) }
-                } ?? false
+            // Checked against every certificate in the chain, not just the leaf: OWASP's pinning
+            // guidance recommends always deploying a backup pin so rotation doesn't lock clients
+            // out, and the common way to do that is pinning an intermediate CA alongside (or
+            // instead of) the leaf, which rotates far more often.
+            let pinsMatched = Self.chainSPKIDERBytes(of: serverTrust).contains { spkiDERBytes in
+                spkiPins.contains { $0.matches(spkiDERBytes) }
+            }
 
             if pinsMatched || !spkiPinningIsStrict {
                 // `.audit` behaves exactly like AsyncHTTPClient's own SPKI pinning policy: a
@@ -331,35 +334,24 @@ extension Internals {
 
         // MARK: - Private methods
 
-        /// The leaf certificate's SPKI (SubjectPublicKeyInfo) structure, DER-encoded -- what an
-        /// `Internals.SPKIHash` pin's digest is computed over. Reuses NIOSSL's own
-        /// `NIOSSLPublicKey.toSPKIBytes()` on the leaf's DER bytes rather than reconstructing the
-        /// SPKI ASN.1 wrapper from a bare `SecKey` export by hand, so a pin configured once
-        /// produces the identical digest regardless of which executor (`URLSession` here, plain
-        /// NIO/NIOTransportServices elsewhere) ends up carrying the connection. `nil` on any
-        /// failure along the way (no certificates in the trust, DER that doesn't round-trip
-        /// through NIOSSL, a public key NIOSSL can't export) -- treated the same as "pin
-        /// mismatch" by the caller, since none of these are expected to happen for a trust that
-        /// `SecTrustEvaluateWithError` already accepted moments earlier.
-        private static func leafSPKIDERBytes(of trust: SecTrust) -> Data? {
-            guard
-                let chain = SecTrustCopyCertificateChain(trust) as? [SecCertificate],
-                let leaf = chain.first
-            else {
-                return nil
+        /// Every certificate's SPKI (SubjectPublicKeyInfo) structure in the chain, DER-encoded --
+        /// what an `Internals.SPKIHash` pin's digest is computed over, checked against leaf and
+        /// intermediates alike. Reuses NIOSSL's own `NIOSSLPublicKey.toSPKIBytes()` on each
+        /// certificate's DER bytes rather than reconstructing the SPKI ASN.1 wrapper from a bare
+        /// `SecKey` export by hand, so a pin configured once produces the identical digest
+        /// regardless of which executor (`URLSession` here, plain NIO/NIOTransportServices
+        /// elsewhere) ends up carrying the connection. Certificates that don't round-trip through
+        /// NIOSSL are dropped rather than failing the whole chain -- not expected in practice for
+        /// a trust that `SecTrustEvaluateWithError` already accepted moments earlier.
+        private static func chainSPKIDERBytes(of trust: SecTrust) -> [Data] {
+            guard let chain = SecTrustCopyCertificateChain(trust) as? [SecCertificate] else {
+                return []
             }
 
-            let derBytes = [UInt8](SecCertificateCopyData(leaf) as Data)
-
-            guard
-                let certificate = try? NIOSSLCertificate(bytes: derBytes, format: .der),
-                let publicKey = try? certificate.extractPublicKey(),
-                let spkiBytes = try? publicKey.toSPKIBytes()
-            else {
-                return nil
+            return chain.compactMap { certificate in
+                let derBytes = [UInt8](SecCertificateCopyData(certificate) as Data)
+                return (try? NIOSSLCertificate(bytes: derBytes, format: .der))?.spkiDERBytes()
             }
-
-            return Data(spkiBytes)
         }
 
         private static func digest(_ data: Data, algorithm: Internals.SPKIHash.KnownAlgorithm) -> Data {
@@ -370,29 +362,6 @@ extension Internals {
             }
         }
 
-        private static func certificates(from trustRoots: Internals.TrustRoots) throws -> [NIOSSLCertificate] {
-            switch trustRoots {
-            case .file(let file):
-                return try Internals.Certificate(file, format: .pem).build()
-            case .bytes(let bytes):
-                return try Internals.Certificate(bytes, format: .pem).build()
-            case .certificates(let certificates):
-                return try certificates.flatMap { try $0.build() }
-            }
-        }
-
-        private static func certificates(
-            from additionalTrustRoots: Internals.AdditionalTrustRoots
-        ) throws -> [NIOSSLCertificate] {
-            switch additionalTrustRoots {
-            case .file(let file):
-                return try Internals.Certificate(file, format: .pem).build()
-            case .bytes(let bytes):
-                return try Internals.Certificate(bytes, format: .pem).build()
-            case .certificates(let certificates):
-                return try certificates.flatMap { try $0.build() }
-            }
-        }
     }
 }
 

--- a/Sources/RequestDLInternals/Sources/Client/URLSession Client/Identity/Internals.ServerTrustPolicy.swift
+++ b/Sources/RequestDLInternals/Sources/Client/URLSession Client/Identity/Internals.ServerTrustPolicy.swift
@@ -24,7 +24,7 @@ extension Internals {
 
     package final class ServerTrustPolicy: @unchecked Sendable {
 
-        /// A `Codable`, `NIOSSL`-free snapshot of one `ServerTrustPolicy` -- what actually
+        /// A `Codable`, `NIOSSL`-free snapshot of one `ServerTrustPolicy`: what actually
         /// survives a relaunch. Certificates are carried as raw DER bytes rather than file paths,
         /// since the original source (`.bytes` or `.file`) has already been resolved once by the
         /// time this is built, and a persisted path could stop pointing at the same content (or
@@ -62,7 +62,7 @@ extension Internals {
                 }
             }
 
-            /// Mirrors `Internals.RevocationPolicy`'s two cases -- a separate `Codable` enum
+            /// Mirrors `Internals.RevocationPolicy`'s two cases: a separate `Codable` enum
             /// rather than making that type itself `Codable`, the same way `SPKIPinning.Policy`
             /// mirrors `Internals.SPKIPinningPolicy` instead of reusing it.
             package enum Revocation: String, Codable, Equatable, Sendable {
@@ -84,12 +84,12 @@ extension Internals {
                 }
             }
 
-            /// SPKI pinning, captured as raw digests rather than `Internals.SPKIHash` -- the
+            /// SPKI pinning, captured as raw digests rather than `Internals.SPKIHash`, since the
             /// latter type-erases its hash algorithm into a closure that can't survive `Codable`
             /// encoding. `algorithm` is restricted to the three named ones
             /// (`Internals.SPKIHash.KnownAlgorithm`) precisely so a `Descriptor` can recompute the
             /// matching digest of a peer's SPKI bytes after a relaunch with no
-            /// `Internals.SecureConnection` in hand -- see ``ServerTrustPolicy/resolve(from:)``,
+            /// `Internals.SecureConnection` in hand. See ``ServerTrustPolicy/resolve(from:)``,
             /// which throws rather than silently dropping a pin it can't capture this way.
             package struct SPKIPinning: Codable, Equatable, Sendable {
                 package let pins: [Pin]
@@ -130,7 +130,7 @@ extension Internals {
         }
 
         /// Thrown by ``descriptor`` when a configured SPKI pin can't be captured into a
-        /// `Descriptor` -- only ever `.unpersistableAlgorithm`, for a pin built with a
+        /// `Descriptor`. Only ever `.unpersistableAlgorithm`, for a pin built with a
         /// `Crypto.HashFunction` other than SHA-256/384/512
         /// (`Internals.SPKIHash.KnownAlgorithm`'s three cases). Live, in-process pinning still
         /// works fine with any such algorithm; only surviving a `BackgroundDownloadTask` relaunch
@@ -149,8 +149,8 @@ extension Internals {
 
         // MARK: - Private properties
 
-        /// The trust-root/SPKI pin decision itself, shared with `Internals.NIOTrustEvaluator` --
-        /// this type only owns what's specific to a `URLAuthenticationChallenge`: the `.none`
+        /// The trust-root/SPKI pin decision itself, shared with `Internals.NIOTrustEvaluator`.
+        /// This type only owns what's specific to a `URLAuthenticationChallenge`: the `.none`
         /// bypass, and `Descriptor` persistence for `BackgroundDownloadTask`.
         private let evaluation: Internals.DarwinTrustEvaluation
         private let certificateVerification: NIOSSL.CertificateVerification
@@ -179,13 +179,13 @@ extension Internals {
         }
 
         /// Rebuilds a policy from a previously captured ``descriptor``. A certificate that fails
-        /// to parse back out of its own DER bytes is dropped silently rather than thrown -- it
+        /// to parse back out of its own DER bytes is dropped silently rather than thrown; it
         /// was already valid DER when captured (`SecCertificateCopyData` never produces anything
         /// else), so this is not expected to happen in practice, and failing the whole challenge
         /// over one bad anchor would be a worse outcome than trusting one fewer root than
         /// intended.
         ///
-        /// - Note: Never carries a ``TrustDecisionObserver`` -- `Descriptor` is `Codable`-only, and
+        /// - Note: Never carries a ``TrustDecisionObserver``. `Descriptor` is `Codable`-only, and
         /// an observer is a live object reference with nothing left to reference after a relaunch.
         package convenience init(descriptor: Descriptor) {
             self.init(
@@ -207,7 +207,7 @@ extension Internals {
 
         // MARK: - Internal properties
 
-        /// The `Codable` snapshot of this exact policy -- everything ``init(descriptor:)`` needs
+        /// The `Codable` snapshot of this exact policy: everything ``init(descriptor:)`` needs
         /// to rebuild an equivalent one later, with no `Internals.SecureConnection` in hand.
         ///
         /// - Throws: ``DescriptorError/unpersistableAlgorithm`` if `resolve(from:)` was given SPKI
@@ -231,7 +231,7 @@ extension Internals {
 
         // MARK: - Internal methods
 
-        /// Resolves trust roots and SPKI pinning straight from a `SecureConnection` -- the same
+        /// Resolves trust roots and SPKI pinning straight from a `SecureConnection`, the same
         /// `Internals.TrustRoots`/`Internals.AdditionalTrustRoots` parsing
         /// `Internals.URLSessionIdentityPolicy` uses for its own server-trust half, shared rather
         /// than duplicated between the two. Every pin's digest is resolved eagerly (base64
@@ -299,7 +299,7 @@ extension Internals {
         }
 
         /// Answers a server-trust challenge. Anything else (client-certificate, or any other
-        /// authentication method) defers to the system's default handling -- this type only ever
+        /// authentication method) defers to the system's default handling; this type only ever
         /// speaks to the server side of a handshake.
         package func handle(
             challenge: URLAuthenticationChallenge,

--- a/Sources/RequestDLInternals/Sources/Client/URLSession Client/Identity/Internals.URLSessionIdentityPolicy.swift
+++ b/Sources/RequestDLInternals/Sources/Client/URLSession Client/Identity/Internals.URLSessionIdentityPolicy.swift
@@ -26,12 +26,14 @@ extension Internals {
     /// that half is needed.
     ///
     /// Built once per `SecureConnection` and held for as long as the owning
-    /// `Internals.URLSessionClient` is alive -- mirrors NIOSSL's own per-connection
-    /// `TLSConfiguration` caching in `Internals.ClientManager`. The Keychain items backing the
-    /// client identity, if any, are released through `identityHandle`'s own `deinit`, not after
-    /// every request -- and only actually deleted once every other live `Internals.IdentityHandle`
-    /// for that same certificate/key pair (e.g. another `URLSessionIdentityPolicy` instance
-    /// configured with the same mTLS identity) has gone away too. See `Internals.IdentityManager`.
+    /// `Internals.URLSessionClient` is alive, mirroring NIOSSL's own per-connection
+    /// `TLSConfiguration` caching in `Internals.ClientManager`.
+    ///
+    /// The Keychain items backing the client identity, if any, are released through
+    /// `identityHandle`'s own `deinit`, not after every request, and only actually deleted once
+    /// every other live `Internals.IdentityHandle` for that same certificate/key pair (e.g.
+    /// another `URLSessionIdentityPolicy` instance configured with the same mTLS identity) has
+    /// gone away too. See `Internals.IdentityManager`.
     package final class URLSessionIdentityPolicy: @unchecked Sendable {
 
         package enum ConfigurationError: Swift.Error, CustomStringConvertible, Sendable {

--- a/Sources/RequestDLInternals/Sources/Client/URLSession Client/Identity/Internals.URLSessionIdentityPolicy.swift
+++ b/Sources/RequestDLInternals/Sources/Client/URLSession Client/Identity/Internals.URLSessionIdentityPolicy.swift
@@ -61,13 +61,13 @@ extension Internals {
                 intermediateCertificates = []
 
             case (.some(let certificateChain), .some(let privateKey)):
-                let derCertificates = try Self.derCertificates(from: certificateChain)
+                let derCertificates = try RawBytesIdentityBuilder.certificateDERs(from: certificateChain)
 
                 guard let leaf = derCertificates.first else {
                     throw ConfigurationError.emptyCertificateChain
                 }
 
-                let privateKeyDER = try Self.privateKeyDER(from: privateKey)
+                let privateKeyDER = try RawBytesIdentityBuilder.privateKeyDER(from: privateKey)
 
                 identityHandle = try RawBytesIdentityBuilder.makeIdentity(
                     certificateDER: leaf,
@@ -119,58 +119,6 @@ extension Internals {
             )
         }
 
-        // MARK: - Private methods
-
-        /// The leaf certificate (index 0) plus any intermediates, as DER bytes -- reuses NIOSSL's
-        /// own PEM/DER + file/bytes parsing (`Internals.CertificateChain.build()`) rather than
-        /// re-implementing it, since `CertificateChain.build()` always resolves to
-        /// `.certificate(NIOSSLCertificate)` sources regardless of how it was configured.
-        private static func derCertificates(from certificateChain: Internals.CertificateChain) throws -> [Data] {
-            try certificateChain.build().map { source in
-                guard case .certificate(let certificate) = source else {
-                    // `Internals.CertificateChain.build()` always resolves to `.certificate`
-                    // sources -- every branch loads the certificate(s) up front rather than
-                    // deferring to NIOSSL via the (deprecated) `.file` source case.
-                    preconditionFailure(
-                        "Internals.CertificateChain.build() unexpectedly produced a non-certificate source"
-                    )
-                }
-                return Data(try certificate.toDERBytes())
-            }
-        }
-
-        /// Loads the configured private key's raw bytes and, for `.pem`, strips the PEM armor
-        /// down to DER -- `RawBytesIdentityBuilder.secKey(fromDER:)` does the actual format
-        /// classification (RSA/EC, PKCS#1/PKCS#8/SEC1) once real DER bytes are in hand either
-        /// way. A password-protected key is rejected outright, since there is no public API to
-        /// export a decrypted key back out to DER once NIOSSL has parsed it.
-        private static func privateKeyDER(from privateKeySource: Internals.PrivateKeySource) throws -> Data {
-            switch privateKeySource {
-            case .privateKey(let privateKey):
-                guard privateKey.password == nil else {
-                    throw RawBytesIdentityBuilder.Error.unsupportedKeyFormat("password-protected key")
-                }
-
-                let rawBytes: Data
-                switch privateKey.source {
-                case .bytes(let bytes):
-                    rawBytes = Data(bytes)
-                case .file(let file):
-                    do {
-                        rawBytes = try Data(contentsOf: URL(fileURLWithPath: file))
-                    } catch {
-                        throw SecureFileLoadError(resource: .privateKey, path: file, underlying: error)
-                    }
-                }
-
-                switch privateKey.format {
-                case .der:
-                    return rawBytes
-                case .pem:
-                    return try RawBytesIdentityBuilder.privateKeyDER(fromPEM: rawBytes)
-                }
-            }
-        }
     }
 }
 

--- a/Sources/RequestDLInternals/Sources/Client/URLSession Client/Identity/Internals.URLSessionIdentityPolicy.swift
+++ b/Sources/RequestDLInternals/Sources/Client/URLSession Client/Identity/Internals.URLSessionIdentityPolicy.swift
@@ -28,7 +28,10 @@ extension Internals {
     /// Built once per `SecureConnection` and held for as long as the owning
     /// `Internals.URLSessionClient` is alive -- mirrors NIOSSL's own per-connection
     /// `TLSConfiguration` caching in `Internals.ClientManager`. The Keychain items backing the
-    /// client identity, if any, are removed in `deinit`, not after every request.
+    /// client identity, if any, are released through `identityHandle`'s own `deinit`, not after
+    /// every request -- and only actually deleted once every other live `Internals.IdentityHandle`
+    /// for that same certificate/key pair (e.g. another `URLSessionIdentityPolicy` instance
+    /// configured with the same mTLS identity) has gone away too. See `Internals.IdentityManager`.
     package final class URLSessionIdentityPolicy: @unchecked Sendable {
 
         package enum ConfigurationError: Swift.Error, CustomStringConvertible, Sendable {
@@ -48,7 +51,7 @@ extension Internals {
 
         // MARK: - Private properties
 
-        private let identityHandle: Internals.RawBytesIdentityBuilder.Handle?
+        private let identityHandle: Internals.IdentityHandle?
         private let intermediateCertificates: [SecCertificate]
         private let serverTrustPolicy: Internals.ServerTrustPolicy
 
@@ -82,12 +85,6 @@ extension Internals {
             }
 
             self.serverTrustPolicy = try Internals.ServerTrustPolicy.resolve(from: secureConnection)
-        }
-
-        deinit {
-            if let identityHandle {
-                RawBytesIdentityBuilder.remove(identityHandle)
-            }
         }
 
         // MARK: - Internal methods

--- a/Sources/RequestDLInternals/Sources/Secure Connection/Additional Trust Roots/Internals.AdditionalTrustRoots.swift
+++ b/Sources/RequestDLInternals/Sources/Secure Connection/Additional Trust Roots/Internals.AdditionalTrustRoots.swift
@@ -48,7 +48,7 @@ extension Internals {
             }
         }
 
-        /// The flat list of `NIOSSLCertificate`s this configuration resolves to -- what a trust
+        /// The flat list of `NIOSSLCertificate`s this configuration resolves to: what a trust
         /// evaluator needs to set as anchors, as opposed to `build()`'s `NIOSSLAdditionalTrustRoots`,
         /// which stays a `.file` reference rather than reading it eagerly.
         package func resolvedCertificates() throws -> [NIOSSLCertificate] {

--- a/Sources/RequestDLInternals/Sources/Secure Connection/Additional Trust Roots/Internals.AdditionalTrustRoots.swift
+++ b/Sources/RequestDLInternals/Sources/Secure Connection/Additional Trust Roots/Internals.AdditionalTrustRoots.swift
@@ -47,5 +47,19 @@ extension Internals {
                 )
             }
         }
+
+        /// The flat list of `NIOSSLCertificate`s this configuration resolves to -- what a trust
+        /// evaluator needs to set as anchors, as opposed to `build()`'s `NIOSSLAdditionalTrustRoots`,
+        /// which stays a `.file` reference rather than reading it eagerly.
+        package func resolvedCertificates() throws -> [NIOSSLCertificate] {
+            switch self {
+            case .file(let file):
+                return try Internals.Certificate(file, format: .pem).build()
+            case .bytes(let bytes):
+                return try Internals.Certificate(bytes, format: .pem).build()
+            case .certificates(let certificates):
+                return try certificates.flatMap { try $0.build() }
+            }
+        }
     }
 }

--- a/Sources/RequestDLInternals/Sources/Secure Connection/SPKI Pinning/Internals.SPKIHash.swift
+++ b/Sources/RequestDLInternals/Sources/Secure Connection/SPKI Pinning/Internals.SPKIHash.swift
@@ -13,8 +13,7 @@ import struct Foundation.Data
 extension Internals {
 
     /// Thrown by `SPKIHash.resolvedDigest()` when the configured source doesn't decode to a
-    /// digest of the length `Algorithm.Digest.byteCount` expects -- same validation
-    /// `AsyncHTTPClient.SPKIHash` used to perform before this type stopped borrowing it.
+    /// digest of the length `Algorithm.Digest.byteCount` expects.
     package struct SPKIHashError: Swift.Error, CustomStringConvertible, Sendable {
         package var description: String {
             "Invalid SPKI hash: the configured digest is not valid base64, or its length doesn't match the hash algorithm's digest size."

--- a/Sources/RequestDLInternals/Sources/Secure Connection/SPKI Pinning/Internals.SPKIHash.swift
+++ b/Sources/RequestDLInternals/Sources/Secure Connection/SPKI Pinning/Internals.SPKIHash.swift
@@ -2,7 +2,6 @@
 // See LICENSE for this package's licensing information.
 //
 
-import AsyncHTTPClient
 import Crypto
 
 #if canImport(FoundationEssentials)
@@ -12,6 +11,17 @@ import struct Foundation.Data
 #endif
 
 extension Internals {
+
+    /// Thrown by `SPKIHash.resolvedDigest()` when the configured source doesn't decode to a
+    /// digest of the length `Algorithm.Digest.byteCount` expects -- same validation
+    /// `AsyncHTTPClient.SPKIHash` used to perform before this type stopped borrowing it.
+    package struct SPKIHashError: Swift.Error, CustomStringConvertible, Sendable {
+        package var description: String {
+            "Invalid SPKI hash: the configured digest is not valid base64, or its length doesn't match the hash algorithm's digest size."
+        }
+
+        package init() {}
+    }
 
     package struct SPKIHash: Sendable, Hashable {
 
@@ -31,7 +41,8 @@ extension Internals {
         private let source: SPKIHashSource
 
         private let algorithmID: ObjectIdentifier
-        private let producer: @Sendable (SPKIHashSource) throws -> AsyncHTTPClient.SPKIHash
+        private let digestByteCount: Int
+        private let producer: @Sendable (SPKIHashSource) throws -> Data
         private let digest: @Sendable (Data) -> Data
 
         package let knownAlgorithm: KnownAlgorithm?
@@ -42,8 +53,24 @@ extension Internals {
         ) {
             self.source = source
             self.algorithmID = .init(algorithm)
-            self.producer = {
-                try AsyncHTTPClient.SPKIHash(algorithm: algorithm, source: $0)
+            self.digestByteCount = Algorithm.Digest.byteCount
+            self.producer = { source in
+                let bytes: Data
+                switch source {
+                case .base64String(let base64):
+                    guard let decoded = Data(base64Encoded: base64) else {
+                        throw SPKIHashError()
+                    }
+                    bytes = decoded
+                case .rawData(let raw):
+                    bytes = raw
+                }
+
+                guard bytes.count == Algorithm.Digest.byteCount else {
+                    throw SPKIHashError()
+                }
+
+                return bytes
             }
             self.digest = { Data(algorithm.hash(data: $0)) }
 
@@ -60,15 +87,10 @@ extension Internals {
                 && lhs.algorithmID == rhs.algorithmID
         }
 
-        package func resolve(_ tlsPins: inout [AsyncHTTPClient.SPKIHash]) throws {
-            let hash = try producer(source)
-            tlsPins.append(hash)
-        }
-
         /// The digest this pin expects the peer's SPKI to hash to -- what `ServerTrustPolicy`
         /// compares against, and what a `Descriptor` persists for `knownAlgorithm != nil` pins.
         package func resolvedDigest() throws -> Data {
-            try producer(source).bytes
+            try producer(source)
         }
 
         /// Whether `spkiDERBytes` (the SPKI structure `NIOSSLPublicKey.toSPKIBytes()` produces for
@@ -102,20 +124,5 @@ extension Internals {
     package enum SPKIHashSource: Sendable, Hashable {
         case base64String(String)
         case rawData(Data)
-    }
-}
-
-extension AsyncHTTPClient.SPKIHash {
-
-    fileprivate init<Algorithm: HashFunction>(
-        algorithm: Algorithm.Type,
-        source: Internals.SPKIHashSource
-    ) throws {
-        switch source {
-        case .base64String(let base64):
-            try self.init(algorithm: algorithm, base64: base64)
-        case .rawData(let bytes):
-            try self.init(algorithm: algorithm, bytes: bytes)
-        }
     }
 }

--- a/Sources/RequestDLInternals/Sources/Secure Connection/SPKI Pinning/Internals.SPKIPinningPolicy.swift
+++ b/Sources/RequestDLInternals/Sources/Secure Connection/SPKI Pinning/Internals.SPKIPinningPolicy.swift
@@ -4,7 +4,7 @@
 
 extension Internals {
 
-    /// Failure behavior for an SPKI pin mismatch -- `RequestDL`'s own definition, since
+    /// Failure behavior for an SPKI pin mismatch. `RequestDL`'s own definition, since
     /// AsyncHTTPClient no longer bundles a pinning policy for this package to borrow. Trust
     /// evaluation, including SPKI pinning, is `RequestDL`'s own responsibility, resolved through
     /// `Internals.ServerTrustPolicy`/`Internals.NIOTrustEvaluator`.

--- a/Sources/RequestDLInternals/Sources/Secure Connection/SPKI Pinning/Internals.SPKIPinningPolicy.swift
+++ b/Sources/RequestDLInternals/Sources/Secure Connection/SPKI Pinning/Internals.SPKIPinningPolicy.swift
@@ -1,0 +1,18 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+extension Internals {
+
+    /// Failure behavior for an SPKI pin mismatch -- `RequestDL`'s own definition, since
+    /// AsyncHTTPClient no longer bundles a pinning policy for this package to borrow (trust
+    /// evaluation, including SPKI pinning, is `RequestDL`'s own responsibility now, resolved
+    /// through `Internals.ServerTrustPolicy`/`Internals.NIOTrustEvaluator`).
+    package enum SPKIPinningPolicy: String, Sendable, Hashable {
+        /// Terminate the connection immediately on a pin mismatch.
+        case strict
+
+        /// Permit the connection on a pin mismatch, for observability only.
+        case audit
+    }
+}

--- a/Sources/RequestDLInternals/Sources/Secure Connection/SPKI Pinning/Internals.SPKIPinningPolicy.swift
+++ b/Sources/RequestDLInternals/Sources/Secure Connection/SPKI Pinning/Internals.SPKIPinningPolicy.swift
@@ -5,9 +5,9 @@
 extension Internals {
 
     /// Failure behavior for an SPKI pin mismatch -- `RequestDL`'s own definition, since
-    /// AsyncHTTPClient no longer bundles a pinning policy for this package to borrow (trust
-    /// evaluation, including SPKI pinning, is `RequestDL`'s own responsibility now, resolved
-    /// through `Internals.ServerTrustPolicy`/`Internals.NIOTrustEvaluator`).
+    /// AsyncHTTPClient no longer bundles a pinning policy for this package to borrow. Trust
+    /// evaluation, including SPKI pinning, is `RequestDL`'s own responsibility, resolved through
+    /// `Internals.ServerTrustPolicy`/`Internals.NIOTrustEvaluator`.
     package enum SPKIPinningPolicy: String, Sendable, Hashable {
         /// Terminate the connection immediately on a pin mismatch.
         case strict

--- a/Sources/RequestDLInternals/Sources/Secure Connection/SPKI Pinning/NIOSSLCertificate+SPKI.swift
+++ b/Sources/RequestDLInternals/Sources/Secure Connection/SPKI Pinning/NIOSSLCertificate+SPKI.swift
@@ -1,0 +1,28 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+import NIOSSL
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import struct Foundation.Data
+#endif
+
+extension NIOSSLCertificate {
+
+    /// The DER-encoded SubjectPublicKeyInfo structure of this certificate's public key -- what an
+    /// `Internals.SPKIHash` pin's digest is computed over. `nil` if the public key can't be
+    /// extracted or exported, which isn't expected for a certificate NIOSSL has already parsed.
+    package func spkiDERBytes() -> Data? {
+        guard
+            let publicKey = try? extractPublicKey(),
+            let spkiBytes = try? publicKey.toSPKIBytes()
+        else {
+            return nil
+        }
+
+        return Data(spkiBytes)
+    }
+}

--- a/Sources/RequestDLInternals/Sources/Secure Connection/SPKI Pinning/NIOSSLCertificate+SPKI.swift
+++ b/Sources/RequestDLInternals/Sources/Secure Connection/SPKI Pinning/NIOSSLCertificate+SPKI.swift
@@ -12,7 +12,7 @@ import struct Foundation.Data
 
 extension NIOSSLCertificate {
 
-    /// The DER-encoded SubjectPublicKeyInfo structure of this certificate's public key -- what an
+    /// The DER-encoded SubjectPublicKeyInfo structure of this certificate's public key: what an
     /// `Internals.SPKIHash` pin's digest is computed over. `nil` if the public key can't be
     /// extracted or exported, which isn't expected for a certificate NIOSSL has already parsed.
     package func spkiDERBytes() -> Data? {

--- a/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.DarwinTrustEvaluation.swift
+++ b/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.DarwinTrustEvaluation.swift
@@ -40,8 +40,8 @@ extension Internals {
 
     /// Shared, `SecTrust`-based trust-root + SPKI pin logic. `prepare(_:skipsHostnameVerification:)`
     /// must run before the caller's own `SecTrustEvaluate(WithError|AsyncWithError)` call;
-    /// `passes(chain:)` is the accept/reject decision once that call already reported the chain
-    /// itself as trusted.
+    /// `evaluate(chain:chainIsTrusted:)` is the accept/reject decision, folding in that call's own
+    /// chain-validity result.
     package struct DarwinTrustEvaluation: Sendable {
 
         // MARK: - Internal properties
@@ -50,6 +50,7 @@ extension Internals {
         package let pins: [ResolvedSPKIPin]
         package let isStrict: Bool
         package let revocationPolicy: Internals.RevocationPolicy?
+        package let observer: (any TrustDecisionObserver)?
 
         // MARK: - Inits
 
@@ -57,12 +58,14 @@ extension Internals {
             trustRootCertificates: [SecCertificate],
             pins: [ResolvedSPKIPin],
             isStrict: Bool,
-            revocationPolicy: Internals.RevocationPolicy? = nil
+            revocationPolicy: Internals.RevocationPolicy? = nil,
+            observer: (any TrustDecisionObserver)? = nil
         ) {
             self.trustRootCertificates = trustRootCertificates
             self.pins = pins
             self.isStrict = isStrict
             self.revocationPolicy = revocationPolicy
+            self.observer = observer
         }
 
         // MARK: - Internal methods
@@ -113,14 +116,23 @@ extension Internals {
             }
         }
 
+        /// The accept/reject decision, given `chainIsTrusted` -- the caller's own
+        /// `SecTrustEvaluate(WithError|AsyncWithError)` result for `trust`. Notifies `observer`,
+        /// when configured, with the outcome either way, before returning it.
+        ///
         /// `pins.isEmpty` means nothing is configured to pin against -- chain validity by itself
-        /// (already confirmed by the caller's own `SecTrustEvaluate...` call before this runs) is
-        /// the whole check then. Otherwise every certificate in `trust`'s chain is checked, leaf
+        /// is the whole check then. Otherwise every certificate in `trust`'s chain is checked, leaf
         /// and intermediates alike -- OWASP's recommended backup-pin practice, pinning an
         /// intermediate CA (which rotates far less often than the leaf) alongside or instead of it
         /// -- and a mismatch only rejects under `isStrict`.
-        package func passes(chain trust: SecTrust) -> Bool {
+        package func evaluate(chain trust: SecTrust, chainIsTrusted: Bool) -> Bool {
+            guard chainIsTrusted else {
+                observer?(TrustDecision(isTrusted: false, pinsMatched: nil))
+                return false
+            }
+
             guard !pins.isEmpty else {
+                observer?(TrustDecision(isTrusted: true, pinsMatched: nil))
                 return true
             }
 
@@ -128,7 +140,9 @@ extension Internals {
                 pins.contains { $0.matches(spkiDERBytes) }
             }
 
-            return matched || !isStrict
+            let accepted = matched || !isStrict
+            observer?(TrustDecision(isTrusted: accepted, pinsMatched: matched))
+            return accepted
         }
 
         // MARK: - Private methods

--- a/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.DarwinTrustEvaluation.swift
+++ b/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.DarwinTrustEvaluation.swift
@@ -49,30 +49,62 @@ extension Internals {
         package let trustRootCertificates: [SecCertificate]
         package let pins: [ResolvedSPKIPin]
         package let isStrict: Bool
+        package let revocationPolicy: Internals.RevocationPolicy?
 
         // MARK: - Inits
 
-        package init(trustRootCertificates: [SecCertificate], pins: [ResolvedSPKIPin], isStrict: Bool) {
+        package init(
+            trustRootCertificates: [SecCertificate],
+            pins: [ResolvedSPKIPin],
+            isStrict: Bool,
+            revocationPolicy: Internals.RevocationPolicy? = nil
+        ) {
             self.trustRootCertificates = trustRootCertificates
             self.pins = pins
             self.isStrict = isStrict
+            self.revocationPolicy = revocationPolicy
         }
 
         // MARK: - Internal methods
 
-        /// Anchors `trust` on `trustRootCertificates` (when any are configured), and -- only when
-        /// `skipsHostnameVerification` -- replaces `trust`'s policy with `SecPolicyCreateSSL(true,
-        /// nil)`: a real SSL server policy (still checks the server-auth `extendedKeyUsage` and
-        /// everything else a certificate presented for TLS server auth normally must satisfy), just
-        /// without the hostname match. Deliberately *not* `SecPolicyCreateBasicX509()` -- that's a
-        /// bare X.509 chain-of-trust policy with no purpose/EKU checks at all, which is what
+        /// Anchors `trust` on `trustRootCertificates` (when any are configured); replaces or
+        /// augments `trust`'s policy array whenever `skipsHostnameVerification` and/or
+        /// `revocationPolicy` ask for it.
+        ///
+        /// `skipsHostnameVerification` swaps in `SecPolicyCreateSSL(true, nil)`: a real SSL server
+        /// policy (still checks the server-auth `extendedKeyUsage` and everything else a
+        /// certificate presented for TLS server auth normally must satisfy), just without the
+        /// hostname match. Deliberately *not* `SecPolicyCreateBasicX509()` -- that's a bare X.509
+        /// chain-of-trust policy with no purpose/EKU checks at all, which is what
         /// `NIOTrustEvaluator`'s Network.framework closure used before this type existed: a wider
         /// relaxation than `.noHostnameVerification` ever asked for. `ServerTrustPolicy` already
         /// used the correct, narrower policy for `.urlSession`; unifying on it here is a real (if
         /// small) tightening for `.nioTransportServices`, not just a refactor.
+        ///
+        /// `revocationPolicy`, when set, is appended to whichever policy array results from the
+        /// above -- `SecTrustCopyPolicies` reads `trust`'s current array first (its default SSL/
+        /// X.509 policy, when `skipsHostnameVerification` didn't just replace it) rather than
+        /// dropping it, since `SecTrustSetPolicies` replaces the whole array rather than appending
+        /// to it.
         package func prepare(_ trust: SecTrust, skipsHostnameVerification: Bool) {
-            if skipsHostnameVerification {
-                SecTrustSetPolicies(trust, SecPolicyCreateSSL(true, nil))
+            if skipsHostnameVerification || revocationPolicy != nil {
+                var policies: [SecPolicy]
+
+                if skipsHostnameVerification {
+                    policies = [SecPolicyCreateSSL(true, nil)]
+                } else {
+                    var currentPolicies: CFArray?
+                    policies =
+                        SecTrustCopyPolicies(trust, &currentPolicies) == errSecSuccess
+                        ? (currentPolicies as? [SecPolicy] ?? [])
+                        : []
+                }
+
+                if let revocationPolicy {
+                    policies.append(revocationPolicy.secPolicy)
+                }
+
+                SecTrustSetPolicies(trust, policies as CFArray)
             }
 
             if !trustRootCertificates.isEmpty {

--- a/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.DarwinTrustEvaluation.swift
+++ b/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.DarwinTrustEvaluation.swift
@@ -4,12 +4,12 @@
 
 // The shared core `Internals.ServerTrustPolicy` (`.urlSession`) and `Internals.NIOTrustEvaluator`
 // (`.nio`/`.nioTransportServices`) both need, extracted after the two independently reimplemented
-// the same `SecTrust`-based accept/reject decision for a while -- and had already drifted once:
+// the same `SecTrust`-based accept/reject decision for a while, and had already drifted once:
 // `ServerTrustPolicy` handled `.noHostnameVerification` correctly from its very first version,
 // while `NIOTrustEvaluator` needed a dedicated fix later to catch up. Neither of the two consumers
-// hands off *how* to call `SecTrustEvaluate(WithError|AsyncWithError)` here -- `.urlSession`'s own
-// delegate queue makes the synchronous call safe, while `.nio`'s NIO event loop can't block on it
-// -- so this only owns what's identical either way: anchoring the trust, swapping in a
+// hands off *how* to call `SecTrustEvaluate(WithError|AsyncWithError)` here. `.urlSession`'s own
+// delegate queue makes the synchronous call safe, while `.nio`'s NIO event loop can't block on it,
+// so this only owns what's identical either way: anchoring the trust, swapping in a
 // hostname-less policy when asked, and the strict/audit SPKI pin decision once chain validation
 // already succeeded.
 
@@ -26,7 +26,7 @@ import Foundation
 
 extension Internals {
 
-    /// One SPKI pin, normalized to a same-process matcher regardless of where it came from --
+    /// One SPKI pin, normalized to a same-process matcher regardless of where it came from.
     /// `Internals.ServerTrustPolicy` also needs a `Descriptor`-capturable digest for
     /// `BackgroundDownloadTask` persistence, `Internals.NIOTrustEvaluator` doesn't; both build one
     /// of these to hand to `DarwinTrustEvaluation`, which only ever needs the matcher itself.

--- a/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.DarwinTrustEvaluation.swift
+++ b/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.DarwinTrustEvaluation.swift
@@ -77,11 +77,13 @@ extension Internals {
         /// `skipsHostnameVerification` swaps in `SecPolicyCreateSSL(true, nil)`: a real SSL server
         /// policy (still checks the server-auth `extendedKeyUsage` and everything else a
         /// certificate presented for TLS server auth normally must satisfy), just without the
-        /// hostname match. Deliberately *not* `SecPolicyCreateBasicX509()`, a bare X.509
-        /// chain-of-trust policy with no purpose/EKU checks at all: that would be a wider
-        /// relaxation than `.noHostnameVerification` ever asked for, accepting a certificate
-        /// lacking the server-auth `extendedKeyUsage` that `SecPolicyCreateSSL(true, nil)`
-        /// correctly rejects (see `InternalsDarwinTrustEvaluationTests`'s
+        /// hostname match.
+        ///
+        /// Deliberately *not* `SecPolicyCreateBasicX509()`, a bare X.509 chain-of-trust policy
+        /// with no purpose/EKU checks at all: that would be a wider relaxation than
+        /// `.noHostnameVerification` ever asked for, accepting a certificate lacking the
+        /// server-auth `extendedKeyUsage` that `SecPolicyCreateSSL(true, nil)` correctly rejects
+        /// (see `InternalsDarwinTrustEvaluationTests`'s
         /// `prepare_whenSkipsHostnameVerification_stillEnforcesServerAuthExtendedKeyUsage`).
         ///
         /// `revocationPolicy`, when set, is appended to whichever policy array results from the
@@ -153,6 +155,7 @@ extension Internals {
         /// reconstructing the SPKI ASN.1 wrapper from a bare `SecKey` export by hand, so a pin
         /// configured once produces the identical digest regardless of which executor
         /// (`.urlSession`, `.nio`, `.nioTransportServices`) ends up carrying the connection.
+        ///
         /// Certificates that don't round-trip through NIOSSL are dropped rather than failing the
         /// whole chain; that isn't expected in practice for a trust `SecTrustEvaluate...` already
         /// accepted moments earlier.

--- a/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.DarwinTrustEvaluation.swift
+++ b/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.DarwinTrustEvaluation.swift
@@ -77,15 +77,15 @@ extension Internals {
         /// `skipsHostnameVerification` swaps in `SecPolicyCreateSSL(true, nil)`: a real SSL server
         /// policy (still checks the server-auth `extendedKeyUsage` and everything else a
         /// certificate presented for TLS server auth normally must satisfy), just without the
-        /// hostname match. Deliberately *not* `SecPolicyCreateBasicX509()` -- that's a bare X.509
-        /// chain-of-trust policy with no purpose/EKU checks at all, a wider relaxation than
-        /// `.noHostnameVerification` ever asked for: it would accept a certificate lacking the
-        /// server-auth `extendedKeyUsage` that `SecPolicyCreateSSL(true, nil)` correctly rejects
-        /// (see `InternalsDarwinTrustEvaluationTests`'s
+        /// hostname match. Deliberately *not* `SecPolicyCreateBasicX509()`, a bare X.509
+        /// chain-of-trust policy with no purpose/EKU checks at all: that would be a wider
+        /// relaxation than `.noHostnameVerification` ever asked for, accepting a certificate
+        /// lacking the server-auth `extendedKeyUsage` that `SecPolicyCreateSSL(true, nil)`
+        /// correctly rejects (see `InternalsDarwinTrustEvaluationTests`'s
         /// `prepare_whenSkipsHostnameVerification_stillEnforcesServerAuthExtendedKeyUsage`).
         ///
         /// `revocationPolicy`, when set, is appended to whichever policy array results from the
-        /// above -- `SecTrustCopyPolicies` reads `trust`'s current array first (its default SSL/
+        /// above. `SecTrustCopyPolicies` reads `trust`'s current array first (its default SSL/
         /// X.509 policy, when `skipsHostnameVerification` didn't just replace it) rather than
         /// dropping it, since `SecTrustSetPolicies` replaces the whole array rather than appending
         /// to it.
@@ -116,15 +116,15 @@ extension Internals {
             }
         }
 
-        /// The accept/reject decision, given `chainIsTrusted` -- the caller's own
+        /// The accept/reject decision, given `chainIsTrusted`, the caller's own
         /// `SecTrustEvaluate(WithError|AsyncWithError)` result for `trust`. Notifies `observer`,
         /// when configured, with the outcome either way, before returning it.
         ///
-        /// `pins.isEmpty` means nothing is configured to pin against -- chain validity by itself
+        /// `pins.isEmpty` means nothing is configured to pin against, so chain validity by itself
         /// is the whole check then. Otherwise every certificate in `trust`'s chain is checked, leaf
-        /// and intermediates alike -- OWASP's recommended backup-pin practice, pinning an
-        /// intermediate CA (which rotates far less often than the leaf) alongside or instead of it
-        /// -- and a mismatch only rejects under `isStrict`.
+        /// and intermediates alike (OWASP's recommended backup-pin practice, pinning an
+        /// intermediate CA, which rotates far less often than the leaf, alongside or instead of
+        /// it), and a mismatch only rejects under `isStrict`.
         package func evaluate(chain trust: SecTrust, chainIsTrusted: Bool) -> Bool {
             guard chainIsTrusted else {
                 observer?(TrustDecision(isTrusted: false, pinsMatched: nil))
@@ -148,13 +148,13 @@ extension Internals {
         // MARK: - Private methods
 
         /// Every certificate's SPKI (SubjectPublicKeyInfo) structure in `trust`'s chain,
-        /// DER-encoded -- what a pin's digest is computed over. Reuses NIOSSL's own
+        /// DER-encoded: what a pin's digest is computed over. Reuses NIOSSL's own
         /// `NIOSSLPublicKey.toSPKIBytes()` on each certificate's DER bytes rather than
         /// reconstructing the SPKI ASN.1 wrapper from a bare `SecKey` export by hand, so a pin
         /// configured once produces the identical digest regardless of which executor
         /// (`.urlSession`, `.nio`, `.nioTransportServices`) ends up carrying the connection.
         /// Certificates that don't round-trip through NIOSSL are dropped rather than failing the
-        /// whole chain -- not expected in practice for a trust `SecTrustEvaluate...` already
+        /// whole chain; that isn't expected in practice for a trust `SecTrustEvaluate...` already
         /// accepted moments earlier.
         private static func chainSPKIDERBytes(of trust: SecTrust) -> [Data] {
             guard let chain = SecTrustCopyCertificateChain(trust) as? [SecCertificate] else {

--- a/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.DarwinTrustEvaluation.swift
+++ b/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.DarwinTrustEvaluation.swift
@@ -1,0 +1,126 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+// The shared core `Internals.ServerTrustPolicy` (`.urlSession`) and `Internals.NIOTrustEvaluator`
+// (`.nio`/`.nioTransportServices`) both need, extracted after the two independently reimplemented
+// the same `SecTrust`-based accept/reject decision for a while -- and had already drifted once:
+// `ServerTrustPolicy` handled `.noHostnameVerification` correctly from its very first version,
+// while `NIOTrustEvaluator` needed a dedicated fix later to catch up. Neither of the two consumers
+// hands off *how* to call `SecTrustEvaluate(WithError|AsyncWithError)` here -- `.urlSession`'s own
+// delegate queue makes the synchronous call safe, while `.nio`'s NIO event loop can't block on it
+// -- so this only owns what's identical either way: anchoring the trust, swapping in a
+// hostname-less policy when asked, and the strict/audit SPKI pin decision once chain validation
+// already succeeded.
+
+#if canImport(Darwin)
+
+import NIOSSL
+import Security
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+
+extension Internals {
+
+    /// One SPKI pin, normalized to a same-process matcher regardless of where it came from --
+    /// `Internals.ServerTrustPolicy` also needs a `Descriptor`-capturable digest for
+    /// `BackgroundDownloadTask` persistence, `Internals.NIOTrustEvaluator` doesn't; both build one
+    /// of these to hand to `DarwinTrustEvaluation`, which only ever needs the matcher itself.
+    package struct ResolvedSPKIPin: Sendable {
+        package let matches: @Sendable (Data) -> Bool
+
+        package init(matches: @escaping @Sendable (Data) -> Bool) {
+            self.matches = matches
+        }
+    }
+
+    /// Shared, `SecTrust`-based trust-root + SPKI pin logic. `prepare(_:skipsHostnameVerification:)`
+    /// must run before the caller's own `SecTrustEvaluate(WithError|AsyncWithError)` call;
+    /// `passes(chain:)` is the accept/reject decision once that call already reported the chain
+    /// itself as trusted.
+    package struct DarwinTrustEvaluation: Sendable {
+
+        // MARK: - Internal properties
+
+        package let trustRootCertificates: [SecCertificate]
+        package let pins: [ResolvedSPKIPin]
+        package let isStrict: Bool
+
+        // MARK: - Inits
+
+        package init(trustRootCertificates: [SecCertificate], pins: [ResolvedSPKIPin], isStrict: Bool) {
+            self.trustRootCertificates = trustRootCertificates
+            self.pins = pins
+            self.isStrict = isStrict
+        }
+
+        // MARK: - Internal methods
+
+        /// Anchors `trust` on `trustRootCertificates` (when any are configured), and -- only when
+        /// `skipsHostnameVerification` -- replaces `trust`'s policy with `SecPolicyCreateSSL(true,
+        /// nil)`: a real SSL server policy (still checks the server-auth `extendedKeyUsage` and
+        /// everything else a certificate presented for TLS server auth normally must satisfy), just
+        /// without the hostname match. Deliberately *not* `SecPolicyCreateBasicX509()` -- that's a
+        /// bare X.509 chain-of-trust policy with no purpose/EKU checks at all, which is what
+        /// `NIOTrustEvaluator`'s Network.framework closure used before this type existed: a wider
+        /// relaxation than `.noHostnameVerification` ever asked for. `ServerTrustPolicy` already
+        /// used the correct, narrower policy for `.urlSession`; unifying on it here is a real (if
+        /// small) tightening for `.nioTransportServices`, not just a refactor.
+        package func prepare(_ trust: SecTrust, skipsHostnameVerification: Bool) {
+            if skipsHostnameVerification {
+                SecTrustSetPolicies(trust, SecPolicyCreateSSL(true, nil))
+            }
+
+            if !trustRootCertificates.isEmpty {
+                SecTrustSetAnchorCertificates(trust, trustRootCertificates as CFArray)
+                SecTrustSetAnchorCertificatesOnly(trust, true)
+            }
+        }
+
+        /// `pins.isEmpty` means nothing is configured to pin against -- chain validity by itself
+        /// (already confirmed by the caller's own `SecTrustEvaluate...` call before this runs) is
+        /// the whole check then. Otherwise every certificate in `trust`'s chain is checked, leaf
+        /// and intermediates alike -- OWASP's recommended backup-pin practice, pinning an
+        /// intermediate CA (which rotates far less often than the leaf) alongside or instead of it
+        /// -- and a mismatch only rejects under `isStrict`.
+        package func passes(chain trust: SecTrust) -> Bool {
+            guard !pins.isEmpty else {
+                return true
+            }
+
+            let matched = Self.chainSPKIDERBytes(of: trust).contains { spkiDERBytes in
+                pins.contains { $0.matches(spkiDERBytes) }
+            }
+
+            return matched || !isStrict
+        }
+
+        // MARK: - Private methods
+
+        /// Every certificate's SPKI (SubjectPublicKeyInfo) structure in `trust`'s chain,
+        /// DER-encoded -- what a pin's digest is computed over. Reuses NIOSSL's own
+        /// `NIOSSLPublicKey.toSPKIBytes()` on each certificate's DER bytes rather than
+        /// reconstructing the SPKI ASN.1 wrapper from a bare `SecKey` export by hand, so a pin
+        /// configured once produces the identical digest regardless of which executor
+        /// (`.urlSession`, `.nio`, `.nioTransportServices`) ends up carrying the connection.
+        /// Certificates that don't round-trip through NIOSSL are dropped rather than failing the
+        /// whole chain -- not expected in practice for a trust `SecTrustEvaluate...` already
+        /// accepted moments earlier.
+        private static func chainSPKIDERBytes(of trust: SecTrust) -> [Data] {
+            guard let chain = SecTrustCopyCertificateChain(trust) as? [SecCertificate] else {
+                return []
+            }
+
+            return chain.compactMap { certificate in
+                let derBytes = [UInt8](SecCertificateCopyData(certificate) as Data)
+                return (try? NIOSSLCertificate(bytes: derBytes, format: .der))?.spkiDERBytes()
+            }
+        }
+    }
+}
+
+#endif

--- a/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.DarwinTrustEvaluation.swift
+++ b/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.DarwinTrustEvaluation.swift
@@ -78,11 +78,11 @@ extension Internals {
         /// policy (still checks the server-auth `extendedKeyUsage` and everything else a
         /// certificate presented for TLS server auth normally must satisfy), just without the
         /// hostname match. Deliberately *not* `SecPolicyCreateBasicX509()` -- that's a bare X.509
-        /// chain-of-trust policy with no purpose/EKU checks at all, which is what
-        /// `NIOTrustEvaluator`'s Network.framework closure used before this type existed: a wider
-        /// relaxation than `.noHostnameVerification` ever asked for. `ServerTrustPolicy` already
-        /// used the correct, narrower policy for `.urlSession`; unifying on it here is a real (if
-        /// small) tightening for `.nioTransportServices`, not just a refactor.
+        /// chain-of-trust policy with no purpose/EKU checks at all, a wider relaxation than
+        /// `.noHostnameVerification` ever asked for: it would accept a certificate lacking the
+        /// server-auth `extendedKeyUsage` that `SecPolicyCreateSSL(true, nil)` correctly rejects
+        /// (see `InternalsDarwinTrustEvaluationTests`'s
+        /// `prepare_whenSkipsHostnameVerification_stillEnforcesServerAuthExtendedKeyUsage`).
         ///
         /// `revocationPolicy`, when set, is appended to whichever policy array results from the
         /// above -- `SecTrustCopyPolicies` reads `trust`'s current array first (its default SSL/

--- a/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.NIOTrustEvaluator+Darwin.swift
+++ b/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.NIOTrustEvaluator+Darwin.swift
@@ -18,15 +18,13 @@ import Foundation
 extension Internals.NIOTrustEvaluator {
 
     /// Same shape of validation as `Internals.ServerTrustPolicy.handle(challenge:)`, minus the
-    /// `URLAuthenticationChallenge` wrapping: evaluate against the OS trust store (so Certificate
-    /// Transparency, revocation, and the continuously-updated root set all keep applying exactly as
-    /// they already do for `.urlSession`), then -- when `pins` isn't empty -- check every
-    /// certificate in the chain, leaf and intermediates alike, against the configured pins too. A
-    /// chain-validation failure always rejects, regardless of policy; a pin mismatch only rejects
-    /// under `.strict`, matching `ServerTrustPolicy`'s existing semantics (and AsyncHTTPClient's
-    /// own former SPKI pinning policy) exactly. An empty `pins` means this evaluator exists only
-    /// to feed `trustRootCertificates` into the OS trust store's anchor set (`additionalTrustRoots`
-    /// with no SPKI pinning) -- chain validity is the whole check then, nothing more to enforce.
+    /// `URLAuthenticationChallenge` wrapping -- both now delegate the actual trust-root/SPKI pin
+    /// decision to the shared `Internals.DarwinTrustEvaluation`, and only own what genuinely
+    /// differs between them: this evaluator can't call `SecTrustEvaluate(WithError|AsyncWithError)`
+    /// synchronously the way `ServerTrustPolicy` does on `.urlSession`'s own delegate queue --
+    /// evaluation can perform network I/O (OCSP), and blocking the NIO event loop that invokes
+    /// these closures would stall every other connection sharing it -- so it always dispatches onto
+    /// its own dedicated queue first.
     static func makeDarwinEvaluator(
         pins: [Internals.SPKIHash],
         isStrict: Bool,
@@ -39,39 +37,29 @@ extension Internals.NIOTrustEvaluator {
             }
         }
 
+        let resolvedPins = pins.map { pin in
+            Internals.ResolvedSPKIPin { spkiDERBytes in
+                (try? pin.matchesSPKI(spkiDERBytes)) ?? false
+            }
+        }
+
+        let evaluation = Internals.DarwinTrustEvaluation(
+            trustRootCertificates: secTrustRoots,
+            pins: resolvedPins,
+            isStrict: isStrict
+        )
+
         // `SecTrustEvaluateAsyncWithError` must be called from -- and calls back on -- the same
-        // queue. This must not run on the NIO event loop thread that invokes these closures: the
-        // evaluation can perform network I/O (OCSP), and blocking the event loop would stall every
-        // other connection sharing it.
+        // queue.
         let queue = DispatchQueue(label: "RequestDL.NIOTrustEvaluator")
 
         @Sendable
-        func matchesAnyPin(chain: [SecCertificate]) -> Bool {
-            let chainSPKIDERBytes: [Data] = chain.compactMap { certificate in
-                let derBytes = [UInt8](SecCertificateCopyData(certificate) as Data)
-                return (try? NIOSSLCertificate(bytes: derBytes, format: .der))?.spkiDERBytes()
-            }
-            return chainSPKIDERBytes.contains { spkiDERBytes in
-                pins.contains { (try? $0.matchesSPKI(spkiDERBytes)) ?? false }
-            }
-        }
-
-        // `pins.isEmpty` means this evaluator was installed for `additionalTrustRoots` alone (see
-        // `resolve(from:)`) -- there's nothing configured to pin against, so chain validity by
-        // itself is the whole check. Without this, `matchesAnyPin` would always be `false` for an
-        // empty pin set and `isStrict` would default to `true`, rejecting every connection
-        // regardless of how trustworthy the chain actually is.
-        @Sendable
-        func passesPinCheck(chain: [SecCertificate]) -> Bool {
-            pins.isEmpty || matchesAnyPin(chain: chain) || !isStrict
-        }
-
-        @Sendable
-        func evaluate(trust: SecTrust, completion: @escaping @Sendable (Bool) -> Void) {
-            if !secTrustRoots.isEmpty {
-                SecTrustSetAnchorCertificates(trust, secTrustRoots as CFArray)
-                SecTrustSetAnchorCertificatesOnly(trust, true)
-            }
+        func evaluate(
+            trust: SecTrust,
+            skipsHostnameVerification: Bool,
+            completion: @escaping @Sendable (Bool) -> Void
+        ) {
+            evaluation.prepare(trust, skipsHostnameVerification: skipsHostnameVerification)
 
             queue.async {
                 if #available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) {
@@ -80,15 +68,13 @@ extension Internals.NIOTrustEvaluator {
                             completion(false)
                             return
                         }
-                        let chain = (SecTrustCopyCertificateChain(trust) as? [SecCertificate]) ?? []
-                        completion(passesPinCheck(chain: chain))
+                        completion(evaluation.passes(chain: trust))
                     }
                 } else {
                     SecTrustEvaluateAsync(trust, queue) { _, result in
                         switch result {
                         case .proceed, .unspecified:
-                            let chain = (SecTrustCopyCertificateChain(trust) as? [SecCertificate]) ?? []
-                            completion(passesPinCheck(chain: chain))
+                            completion(evaluation.passes(chain: trust))
                         default:
                             completion(false)
                         }
@@ -114,7 +100,10 @@ extension Internals.NIOTrustEvaluator {
                 // A plain X.509 policy, deliberately without a hostname -- hostname/SNI matching
                 // stays NIOSSL's own separate gate (tied purely to `certificateVerification`,
                 // independent of this callback being installed), so this evaluator only needs to
-                // own chain-of-trust validation.
+                // own chain-of-trust validation. Never affected by `skipsHostnameVerification`:
+                // there's no live hostname context on this from-scratch `SecTrust` for
+                // `DarwinTrustEvaluation.prepare(_:skipsHostnameVerification:)`'s policy swap to
+                // apply to in the first place.
                 let status = SecTrustCreateWithCertificates(
                     secCertificates as CFArray,
                     SecPolicyCreateBasicX509(),
@@ -126,24 +115,12 @@ extension Internals.NIOTrustEvaluator {
                     return
                 }
 
-                evaluate(trust: trust) { verified in
+                evaluate(trust: trust, skipsHostnameVerification: false) { verified in
                     promise.succeed(verified ? .certificateVerified : .failed)
                 }
             },
             tlsCustomVerificationNetworkFramework: { trust, complete in
-                // Network.framework already attaches its own SNI-aware policy to this `SecTrust`
-                // before handing it here -- left untouched by default, so hostname validation
-                // keeps applying exactly as it would without this callback installed. Only when
-                // `.noHostnameVerification` was actually configured is that policy swapped out for
-                // a plain X.509 one (chain-of-trust only, no hostname), mirroring what the
-                // NIOSSL-facing closure above already builds from scratch -- there's no other way
-                // to get Network.framework to skip hostname matching, since (unlike NIOSSL) it has
-                // no separate knob for that: this custom callback is the only lever, and it either
-                // keeps or replaces the whole policy wholesale, chain validation included.
-                if skipsHostnameVerification {
-                    SecTrustSetPolicies(trust, SecPolicyCreateBasicX509())
-                }
-                evaluate(trust: trust, completion: complete)
+                evaluate(trust: trust, skipsHostnameVerification: skipsHostnameVerification, completion: complete)
             }
         )
     }

--- a/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.NIOTrustEvaluator+Darwin.swift
+++ b/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.NIOTrustEvaluator+Darwin.swift
@@ -29,7 +29,8 @@ extension Internals.NIOTrustEvaluator {
         pins: [Internals.SPKIHash],
         isStrict: Bool,
         trustRootCertificates: [NIOSSLCertificate],
-        skipsHostnameVerification: Bool
+        skipsHostnameVerification: Bool,
+        revocationPolicy: Internals.RevocationPolicy?
     ) throws -> Internals.NIOTrustEvaluator {
         let secTrustRoots: [SecCertificate] = trustRootCertificates.compactMap { certificate in
             (try? certificate.toDERBytes()).flatMap {
@@ -46,7 +47,8 @@ extension Internals.NIOTrustEvaluator {
         let evaluation = Internals.DarwinTrustEvaluation(
             trustRootCertificates: secTrustRoots,
             pins: resolvedPins,
-            isStrict: isStrict
+            isStrict: isStrict,
+            revocationPolicy: revocationPolicy
         )
 
         // `SecTrustEvaluateAsyncWithError` must be called from -- and calls back on -- the same

--- a/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.NIOTrustEvaluator+Darwin.swift
+++ b/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.NIOTrustEvaluator+Darwin.swift
@@ -20,11 +20,13 @@ extension Internals.NIOTrustEvaluator {
     /// Same shape of validation as `Internals.ServerTrustPolicy.handle(challenge:)`, minus the
     /// `URLAuthenticationChallenge` wrapping. Both delegate the actual trust-root/SPKI pin
     /// decision to the shared `Internals.DarwinTrustEvaluation`, and only own what genuinely
-    /// differs between them: this evaluator can't call `SecTrustEvaluate(WithError|AsyncWithError)`
-    /// synchronously the way `ServerTrustPolicy` does on `.urlSession`'s own delegate queue,
-    /// since evaluation can perform network I/O (OCSP), and blocking the NIO event loop that
-    /// invokes these closures would stall every other connection sharing it. So it always
-    /// dispatches onto its own dedicated queue first.
+    /// differs between them.
+    ///
+    /// This evaluator can't call `SecTrustEvaluate(WithError|AsyncWithError)` synchronously the
+    /// way `ServerTrustPolicy` does on `.urlSession`'s own delegate queue, since evaluation can
+    /// perform network I/O (OCSP), and blocking the NIO event loop that invokes these closures
+    /// would stall every other connection sharing it. So it always dispatches onto its own
+    /// dedicated queue first.
     static func makeDarwinEvaluator(
         pins: [Internals.SPKIHash],
         isStrict: Bool,

--- a/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.NIOTrustEvaluator+Darwin.swift
+++ b/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.NIOTrustEvaluator+Darwin.swift
@@ -1,0 +1,130 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+#if canImport(Darwin)
+
+import Dispatch
+import NIOCore
+import NIOSSL
+import Security
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+
+extension Internals.NIOTrustEvaluator {
+
+    /// Same shape of validation as `Internals.ServerTrustPolicy.handle(challenge:)`, minus the
+    /// `URLAuthenticationChallenge` wrapping: evaluate against the OS trust store (so Certificate
+    /// Transparency, revocation, and the continuously-updated root set all keep applying exactly as
+    /// they already do for `.urlSession`), then check every certificate in the chain -- leaf and
+    /// intermediates alike -- against the configured pins. A chain-validation failure always
+    /// rejects, regardless of policy; a pin mismatch only rejects under `.strict`, matching
+    /// `ServerTrustPolicy`'s existing semantics (and AsyncHTTPClient's own former SPKI pinning
+    /// policy) exactly.
+    static func makeDarwinEvaluator(
+        pins: [Internals.SPKIHash],
+        isStrict: Bool,
+        trustRootCertificates: [NIOSSLCertificate]
+    ) throws -> Internals.NIOTrustEvaluator {
+        let secTrustRoots: [SecCertificate] = trustRootCertificates.compactMap { certificate in
+            (try? certificate.toDERBytes()).flatMap {
+                SecCertificateCreateWithData(nil, Data($0) as CFData)
+            }
+        }
+
+        // `SecTrustEvaluateAsyncWithError` must be called from -- and calls back on -- the same
+        // queue. This must not run on the NIO event loop thread that invokes these closures: the
+        // evaluation can perform network I/O (OCSP), and blocking the event loop would stall every
+        // other connection sharing it.
+        let queue = DispatchQueue(label: "RequestDL.NIOTrustEvaluator")
+
+        @Sendable
+        func matchesAnyPin(chain: [SecCertificate]) -> Bool {
+            let chainSPKIDERBytes: [Data] = chain.compactMap { certificate in
+                let derBytes = [UInt8](SecCertificateCopyData(certificate) as Data)
+                return (try? NIOSSLCertificate(bytes: derBytes, format: .der))?.spkiDERBytes()
+            }
+            return chainSPKIDERBytes.contains { spkiDERBytes in
+                pins.contains { (try? $0.matchesSPKI(spkiDERBytes)) ?? false }
+            }
+        }
+
+        @Sendable
+        func evaluate(trust: SecTrust, completion: @escaping @Sendable (Bool) -> Void) {
+            if !secTrustRoots.isEmpty {
+                SecTrustSetAnchorCertificates(trust, secTrustRoots as CFArray)
+                SecTrustSetAnchorCertificatesOnly(trust, true)
+            }
+
+            queue.async {
+                if #available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) {
+                    SecTrustEvaluateAsyncWithError(trust, queue) { _, isTrusted, _ in
+                        guard isTrusted else {
+                            completion(false)
+                            return
+                        }
+                        let chain = (SecTrustCopyCertificateChain(trust) as? [SecCertificate]) ?? []
+                        completion(matchesAnyPin(chain: chain) || !isStrict)
+                    }
+                } else {
+                    SecTrustEvaluateAsync(trust, queue) { _, result in
+                        switch result {
+                        case .proceed, .unspecified:
+                            let chain = (SecTrustCopyCertificateChain(trust) as? [SecCertificate]) ?? []
+                            completion(matchesAnyPin(chain: chain) || !isStrict)
+                        default:
+                            completion(false)
+                        }
+                    }
+                }
+            }
+        }
+
+        return Internals.NIOTrustEvaluator(
+            tlsCustomVerification: { certificates, promise in
+                let secCertificates: [SecCertificate] = certificates.compactMap { certificate in
+                    (try? certificate.toDERBytes()).flatMap {
+                        SecCertificateCreateWithData(nil, Data($0) as CFData)
+                    }
+                }
+
+                guard !secCertificates.isEmpty else {
+                    promise.succeed(.failed)
+                    return
+                }
+
+                var trust: SecTrust?
+                // A plain X.509 policy, deliberately without a hostname -- hostname/SNI matching
+                // stays NIOSSL's own separate gate (tied purely to `certificateVerification`,
+                // independent of this callback being installed), so this evaluator only needs to
+                // own chain-of-trust validation.
+                let status = SecTrustCreateWithCertificates(
+                    secCertificates as CFArray,
+                    SecPolicyCreateBasicX509(),
+                    &trust
+                )
+
+                guard status == errSecSuccess, let trust else {
+                    promise.succeed(.failed)
+                    return
+                }
+
+                evaluate(trust: trust) { verified in
+                    promise.succeed(verified ? .certificateVerified : .failed)
+                }
+            },
+            tlsCustomVerificationNetworkFramework: { trust, complete in
+                // Network.framework already attaches its own SNI-aware policy to this `SecTrust`
+                // before handing it here -- left untouched, so hostname validation keeps applying
+                // exactly as it would without this callback installed.
+                evaluate(trust: trust, completion: complete)
+            }
+        )
+    }
+}
+
+#endif

--- a/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.NIOTrustEvaluator+Darwin.swift
+++ b/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.NIOTrustEvaluator+Darwin.swift
@@ -18,7 +18,7 @@ import Foundation
 extension Internals.NIOTrustEvaluator {
 
     /// Same shape of validation as `Internals.ServerTrustPolicy.handle(challenge:)`, minus the
-    /// `URLAuthenticationChallenge` wrapping -- both now delegate the actual trust-root/SPKI pin
+    /// `URLAuthenticationChallenge` wrapping -- both delegate the actual trust-root/SPKI pin
     /// decision to the shared `Internals.DarwinTrustEvaluation`, and only own what genuinely
     /// differs between them: this evaluator can't call `SecTrustEvaluate(WithError|AsyncWithError)`
     /// synchronously the way `ServerTrustPolicy` does on `.urlSession`'s own delegate queue --

--- a/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.NIOTrustEvaluator+Darwin.swift
+++ b/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.NIOTrustEvaluator+Darwin.swift
@@ -30,7 +30,8 @@ extension Internals.NIOTrustEvaluator {
     static func makeDarwinEvaluator(
         pins: [Internals.SPKIHash],
         isStrict: Bool,
-        trustRootCertificates: [NIOSSLCertificate]
+        trustRootCertificates: [NIOSSLCertificate],
+        skipsHostnameVerification: Bool
     ) throws -> Internals.NIOTrustEvaluator {
         let secTrustRoots: [SecCertificate] = trustRootCertificates.compactMap { certificate in
             (try? certificate.toDERBytes()).flatMap {
@@ -131,8 +132,17 @@ extension Internals.NIOTrustEvaluator {
             },
             tlsCustomVerificationNetworkFramework: { trust, complete in
                 // Network.framework already attaches its own SNI-aware policy to this `SecTrust`
-                // before handing it here -- left untouched, so hostname validation keeps applying
-                // exactly as it would without this callback installed.
+                // before handing it here -- left untouched by default, so hostname validation
+                // keeps applying exactly as it would without this callback installed. Only when
+                // `.noHostnameVerification` was actually configured is that policy swapped out for
+                // a plain X.509 one (chain-of-trust only, no hostname), mirroring what the
+                // NIOSSL-facing closure above already builds from scratch -- there's no other way
+                // to get Network.framework to skip hostname matching, since (unlike NIOSSL) it has
+                // no separate knob for that: this custom callback is the only lever, and it either
+                // keeps or replaces the whole policy wholesale, chain validation included.
+                if skipsHostnameVerification {
+                    SecTrustSetPolicies(trust, SecPolicyCreateBasicX509())
+                }
                 evaluate(trust: trust, completion: complete)
             }
         )

--- a/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.NIOTrustEvaluator+Darwin.swift
+++ b/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.NIOTrustEvaluator+Darwin.swift
@@ -30,7 +30,8 @@ extension Internals.NIOTrustEvaluator {
         isStrict: Bool,
         trustRootCertificates: [NIOSSLCertificate],
         skipsHostnameVerification: Bool,
-        revocationPolicy: Internals.RevocationPolicy?
+        revocationPolicy: Internals.RevocationPolicy?,
+        observer: (any TrustDecisionObserver)?
     ) throws -> Internals.NIOTrustEvaluator {
         let secTrustRoots: [SecCertificate] = trustRootCertificates.compactMap { certificate in
             (try? certificate.toDERBytes()).flatMap {
@@ -48,7 +49,8 @@ extension Internals.NIOTrustEvaluator {
             trustRootCertificates: secTrustRoots,
             pins: resolvedPins,
             isStrict: isStrict,
-            revocationPolicy: revocationPolicy
+            revocationPolicy: revocationPolicy,
+            observer: observer
         )
 
         // `SecTrustEvaluateAsyncWithError` must be called from -- and calls back on -- the same
@@ -66,19 +68,15 @@ extension Internals.NIOTrustEvaluator {
             queue.async {
                 if #available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) {
                     SecTrustEvaluateAsyncWithError(trust, queue) { _, isTrusted, _ in
-                        guard isTrusted else {
-                            completion(false)
-                            return
-                        }
-                        completion(evaluation.passes(chain: trust))
+                        completion(evaluation.evaluate(chain: trust, chainIsTrusted: isTrusted))
                     }
                 } else {
                     SecTrustEvaluateAsync(trust, queue) { _, result in
                         switch result {
                         case .proceed, .unspecified:
-                            completion(evaluation.passes(chain: trust))
+                            completion(evaluation.evaluate(chain: trust, chainIsTrusted: true))
                         default:
-                            completion(false)
+                            completion(evaluation.evaluate(chain: trust, chainIsTrusted: false))
                         }
                     }
                 }

--- a/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.NIOTrustEvaluator+Darwin.swift
+++ b/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.NIOTrustEvaluator+Darwin.swift
@@ -53,7 +53,7 @@ extension Internals.NIOTrustEvaluator {
             observer: observer
         )
 
-        // `SecTrustEvaluateAsyncWithError` must be called from -- and calls back on -- the same
+        // `SecTrustEvaluateAsyncWithError` must be called from, and calls back on, the same
         // queue.
         let queue = DispatchQueue(label: "RequestDL.NIOTrustEvaluator")
 
@@ -97,7 +97,7 @@ extension Internals.NIOTrustEvaluator {
                 }
 
                 var trust: SecTrust?
-                // A plain X.509 policy, deliberately without a hostname -- hostname/SNI matching
+                // A plain X.509 policy, deliberately without a hostname. Hostname/SNI matching
                 // stays NIOSSL's own separate gate (tied purely to `certificateVerification`,
                 // independent of this callback being installed), so this evaluator only needs to
                 // own chain-of-trust validation. Never affected by `skipsHostnameVerification`:

--- a/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.NIOTrustEvaluator+Darwin.swift
+++ b/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.NIOTrustEvaluator+Darwin.swift
@@ -18,13 +18,13 @@ import Foundation
 extension Internals.NIOTrustEvaluator {
 
     /// Same shape of validation as `Internals.ServerTrustPolicy.handle(challenge:)`, minus the
-    /// `URLAuthenticationChallenge` wrapping -- both delegate the actual trust-root/SPKI pin
+    /// `URLAuthenticationChallenge` wrapping. Both delegate the actual trust-root/SPKI pin
     /// decision to the shared `Internals.DarwinTrustEvaluation`, and only own what genuinely
     /// differs between them: this evaluator can't call `SecTrustEvaluate(WithError|AsyncWithError)`
-    /// synchronously the way `ServerTrustPolicy` does on `.urlSession`'s own delegate queue --
-    /// evaluation can perform network I/O (OCSP), and blocking the NIO event loop that invokes
-    /// these closures would stall every other connection sharing it -- so it always dispatches onto
-    /// its own dedicated queue first.
+    /// synchronously the way `ServerTrustPolicy` does on `.urlSession`'s own delegate queue,
+    /// since evaluation can perform network I/O (OCSP), and blocking the NIO event loop that
+    /// invokes these closures would stall every other connection sharing it. So it always
+    /// dispatches onto its own dedicated queue first.
     static func makeDarwinEvaluator(
         pins: [Internals.SPKIHash],
         isStrict: Bool,

--- a/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.NIOTrustEvaluator+Darwin.swift
+++ b/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.NIOTrustEvaluator+Darwin.swift
@@ -20,11 +20,13 @@ extension Internals.NIOTrustEvaluator {
     /// Same shape of validation as `Internals.ServerTrustPolicy.handle(challenge:)`, minus the
     /// `URLAuthenticationChallenge` wrapping: evaluate against the OS trust store (so Certificate
     /// Transparency, revocation, and the continuously-updated root set all keep applying exactly as
-    /// they already do for `.urlSession`), then check every certificate in the chain -- leaf and
-    /// intermediates alike -- against the configured pins. A chain-validation failure always
-    /// rejects, regardless of policy; a pin mismatch only rejects under `.strict`, matching
-    /// `ServerTrustPolicy`'s existing semantics (and AsyncHTTPClient's own former SPKI pinning
-    /// policy) exactly.
+    /// they already do for `.urlSession`), then -- when `pins` isn't empty -- check every
+    /// certificate in the chain, leaf and intermediates alike, against the configured pins too. A
+    /// chain-validation failure always rejects, regardless of policy; a pin mismatch only rejects
+    /// under `.strict`, matching `ServerTrustPolicy`'s existing semantics (and AsyncHTTPClient's
+    /// own former SPKI pinning policy) exactly. An empty `pins` means this evaluator exists only
+    /// to feed `trustRootCertificates` into the OS trust store's anchor set (`additionalTrustRoots`
+    /// with no SPKI pinning) -- chain validity is the whole check then, nothing more to enforce.
     static func makeDarwinEvaluator(
         pins: [Internals.SPKIHash],
         isStrict: Bool,
@@ -53,6 +55,16 @@ extension Internals.NIOTrustEvaluator {
             }
         }
 
+        // `pins.isEmpty` means this evaluator was installed for `additionalTrustRoots` alone (see
+        // `resolve(from:)`) -- there's nothing configured to pin against, so chain validity by
+        // itself is the whole check. Without this, `matchesAnyPin` would always be `false` for an
+        // empty pin set and `isStrict` would default to `true`, rejecting every connection
+        // regardless of how trustworthy the chain actually is.
+        @Sendable
+        func passesPinCheck(chain: [SecCertificate]) -> Bool {
+            pins.isEmpty || matchesAnyPin(chain: chain) || !isStrict
+        }
+
         @Sendable
         func evaluate(trust: SecTrust, completion: @escaping @Sendable (Bool) -> Void) {
             if !secTrustRoots.isEmpty {
@@ -68,14 +80,14 @@ extension Internals.NIOTrustEvaluator {
                             return
                         }
                         let chain = (SecTrustCopyCertificateChain(trust) as? [SecCertificate]) ?? []
-                        completion(matchesAnyPin(chain: chain) || !isStrict)
+                        completion(passesPinCheck(chain: chain))
                     }
                 } else {
                     SecTrustEvaluateAsync(trust, queue) { _, result in
                         switch result {
                         case .proceed, .unspecified:
                             let chain = (SecTrustCopyCertificateChain(trust) as? [SecCertificate]) ?? []
-                            completion(matchesAnyPin(chain: chain) || !isStrict)
+                            completion(passesPinCheck(chain: chain))
                         default:
                             completion(false)
                         }

--- a/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.NIOTrustEvaluator+Portable.swift
+++ b/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.NIOTrustEvaluator+Portable.swift
@@ -104,13 +104,55 @@ extension Internals.NIOTrustEvaluator {
         )
     }
 
-    /// A minimal version of NIOSSL's own `LinuxCABundle.swift` search heuristic (file-based paths
-    /// only -- covers Ubuntu/Debian/Arch/Alpine and Fedora) -- kept in sync with NIOSSL's own list
-    /// so pinning on top of the system default trust store resolves the same roots NIOSSL's
-    /// default path would have used.
+    #if os(Android)
+    /// Mirrors NIOSSL's own `AndroidCABundle.swift` search heuristic -- Android ships its trust
+    /// store as a directory of individual PEM certificates, not a single bundle file the way
+    /// Linux/FreeBSD do, so `systemDefaultCertificateStore()` below reads every entry in whichever
+    /// of these is found instead of parsing one path as a single PEM bundle.
+    private static let systemCABundleDirectorySearchPaths = [
+        "/apex/com.android.conscrypt/cacerts",  // Android 14+
+        "/system/etc/security/cacerts",  // < Android 14
+    ]
+
+    private static func systemDefaultCertificateStore() throws -> CertificateStore {
+        // `contentsOfDirectory(atPath:)` itself is the existence/is-a-directory check -- it
+        // throws for a path that's missing, a plain file, or unreadable, so the first path that
+        // doesn't throw is the match, same "first candidate wins" shape as the file-based branch
+        // below.
+        for directory in systemCABundleDirectorySearchPaths {
+            guard let entries = try? FileManager.default.contentsOfDirectory(atPath: directory) else {
+                continue
+            }
+
+            var store = CertificateStore()
+            for entry in entries {
+                guard let certificates = try? NIOSSLCertificate.fromPEMFile(directory + "/" + entry) else {
+                    continue
+                }
+                for certificate in certificates {
+                    if let x509Certificate = try? Certificate(derEncoded: certificate.toDERBytes()) {
+                        store.append(x509Certificate)
+                    }
+                }
+            }
+            return store
+        }
+
+        return CertificateStore()
+    }
+    #else
+    /// A minimal version of NIOSSL's own `LinuxCABundle.swift`/`FreeBSDCABundle.swift` search
+    /// heuristics (file-based paths only) -- kept in sync with NIOSSL's own lists so pinning on
+    /// top of the system default trust store resolves the same roots NIOSSL's default path would
+    /// have used. Windows and WASI have no entry here because NIOSSL's own
+    /// `platformDefaultConfiguration` doesn't load a default trust store on either platform either
+    /// -- there's no NIOSSL-native behavior left to mirror.
     private static let systemCABundleFileSearchPaths = [
-        "/etc/ssl/certs/ca-certificates.crt",
-        "/etc/pki/tls/certs/ca-bundle.crt",
+        "/etc/ssl/certs/ca-certificates.crt",  // Ubuntu, Debian, Arch, Alpine (Linux)
+        "/etc/pki/tls/certs/ca-bundle.crt",  // Fedora (Linux)
+        "/usr/local/etc/ssl/cert.pem",  // openssl / ca_root_nss (FreeBSD)
+        "/etc/ssl/cert.pem",  // base system, FreeBSD 14+
+        "/usr/local/share/certs/ca-root-nss.crt",  // ca_root_nss port bundle (FreeBSD)
     ]
 
     private static func systemDefaultCertificateStore() throws -> CertificateStore {
@@ -130,6 +172,7 @@ extension Internals.NIOTrustEvaluator {
 
         return store
     }
+    #endif
 }
 
 #endif

--- a/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.NIOTrustEvaluator+Portable.swift
+++ b/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.NIOTrustEvaluator+Portable.swift
@@ -29,7 +29,7 @@ extension Internals.NIOTrustEvaluator {
         trustRootCertificates: [NIOSSLCertificate],
         observer: (any TrustDecisionObserver)?
     ) throws -> Internals.NIOTrustEvaluator {
-        // A `let`, fully resolved before the closure below captures it -- a `var` captured across
+        // A `let`, fully resolved before the closure below captures it. A `var` captured across
         // both this `@Sendable` closure and the `Task` nested inside it doesn't satisfy Swift 6
         // concurrency checking, even though nothing ever mutates it again after this point.
         let rootStore: CertificateStore = {
@@ -40,7 +40,7 @@ extension Internals.NIOTrustEvaluator {
                 }
             }
 
-            // No explicit trust roots configured -- fall back to the same distro CA bundle
+            // No explicit trust roots configured; fall back to the same distro CA bundle
             // NIOSSL's own `.default` trust roots would have loaded, so pinning on top of the
             // system default still validates against the system default, not an empty root set.
             if trustRootCertificates.isEmpty {
@@ -94,7 +94,7 @@ extension Internals.NIOTrustEvaluator {
                         promise.succeed(accepted ? .certificateVerified : .failed)
 
                     case .couldNotValidate:
-                        // The chain itself doesn't validate -- always rejects, `.audit` only ever
+                        // The chain itself doesn't validate; always rejects, `.audit` only ever
                         // relaxes a pin mismatch, never a broken chain.
                         observer?(TrustDecision(isTrusted: false, pinsMatched: nil))
                         promise.succeed(.failed)
@@ -115,7 +115,7 @@ extension Internals.NIOTrustEvaluator {
     ]
 
     private static func systemDefaultCertificateStore() throws -> CertificateStore {
-        // `contentsOfDirectory(atPath:)` itself is the existence/is-a-directory check -- it
+        // `contentsOfDirectory(atPath:)` itself is the existence/is-a-directory check; it
         // throws for a path that's missing, a plain file, or unreadable, so the first path that
         // doesn't throw is the match, same "first candidate wins" shape as the file-based branch
         // below.

--- a/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.NIOTrustEvaluator+Portable.swift
+++ b/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.NIOTrustEvaluator+Portable.swift
@@ -1,0 +1,131 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+#if !canImport(Darwin)
+
+import NIOCore
+import NIOSSL
+import SwiftASN1
+import X509
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+
+extension Internals.NIOTrustEvaluator {
+
+    /// Off Darwin there's no `Security.framework` to hand chain-of-trust validation off to, so
+    /// this replicates it with `swift-certificates` -- `RFC5280Policy` for the same category of
+    /// checks NIOSSL's own BoringSSL-backed default path performs (chain building, signature,
+    /// validity period, basic constraints), run *separately* from the SPKI pin check below, so a
+    /// pin mismatch under `.audit` can be told apart from an actual broken chain, which must
+    /// always reject regardless of policy.
+    static func makePortableEvaluator(
+        pins: [Internals.SPKIHash],
+        isStrict: Bool,
+        trustRootCertificates: [NIOSSLCertificate]
+    ) throws -> Internals.NIOTrustEvaluator {
+        // A `let`, fully resolved before the closure below captures it -- a `var` captured across
+        // both this `@Sendable` closure and the `Task` nested inside it doesn't satisfy Swift 6
+        // concurrency checking, even though nothing ever mutates it again after this point.
+        let rootStore: CertificateStore = {
+            var store = CertificateStore()
+            for certificate in trustRootCertificates {
+                if let x509Certificate = try? Certificate(derEncoded: certificate.toDERBytes()) {
+                    store.append(x509Certificate)
+                }
+            }
+
+            // No explicit trust roots configured -- fall back to the same distro CA bundle
+            // NIOSSL's own `.default` trust roots would have loaded, so pinning on top of the
+            // system default still validates against the system default, not an empty root set.
+            if trustRootCertificates.isEmpty {
+                store = (try? Self.systemDefaultCertificateStore()) ?? store
+            }
+
+            return store
+        }()
+
+        return Internals.NIOTrustEvaluator(
+            tlsCustomVerification: { certificates, promise in
+                guard let leafCertificate = certificates.first else {
+                    promise.succeed(.failed)
+                    return
+                }
+
+                guard
+                    let leafDER = try? leafCertificate.toDERBytes(),
+                    let leaf = try? Certificate(derEncoded: leafDER)
+                else {
+                    promise.succeed(.failed)
+                    return
+                }
+
+                var intermediateStore = CertificateStore()
+                for certificate in certificates.dropFirst() {
+                    guard
+                        let der = try? certificate.toDERBytes(),
+                        let intermediate = try? Certificate(derEncoded: der)
+                    else { continue }
+                    intermediateStore.append(intermediate)
+                }
+
+                Task {
+                    var verifier = Verifier(rootCertificates: rootStore) {
+                        RFC5280Policy()
+                    }
+
+                    switch await verifier.validate(leaf: leaf, intermediates: intermediateStore) {
+                    case .validCertificate(let chain):
+                        let matched = chain.contains { certificate in
+                            var serializer = DER.Serializer()
+                            guard (try? certificate.publicKey.serialize(into: &serializer)) != nil else {
+                                return false
+                            }
+                            let spkiDERBytes = Data(serializer.serializedBytes)
+                            return pins.contains { (try? $0.matchesSPKI(spkiDERBytes)) ?? false }
+                        }
+                        promise.succeed((matched || !isStrict) ? .certificateVerified : .failed)
+
+                    case .couldNotValidate:
+                        // The chain itself doesn't validate -- always rejects, `.audit` only ever
+                        // relaxes a pin mismatch, never a broken chain.
+                        promise.succeed(.failed)
+                    }
+                }
+            }
+        )
+    }
+
+    /// A minimal version of NIOSSL's own `LinuxCABundle.swift` search heuristic (file-based paths
+    /// only -- covers Ubuntu/Debian/Arch/Alpine and Fedora) -- kept in sync with NIOSSL's own list
+    /// so pinning on top of the system default trust store resolves the same roots NIOSSL's
+    /// default path would have used.
+    private static let systemCABundleFileSearchPaths = [
+        "/etc/ssl/certs/ca-certificates.crt",
+        "/etc/pki/tls/certs/ca-bundle.crt",
+    ]
+
+    private static func systemDefaultCertificateStore() throws -> CertificateStore {
+        var store = CertificateStore()
+
+        guard
+            let path = systemCABundleFileSearchPaths.first(where: { FileManager.default.fileExists(atPath: $0) })
+        else {
+            return store
+        }
+
+        for certificate in try NIOSSLCertificate.fromPEMFile(path) {
+            if let x509Certificate = try? Certificate(derEncoded: certificate.toDERBytes()) {
+                store.append(x509Certificate)
+            }
+        }
+
+        return store
+    }
+}
+
+#endif

--- a/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.NIOTrustEvaluator+Portable.swift
+++ b/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.NIOTrustEvaluator+Portable.swift
@@ -18,8 +18,8 @@ import Foundation
 extension Internals.NIOTrustEvaluator {
 
     /// Off Darwin there's no `Security.framework` to hand chain-of-trust validation off to, so
-    /// this replicates it with `swift-certificates` -- `RFC5280Policy` for the same category of
-    /// checks NIOSSL's own BoringSSL-backed default path performs (chain building, signature,
+    /// this replicates it with `swift-certificates`, using `RFC5280Policy` for the same category
+    /// of checks NIOSSL's own BoringSSL-backed default path performs (chain building, signature,
     /// validity period, basic constraints), run *separately* from the SPKI pin check below, so a
     /// pin mismatch under `.audit` can be told apart from an actual broken chain, which must
     /// always reject regardless of policy.
@@ -105,7 +105,7 @@ extension Internals.NIOTrustEvaluator {
     }
 
     #if os(Android)
-    /// Mirrors NIOSSL's own `AndroidCABundle.swift` search heuristic -- Android ships its trust
+    /// Mirrors NIOSSL's own `AndroidCABundle.swift` search heuristic. Android ships its trust
     /// store as a directory of individual PEM certificates, not a single bundle file the way
     /// Linux/FreeBSD do, so `systemDefaultCertificateStore()` below reads every entry in whichever
     /// of these is found instead of parsing one path as a single PEM bundle.
@@ -142,11 +142,11 @@ extension Internals.NIOTrustEvaluator {
     }
     #else
     /// A minimal version of NIOSSL's own `LinuxCABundle.swift`/`FreeBSDCABundle.swift` search
-    /// heuristics (file-based paths only) -- kept in sync with NIOSSL's own lists so pinning on
+    /// heuristics (file-based paths only), kept in sync with NIOSSL's own lists so pinning on
     /// top of the system default trust store resolves the same roots NIOSSL's default path would
     /// have used. Windows and WASI have no entry here because NIOSSL's own
-    /// `platformDefaultConfiguration` doesn't load a default trust store on either platform either
-    /// -- there's no NIOSSL-native behavior left to mirror.
+    /// `platformDefaultConfiguration` doesn't load a default trust store on either platform
+    /// either, so there's no NIOSSL-native behavior left to mirror.
     private static let systemCABundleFileSearchPaths = [
         "/etc/ssl/certs/ca-certificates.crt",  // Ubuntu, Debian, Arch, Alpine (Linux)
         "/etc/pki/tls/certs/ca-bundle.crt",  // Fedora (Linux)

--- a/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.NIOTrustEvaluator+Portable.swift
+++ b/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.NIOTrustEvaluator+Portable.swift
@@ -26,7 +26,8 @@ extension Internals.NIOTrustEvaluator {
     static func makePortableEvaluator(
         pins: [Internals.SPKIHash],
         isStrict: Bool,
-        trustRootCertificates: [NIOSSLCertificate]
+        trustRootCertificates: [NIOSSLCertificate],
+        observer: (any TrustDecisionObserver)?
     ) throws -> Internals.NIOTrustEvaluator {
         // A `let`, fully resolved before the closure below captures it -- a `var` captured across
         // both this `@Sendable` closure and the `Task` nested inside it doesn't satisfy Swift 6
@@ -88,11 +89,14 @@ extension Internals.NIOTrustEvaluator {
                             let spkiDERBytes = Data(serializer.serializedBytes)
                             return pins.contains { (try? $0.matchesSPKI(spkiDERBytes)) ?? false }
                         }
-                        promise.succeed((matched || !isStrict) ? .certificateVerified : .failed)
+                        let accepted = matched || !isStrict
+                        observer?(TrustDecision(isTrusted: accepted, pinsMatched: matched))
+                        promise.succeed(accepted ? .certificateVerified : .failed)
 
                     case .couldNotValidate:
                         // The chain itself doesn't validate -- always rejects, `.audit` only ever
                         // relaxes a pin mismatch, never a broken chain.
+                        observer?(TrustDecision(isTrusted: false, pinsMatched: nil))
                         promise.succeed(.failed)
                     }
                 }

--- a/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.NIOTrustEvaluator.swift
+++ b/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.NIOTrustEvaluator.swift
@@ -26,13 +26,16 @@ extension Internals {
     /// `TLSConfiguration.additionalTrustRoots` on its own) stays completely untouched, at no added
     /// cost, for the common case of not pinning.
     ///
-    /// On Darwin, `resolve(from:)` *also* triggers on `additionalTrustRoots` alone, with no pins:
-    /// unlike NIOSSL, Network.framework has no native way to see `additionalTrustRoots` at all
-    /// (see `Internals.SecureConnection`'s own doc comment on `isCompatibleWithNetworkFramework`),
-    /// so closing that gap needs this evaluator's `tlsCustomVerificationNetworkFramework` even
-    /// with an empty pin set -- `evaluate(trust:completion:)` (`+Darwin.swift`) treats an empty
-    /// pin set as "nothing to pin," passing on chain validity alone rather than failing closed the
-    /// way it would for a genuine, configured-but-unmatched pin.
+    /// On Darwin, `resolve(from:)` *also* triggers on `additionalTrustRoots` and/or
+    /// `.noHostnameVerification` alone, with no pins: unlike NIOSSL, Network.framework has no
+    /// native way to see `additionalTrustRoots` at all, and no simple flag to skip hostname
+    /// matching the way NIOSSL's `certificateVerification` does (see `Internals.SecureConnection`'s
+    /// own doc comment on `isCompatibleWithNetworkFramework`) -- both gaps only close through this
+    /// evaluator's `tlsCustomVerificationNetworkFramework`. `evaluate(trust:completion:)`
+    /// (`+Darwin.swift`) treats an empty pin set as "nothing to pin," passing on chain validity
+    /// alone rather than failing closed the way it would for a genuine, configured-but-unmatched
+    /// pin; `makeDarwinEvaluator`'s `skipsHostnameVerification` separately controls whether the
+    /// chain check itself considers the hostname at all.
     package struct NIOTrustEvaluator: Sendable {
 
         /// Installs on `HTTPClient.Configuration.tlsCustomVerification` -- the NIOSSL backend,
@@ -52,7 +55,9 @@ extension Internals {
             let hasAdditionalTrustRoots = !(secureConnection.additionalTrustRoots ?? []).isEmpty
 
             #if canImport(Darwin)
-            guard !tlsPins.isEmpty || hasAdditionalTrustRoots else {
+            let skipsHostnameVerification = secureConnection.certificateVerification == .noHostnameVerification
+
+            guard !tlsPins.isEmpty || hasAdditionalTrustRoots || skipsHostnameVerification else {
                 return nil
             }
             #else
@@ -77,7 +82,8 @@ extension Internals {
             return try Self.makeDarwinEvaluator(
                 pins: tlsPins,
                 isStrict: isStrict,
-                trustRootCertificates: trustRootCertificates
+                trustRootCertificates: trustRootCertificates,
+                skipsHostnameVerification: skipsHostnameVerification
             )
             #else
             return try Self.makePortableEvaluator(

--- a/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.NIOTrustEvaluator.swift
+++ b/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.NIOTrustEvaluator.swift
@@ -21,7 +21,7 @@ extension Internals {
 
     /// Resolves an `Internals.SecureConnection`'s trust roots and SPKI pins into the callbacks
     /// `.nio` needs. Off Darwin, `resolve(from:)` returns `nil` whenever no SPKI pins are
-    /// configured, so the caller can skip installing any custom verification at all -- NIOSSL's
+    /// configured, so the caller can skip installing any custom verification at all. NIOSSL's
     /// own native trust-root handling (plain BoringSSL against the OS CA bundle, already honoring
     /// `TLSConfiguration.additionalTrustRoots` on its own) stays completely untouched, at no added
     /// cost, for the common case of not pinning.
@@ -31,7 +31,7 @@ extension Internals {
     /// Network.framework has no native way to see `additionalTrustRoots` at all, no simple flag to
     /// skip hostname matching the way NIOSSL's `certificateVerification` does (see
     /// `Internals.SecureConnection`'s own doc comment on `isCompatibleWithNetworkFramework`), and no
-    /// revocation-checking or trust-decision-observability hook of its own either -- all four gaps
+    /// revocation-checking or trust-decision-observability hook of its own either; all four gaps
     /// only close through this evaluator's `tlsCustomVerificationNetworkFramework`. The actual
     /// accept/reject decision is `Internals.DarwinTrustEvaluation`'s, shared with
     /// `Internals.ServerTrustPolicy` (`.urlSession`) rather than reimplemented here: an empty pin
@@ -40,13 +40,13 @@ extension Internals {
     /// separately controls whether the chain check itself considers the hostname at all.
     package struct NIOTrustEvaluator: Sendable {
 
-        /// Installs on `HTTPClient.Configuration.tlsCustomVerification` -- the NIOSSL backend,
+        /// Installs on `HTTPClient.Configuration.tlsCustomVerification`, the NIOSSL backend,
         /// used everywhere except direct (non-proxied) connections on Apple platforms.
         package let tlsCustomVerification:
             @Sendable ([NIOSSLCertificate], EventLoopPromise<NIOSSLVerificationResult>) -> Void
 
         #if canImport(Darwin)
-        /// Installs on `HTTPClient.Configuration.tlsCustomVerificationNetworkFramework` -- the
+        /// Installs on `HTTPClient.Configuration.tlsCustomVerificationNetworkFramework`, the
         /// Network.framework backend, used for direct connections on Apple platforms.
         package let tlsCustomVerificationNetworkFramework:
             @Sendable (SecTrust, @escaping @Sendable (Bool) -> Void) -> Void

--- a/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.NIOTrustEvaluator.swift
+++ b/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.NIOTrustEvaluator.swift
@@ -3,7 +3,7 @@
 //
 
 // The `.nio` counterpart to `Internals.ServerTrustPolicy` (which only ever answers `.urlSession`'s
-// `SecTrust`-based challenge). AsyncHTTPClient no longer bundles SPKI pinning -- `tlsPinning`/
+// `SecTrust`-based challenge). AsyncHTTPClient no longer bundles SPKI pinning: `tlsPinning`/
 // `SPKIPinningConfiguration` were removed upstream in the fork's 1.38.0 release, replaced by two
 // thin, policy-free hooks (`HTTPClient.Configuration.tlsCustomVerification` for the NIOSSL backend,
 // `.tlsCustomVerificationNetworkFramework` for the Network.framework one) that let a caller fully

--- a/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.NIOTrustEvaluator.swift
+++ b/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.NIOTrustEvaluator.swift
@@ -31,10 +31,11 @@ extension Internals {
     /// native way to see `additionalTrustRoots` at all, and no simple flag to skip hostname
     /// matching the way NIOSSL's `certificateVerification` does (see `Internals.SecureConnection`'s
     /// own doc comment on `isCompatibleWithNetworkFramework`) -- both gaps only close through this
-    /// evaluator's `tlsCustomVerificationNetworkFramework`. `evaluate(trust:completion:)`
-    /// (`+Darwin.swift`) treats an empty pin set as "nothing to pin," passing on chain validity
-    /// alone rather than failing closed the way it would for a genuine, configured-but-unmatched
-    /// pin; `makeDarwinEvaluator`'s `skipsHostnameVerification` separately controls whether the
+    /// evaluator's `tlsCustomVerificationNetworkFramework`. The actual accept/reject decision is
+    /// `Internals.DarwinTrustEvaluation`'s, shared with `Internals.ServerTrustPolicy`
+    /// (`.urlSession`) rather than reimplemented here: an empty pin set means "nothing to pin,"
+    /// passing on chain validity alone rather than failing closed the way it would for a genuine,
+    /// configured-but-unmatched pin; `skipsHostnameVerification` separately controls whether the
     /// chain check itself considers the hostname at all.
     package struct NIOTrustEvaluator: Sendable {
 

--- a/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.NIOTrustEvaluator.swift
+++ b/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.NIOTrustEvaluator.swift
@@ -58,8 +58,11 @@ extension Internals {
             #if canImport(Darwin)
             let skipsHostnameVerification = secureConnection.certificateVerification == .noHostnameVerification
             let revocationPolicy = secureConnection.revocationPolicy
+            let observer = secureConnection.trustDecisionObserver
 
-            guard !tlsPins.isEmpty || hasAdditionalTrustRoots || skipsHostnameVerification || revocationPolicy != nil
+            guard
+                !tlsPins.isEmpty || hasAdditionalTrustRoots || skipsHostnameVerification || revocationPolicy != nil
+                    || observer != nil
             else {
                 return nil
             }
@@ -67,6 +70,7 @@ extension Internals {
             guard !tlsPins.isEmpty else {
                 return nil
             }
+            let observer = secureConnection.trustDecisionObserver
             #endif
 
             let isStrict = (secureConnection.tlsPinningPolicy ?? .strict) == .strict
@@ -87,13 +91,15 @@ extension Internals {
                 isStrict: isStrict,
                 trustRootCertificates: trustRootCertificates,
                 skipsHostnameVerification: skipsHostnameVerification,
-                revocationPolicy: revocationPolicy
+                revocationPolicy: revocationPolicy,
+                observer: observer
             )
             #else
             return try Self.makePortableEvaluator(
                 pins: tlsPins,
                 isStrict: isStrict,
-                trustRootCertificates: trustRootCertificates
+                trustRootCertificates: trustRootCertificates,
+                observer: observer
             )
             #endif
         }

--- a/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.NIOTrustEvaluator.swift
+++ b/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.NIOTrustEvaluator.swift
@@ -20,11 +20,19 @@ import Security
 extension Internals {
 
     /// Resolves an `Internals.SecureConnection`'s trust roots and SPKI pins into the callbacks
-    /// `.nio` needs. `resolve(from:)` returns `nil` whenever no SPKI pins are configured, so the
-    /// caller can skip installing any custom verification at all -- the TLS backend's own native
-    /// trust-root handling (NIOSSL's BoringSSL/Security.framework-backed default on Darwin, plain
-    /// BoringSSL against the OS CA bundle on Linux) stays completely untouched, at no added cost,
-    /// for the common case of not pinning.
+    /// `.nio` needs. Off Darwin, `resolve(from:)` returns `nil` whenever no SPKI pins are
+    /// configured, so the caller can skip installing any custom verification at all -- NIOSSL's
+    /// own native trust-root handling (plain BoringSSL against the OS CA bundle, already honoring
+    /// `TLSConfiguration.additionalTrustRoots` on its own) stays completely untouched, at no added
+    /// cost, for the common case of not pinning.
+    ///
+    /// On Darwin, `resolve(from:)` *also* triggers on `additionalTrustRoots` alone, with no pins:
+    /// unlike NIOSSL, Network.framework has no native way to see `additionalTrustRoots` at all
+    /// (see `Internals.SecureConnection`'s own doc comment on `isCompatibleWithNetworkFramework`),
+    /// so closing that gap needs this evaluator's `tlsCustomVerificationNetworkFramework` even
+    /// with an empty pin set -- `evaluate(trust:completion:)` (`+Darwin.swift`) treats an empty
+    /// pin set as "nothing to pin," passing on chain validity alone rather than failing closed the
+    /// way it would for a genuine, configured-but-unmatched pin.
     package struct NIOTrustEvaluator: Sendable {
 
         /// Installs on `HTTPClient.Configuration.tlsCustomVerification` -- the NIOSSL backend,
@@ -40,9 +48,18 @@ extension Internals {
         #endif
 
         package static func resolve(from secureConnection: Internals.SecureConnection) throws -> NIOTrustEvaluator? {
-            guard let tlsPins = secureConnection.tlsPins, !tlsPins.isEmpty else {
+            let tlsPins = secureConnection.tlsPins ?? []
+            let hasAdditionalTrustRoots = !(secureConnection.additionalTrustRoots ?? []).isEmpty
+
+            #if canImport(Darwin)
+            guard !tlsPins.isEmpty || hasAdditionalTrustRoots else {
                 return nil
             }
+            #else
+            guard !tlsPins.isEmpty else {
+                return nil
+            }
+            #endif
 
             let isStrict = (secureConnection.tlsPinningPolicy ?? .strict) == .strict
 

--- a/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.NIOTrustEvaluator.swift
+++ b/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.NIOTrustEvaluator.swift
@@ -57,8 +57,10 @@ extension Internals {
 
             #if canImport(Darwin)
             let skipsHostnameVerification = secureConnection.certificateVerification == .noHostnameVerification
+            let revocationPolicy = secureConnection.revocationPolicy
 
-            guard !tlsPins.isEmpty || hasAdditionalTrustRoots || skipsHostnameVerification else {
+            guard !tlsPins.isEmpty || hasAdditionalTrustRoots || skipsHostnameVerification || revocationPolicy != nil
+            else {
                 return nil
             }
             #else
@@ -84,7 +86,8 @@ extension Internals {
                 pins: tlsPins,
                 isStrict: isStrict,
                 trustRootCertificates: trustRootCertificates,
-                skipsHostnameVerification: skipsHostnameVerification
+                skipsHostnameVerification: skipsHostnameVerification,
+                revocationPolicy: revocationPolicy
             )
             #else
             return try Self.makePortableEvaluator(

--- a/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.NIOTrustEvaluator.swift
+++ b/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.NIOTrustEvaluator.swift
@@ -32,8 +32,9 @@ extension Internals {
     /// skip hostname matching the way NIOSSL's `certificateVerification` does (see
     /// `Internals.SecureConnection`'s own doc comment on `isCompatibleWithNetworkFramework`), and no
     /// revocation-checking or trust-decision-observability hook of its own either; all four gaps
-    /// only close through this evaluator's `tlsCustomVerificationNetworkFramework`. The actual
-    /// accept/reject decision is `Internals.DarwinTrustEvaluation`'s, shared with
+    /// only close through this evaluator's `tlsCustomVerificationNetworkFramework`.
+    ///
+    /// The actual accept/reject decision is `Internals.DarwinTrustEvaluation`'s, shared with
     /// `Internals.ServerTrustPolicy` (`.urlSession`) rather than reimplemented here: an empty pin
     /// set means "nothing to pin," passing on chain validity alone rather than failing closed the
     /// way it would for a genuine, configured-but-unmatched pin; `skipsHostnameVerification`

--- a/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.NIOTrustEvaluator.swift
+++ b/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.NIOTrustEvaluator.swift
@@ -1,0 +1,74 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+// The `.nio` counterpart to `Internals.ServerTrustPolicy` (which only ever answers `.urlSession`'s
+// `SecTrust`-based challenge). AsyncHTTPClient no longer bundles SPKI pinning -- `tlsPinning`/
+// `SPKIPinningConfiguration` were removed upstream in the fork's 1.38.0 release, replaced by two
+// thin, policy-free hooks (`HTTPClient.Configuration.tlsCustomVerification` for the NIOSSL backend,
+// `.tlsCustomVerificationNetworkFramework` for the Network.framework one) that let a caller fully
+// own the accept/reject decision. This type is what plugs RequestDL's own trust-root + SPKI pinning
+// logic into those hooks, so `.nio` keeps working exactly as before from a caller's perspective.
+
+import NIOCore
+import NIOSSL
+
+#if canImport(Darwin)
+import Security
+#endif
+
+extension Internals {
+
+    /// Resolves an `Internals.SecureConnection`'s trust roots and SPKI pins into the callbacks
+    /// `.nio` needs. `resolve(from:)` returns `nil` whenever no SPKI pins are configured, so the
+    /// caller can skip installing any custom verification at all -- the TLS backend's own native
+    /// trust-root handling (NIOSSL's BoringSSL/Security.framework-backed default on Darwin, plain
+    /// BoringSSL against the OS CA bundle on Linux) stays completely untouched, at no added cost,
+    /// for the common case of not pinning.
+    package struct NIOTrustEvaluator: Sendable {
+
+        /// Installs on `HTTPClient.Configuration.tlsCustomVerification` -- the NIOSSL backend,
+        /// used everywhere except direct (non-proxied) connections on Apple platforms.
+        package let tlsCustomVerification:
+            @Sendable ([NIOSSLCertificate], EventLoopPromise<NIOSSLVerificationResult>) -> Void
+
+        #if canImport(Darwin)
+        /// Installs on `HTTPClient.Configuration.tlsCustomVerificationNetworkFramework` -- the
+        /// Network.framework backend, used for direct connections on Apple platforms.
+        package let tlsCustomVerificationNetworkFramework:
+            @Sendable (SecTrust, @escaping @Sendable (Bool) -> Void) -> Void
+        #endif
+
+        package static func resolve(from secureConnection: Internals.SecureConnection) throws -> NIOTrustEvaluator? {
+            guard let tlsPins = secureConnection.tlsPins, !tlsPins.isEmpty else {
+                return nil
+            }
+
+            let isStrict = (secureConnection.tlsPinningPolicy ?? .strict) == .strict
+
+            var trustRootCertificates: [NIOSSLCertificate] = []
+            if let trustRoots = secureConnection.trustRoots {
+                trustRootCertificates += try trustRoots.resolvedCertificates()
+            }
+            if let additionalTrustRoots = secureConnection.additionalTrustRoots {
+                for additionalTrustRoot in additionalTrustRoots {
+                    trustRootCertificates += try additionalTrustRoot.resolvedCertificates()
+                }
+            }
+
+            #if canImport(Darwin)
+            return try Self.makeDarwinEvaluator(
+                pins: tlsPins,
+                isStrict: isStrict,
+                trustRootCertificates: trustRootCertificates
+            )
+            #else
+            return try Self.makePortableEvaluator(
+                pins: tlsPins,
+                isStrict: isStrict,
+                trustRootCertificates: trustRootCertificates
+            )
+            #endif
+        }
+    }
+}

--- a/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.NIOTrustEvaluator.swift
+++ b/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.NIOTrustEvaluator.swift
@@ -26,17 +26,18 @@ extension Internals {
     /// `TLSConfiguration.additionalTrustRoots` on its own) stays completely untouched, at no added
     /// cost, for the common case of not pinning.
     ///
-    /// On Darwin, `resolve(from:)` *also* triggers on `additionalTrustRoots` and/or
-    /// `.noHostnameVerification` alone, with no pins: unlike NIOSSL, Network.framework has no
-    /// native way to see `additionalTrustRoots` at all, and no simple flag to skip hostname
-    /// matching the way NIOSSL's `certificateVerification` does (see `Internals.SecureConnection`'s
-    /// own doc comment on `isCompatibleWithNetworkFramework`) -- both gaps only close through this
-    /// evaluator's `tlsCustomVerificationNetworkFramework`. The actual accept/reject decision is
-    /// `Internals.DarwinTrustEvaluation`'s, shared with `Internals.ServerTrustPolicy`
-    /// (`.urlSession`) rather than reimplemented here: an empty pin set means "nothing to pin,"
-    /// passing on chain validity alone rather than failing closed the way it would for a genuine,
-    /// configured-but-unmatched pin; `skipsHostnameVerification` separately controls whether the
-    /// chain check itself considers the hostname at all.
+    /// On Darwin, `resolve(from:)` *also* triggers on `additionalTrustRoots`, `.noHostnameVerification`,
+    /// `revocationPolicy`, or a `trustDecisionObserver`, any one alone with no pins: unlike NIOSSL,
+    /// Network.framework has no native way to see `additionalTrustRoots` at all, no simple flag to
+    /// skip hostname matching the way NIOSSL's `certificateVerification` does (see
+    /// `Internals.SecureConnection`'s own doc comment on `isCompatibleWithNetworkFramework`), and no
+    /// revocation-checking or trust-decision-observability hook of its own either -- all four gaps
+    /// only close through this evaluator's `tlsCustomVerificationNetworkFramework`. The actual
+    /// accept/reject decision is `Internals.DarwinTrustEvaluation`'s, shared with
+    /// `Internals.ServerTrustPolicy` (`.urlSession`) rather than reimplemented here: an empty pin
+    /// set means "nothing to pin," passing on chain validity alone rather than failing closed the
+    /// way it would for a genuine, configured-but-unmatched pin; `skipsHostnameVerification`
+    /// separately controls whether the chain check itself considers the hostname at all.
     package struct NIOTrustEvaluator: Sendable {
 
         /// Installs on `HTTPClient.Configuration.tlsCustomVerification` -- the NIOSSL backend,

--- a/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.RevocationPolicy+Darwin.swift
+++ b/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.RevocationPolicy+Darwin.swift
@@ -13,7 +13,7 @@ extension Internals.RevocationPolicy {
     var secPolicy: SecPolicy {
         // `SecPolicyCreateRevocation` is declared `__nullable` in the SDK header the way every
         // `SecPolicyCreate*` factory is, but never actually returns `NULL` for any combination of
-        // its own documented flags -- there's no invalid combination among
+        // its own documented flags: there's no invalid combination among
         // `kSecRevocation*`'s five bits for it to reject.
         switch self {
         case .strict:

--- a/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.RevocationPolicy+Darwin.swift
+++ b/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.RevocationPolicy+Darwin.swift
@@ -1,0 +1,32 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+#if canImport(Darwin)
+
+import Security
+
+extension Internals.RevocationPolicy {
+
+    /// The `SecPolicyCreateRevocation` policy this case composes onto a `SecTrust`'s policy array,
+    /// via `Internals.DarwinTrustEvaluation.prepare(_:skipsHostnameVerification:)`.
+    var secPolicy: SecPolicy {
+        // `SecPolicyCreateRevocation` is declared `__nullable` in the SDK header the way every
+        // `SecPolicyCreate*` factory is, but never actually returns `NULL` for any combination of
+        // its own documented flags -- there's no invalid combination among
+        // `kSecRevocation*`'s five bits for it to reject.
+        switch self {
+        case .strict:
+            // `kSecRevocationRequirePositiveResponse` is what turns `SecTrust`'s already-automatic,
+            // best-effort revocation check into a hard requirement; `kSecRevocationUseAnyAvailableMethod`
+            // lets the peer's own certificate pick OCSP or CRL rather than forcing one.
+            return SecPolicyCreateRevocation(
+                kSecRevocationUseAnyAvailableMethod | kSecRevocationRequirePositiveResponse
+            )!
+        case .disabled:
+            return SecPolicyCreateRevocation(kSecRevocationNetworkAccessDisabled)!
+        }
+    }
+}
+
+#endif

--- a/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.RevocationPolicy.swift
+++ b/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.RevocationPolicy.swift
@@ -8,10 +8,12 @@ extension Internals {
     /// layered on top of `SecTrust`'s own default check, which already runs automatically on
     /// every evaluation, but only on a best-effort basis: a revocation responder that can't be
     /// reached doesn't fail the handshake. NIOSSL/BoringSSL implements no revocation checking of
-    /// its own, so this has no effect at all off Darwin. `Internals.NIOTrustEvaluator.resolve(
-    /// from:)` only installs the custom verification this rides on when `canImport(Darwin)`, and
-    /// `Internals.DarwinTrustEvaluation` is what both `.urlSession` (`ServerTrustPolicy`) and
-    /// `.nio`/`.nioTransportServices` (`NIOTrustEvaluator`) share it through.
+    /// its own, so this has no effect at all off Darwin.
+    ///
+    /// `Internals.NIOTrustEvaluator.resolve(from:)` only installs the custom verification this
+    /// rides on when `canImport(Darwin)`, and `Internals.DarwinTrustEvaluation` is what both
+    /// `.urlSession` (`ServerTrustPolicy`) and `.nio`/`.nioTransportServices` (`NIOTrustEvaluator`)
+    /// share it through.
     package enum RevocationPolicy: Sendable, Hashable {
 
         /// Requires a definitive, verified positive response from OCSP or CRL before trusting the

--- a/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.RevocationPolicy.swift
+++ b/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.RevocationPolicy.swift
@@ -1,0 +1,32 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+extension Internals {
+
+    /// How strictly a Darwin executor checks a peer certificate's revocation status (OCSP/CRL),
+    /// layered on top of `SecTrust`'s own default check -- which already runs automatically on
+    /// every evaluation, but only on a best-effort basis: a revocation responder that can't be
+    /// reached doesn't fail the handshake. NIOSSL/BoringSSL implements no revocation checking of
+    /// its own, so this has no effect at all off Darwin -- `Internals.NIOTrustEvaluator.resolve(
+    /// from:)` only installs the custom verification this rides on when `canImport(Darwin)`, and
+    /// `Internals.DarwinTrustEvaluation` is what both `.urlSession` (`ServerTrustPolicy`) and
+    /// `.nio`/`.nioTransportServices` (`NIOTrustEvaluator`) share it through.
+    package enum RevocationPolicy: Sendable, Hashable {
+
+        /// Requires a definitive, verified positive response from OCSP or CRL before trusting the
+        /// certificate -- fails the handshake outright if that can't be obtained, including when
+        /// the revocation responder is simply unreachable.
+        case strict
+
+        /// Skips network-based revocation checking (OCSP/CRL fetches) entirely, consulting only
+        /// locally cached responses if any -- never fails a handshake over revocation status.
+        ///
+        /// - Warning: `SecPolicyCreateRevocation`'s `kSecRevocationNetworkAccessDisabled` flag,
+        /// which this rides on, also disallows network access for intermediate CA issuer (AIA)
+        /// fetching, not only revocation checking itself -- a chain that depends on that to
+        /// complete may fail to validate at all under this policy, independent of revocation
+        /// status.
+        case disabled
+    }
+}

--- a/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.RevocationPolicy.swift
+++ b/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.RevocationPolicy.swift
@@ -5,26 +5,26 @@
 extension Internals {
 
     /// How strictly a Darwin executor checks a peer certificate's revocation status (OCSP/CRL),
-    /// layered on top of `SecTrust`'s own default check -- which already runs automatically on
+    /// layered on top of `SecTrust`'s own default check, which already runs automatically on
     /// every evaluation, but only on a best-effort basis: a revocation responder that can't be
     /// reached doesn't fail the handshake. NIOSSL/BoringSSL implements no revocation checking of
-    /// its own, so this has no effect at all off Darwin -- `Internals.NIOTrustEvaluator.resolve(
+    /// its own, so this has no effect at all off Darwin. `Internals.NIOTrustEvaluator.resolve(
     /// from:)` only installs the custom verification this rides on when `canImport(Darwin)`, and
     /// `Internals.DarwinTrustEvaluation` is what both `.urlSession` (`ServerTrustPolicy`) and
     /// `.nio`/`.nioTransportServices` (`NIOTrustEvaluator`) share it through.
     package enum RevocationPolicy: Sendable, Hashable {
 
         /// Requires a definitive, verified positive response from OCSP or CRL before trusting the
-        /// certificate -- fails the handshake outright if that can't be obtained, including when
+        /// certificate, failing the handshake outright if that can't be obtained, including when
         /// the revocation responder is simply unreachable.
         case strict
 
         /// Skips network-based revocation checking (OCSP/CRL fetches) entirely, consulting only
-        /// locally cached responses if any -- never fails a handshake over revocation status.
+        /// locally cached responses if any, and never fails a handshake over revocation status.
         ///
         /// - Warning: `SecPolicyCreateRevocation`'s `kSecRevocationNetworkAccessDisabled` flag,
         /// which this rides on, also disallows network access for intermediate CA issuer (AIA)
-        /// fetching, not only revocation checking itself -- a chain that depends on that to
+        /// fetching, not only revocation checking itself. A chain that depends on that to
         /// complete may fail to validate at all under this policy, independent of revocation
         /// status.
         case disabled

--- a/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.SecureConnection.swift
+++ b/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.SecureConnection.swift
@@ -49,6 +49,7 @@ extension Internals {
         package var additionalTrustRoots: [AdditionalTrustRoots]?
         package var tlsPinningPolicy: Internals.SPKIPinningPolicy?
         package var tlsPins: [SPKIHash]?
+        package var revocationPolicy: Internals.RevocationPolicy?
         package var privateKey: PrivateKeySource?
         package var signingSignatureAlgorithms: [NIOSSL.SignatureAlgorithm]?
         package var verifySignatureAlgorithms: [NIOSSL.SignatureAlgorithm]?
@@ -331,6 +332,7 @@ extension Internals.SecureConnection: Equatable {
             && lhs.cipherSuiteValues == rhs.cipherSuiteValues
             && lhs.tlsPins == rhs.tlsPins
             && lhs.tlsPinningPolicy == rhs.tlsPinningPolicy
+            && lhs.revocationPolicy == rhs.revocationPolicy
     }
 }
 

--- a/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.SecureConnection.swift
+++ b/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.SecureConnection.swift
@@ -26,18 +26,22 @@ extension Internals {
         /// `tlsCustomVerificationNetworkFramework` whenever any one is configured, independently of
         /// whether SPKI pinning is also active, and swaps in a hostname-less policy and/or a
         /// revocation policy on the `SecTrust` it's handed only when those are actually configured
-        /// (`Internals.DarwinTrustEvaluation.prepare(_:skipsHostnameVerification:)`). `build()`'s
-        /// NIOSSL-facing `tlsCustomVerification` stays gated to pins only, since NIOSSL already
-        /// honors both `additionalTrustRoots` and `.noHostnameVerification` natively via
+        /// (`Internals.DarwinTrustEvaluation.prepare(_:skipsHostnameVerification:)`).
+        ///
+        /// `build()`'s NIOSSL-facing `tlsCustomVerification` stays gated to pins only, since NIOSSL
+        /// already honors both `additionalTrustRoots` and `.noHostnameVerification` natively via
         /// `TLSConfiguration` and doesn't need the assist for those two. `revocationPolicy` and
         /// `trustDecisionObserver`, though, still route through it on `.nio` as well, since
         /// NIOSSL/BoringSSL has no revocation checking or trust-decision hook of its own at all.
+        ///
         /// What's genuinely unreachable under Network.framework is `keyLogger` (no
-        /// Network.framework equivalent at all). The rest (`cipherSuiteValues`,
-        /// `renegotiationSupport`, `signingSignatureAlgorithms`, `verifySignatureAlgorithms`,
-        /// `sendCANameList`, `shutdownTimeout`, `pskHint`, `pskIdentityResolver`) aren't rejected
-        /// there at all; they're read from the built `TLSConfiguration` and then never looked at
-        /// again, so the connection silently negotiates without them rather than failing loudly.
+        /// Network.framework equivalent at all).
+        ///
+        /// The rest (`cipherSuiteValues`, `renegotiationSupport`, `signingSignatureAlgorithms`,
+        /// `verifySignatureAlgorithms`, `sendCANameList`, `shutdownTimeout`, `pskHint`,
+        /// `pskIdentityResolver`) aren't rejected there at all; they're read from the built
+        /// `TLSConfiguration` and then never looked at again, so the connection silently negotiates
+        /// without them rather than failing loudly.
         package var isCompatibleWithNetworkFramework: Bool {
             #if canImport(Darwin)
             return networkFrameworkIncompatibilityReasons().isEmpty
@@ -102,10 +106,11 @@ extension Internals {
         /// under Network.framework (see `networkFrameworkIncompatibilityReasons()` above) via
         /// `Internals.NIOTrustEvaluator`/`makeLocalIdentityForNetworkFramework()`, so this list and
         /// that one agree on every field except `keyLogger`, the one genuine
-        /// Network.framework-specific gap. Whether the app actually carries the Keychain Sharing
-        /// entitlement the identity round-trip needs is a runtime fact this static check cannot
-        /// see; a missing entitlement surfaces at identity-build time as its own runtime error, not
-        /// as a reason in this list.
+        /// Network.framework-specific gap.
+        ///
+        /// Whether the app actually carries the Keychain Sharing entitlement the identity
+        /// round-trip needs is a runtime fact this static check cannot see; a missing entitlement
+        /// surfaces at identity-build time as its own runtime error, not as a reason in this list.
         package func urlSessionIncompatibilityReasons() -> [Internals.ExecutorIncompatibilityReason] {
             var reasons: [Internals.ExecutorIncompatibilityReason] = []
 

--- a/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.SecureConnection.swift
+++ b/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.SecureConnection.swift
@@ -2,9 +2,12 @@
 // See LICENSE for this package's licensing information.
 //
 
-import AsyncHTTPClient
 import NIOCore
 import NIOSSL
+
+#if canImport(Darwin)
+import Security
+#endif
 
 extension Internals {
 
@@ -12,17 +15,20 @@ extension Internals {
 
         // MARK: - Internal properties
 
-        /// - Note: Mirrors exactly what AsyncHTTPClient's NIOTransportServices bridge
-        /// (`TLSConfiguration.getNWProtocolTLSOptions`) can carry over into native
-        /// `sec_protocol_options` when running on Network.framework. `certificateChain`,
-        /// `privateKey`, `keyLogger`, and `.noHostnameVerification` trap there via
-        /// `precondition` — reaching this transport with any of them set would crash the
-        /// process, not just silently downgrade. The others listed below (`cipherSuiteValues`,
-        /// `additionalTrustRoots`, `renegotiationSupport`, `signingSignatureAlgorithms`,
+        /// - Note: `certificateChain`/`privateKey` (mTLS, via `tlsLocalIdentityNetworkFramework`)
+        /// and `tlsPins` (SPKI pinning, via `tlsCustomVerificationNetworkFramework`) both reach
+        /// Network.framework now, through the two trust/identity hooks
+        /// `Internals.NIOTrustEvaluator`/`makeLocalIdentityForNetworkFramework()` install. What's
+        /// left genuinely unreachable there: `keyLogger` (no Network.framework equivalent at all)
+        /// and `.noHostnameVerification` (traps via `precondition` unless a custom verification
+        /// callback is also installed -- see `getNWProtocolTLSOptions`). `additionalTrustRoots`
+        /// only reaches Network.framework's *native* trust-root handling when SPKI pinning isn't
+        /// also configured; when it is, `Internals.NIOTrustEvaluator` reads it directly instead.
+        /// The rest (`cipherSuiteValues`, `renegotiationSupport`, `signingSignatureAlgorithms`,
         /// `verifySignatureAlgorithms`, `sendCANameList`, `shutdownTimeout`, `pskHint`,
-        /// `pskIdentityResolver`, `tlsPins`) aren't rejected there at all — they're read from the
-        /// built `TLSConfiguration` and then never looked at again, so the connection would
-        /// silently negotiate without them rather than fail loudly.
+        /// `pskIdentityResolver`) aren't rejected there at all — they're read from the built
+        /// `TLSConfiguration` and then never looked at again, so the connection would silently
+        /// negotiate without them rather than fail loudly.
         package var isCompatibleWithNetworkFramework: Bool {
             #if canImport(Darwin)
             return networkFrameworkIncompatibilityReasons().isEmpty
@@ -36,7 +42,7 @@ extension Internals {
         package var useDefaultTrustRoots: Bool = false
         package var trustRoots: TrustRoots?
         package var additionalTrustRoots: [AdditionalTrustRoots]?
-        package var tlsPinningPolicy: SPKIPinningPolicy?
+        package var tlsPinningPolicy: Internals.SPKIPinningPolicy?
         package var tlsPins: [SPKIHash]?
         package var privateKey: PrivateKeySource?
         package var signingSignatureAlgorithms: [NIOSSL.SignatureAlgorithm]?
@@ -64,16 +70,15 @@ extension Internals {
         package func networkFrameworkIncompatibilityReasons() -> [Internals.ExecutorIncompatibilityReason] {
             var reasons: [Internals.ExecutorIncompatibilityReason] = []
 
-            if certificateChain != nil { reasons.append(.certificateChain) }
-            if privateKey != nil { reasons.append(.privateKey) }
             if keyLogger != nil { reasons.append(.keyLogger) }
             if certificateVerification == .noHostnameVerification {
                 reasons.append(.noHostnameVerificationUnderNetworkFramework)
             }
             if cipherSuites != nil { reasons.append(.cipherSuites) }
             if cipherSuiteValues != nil { reasons.append(.cipherSuiteValues) }
-            if additionalTrustRoots != nil { reasons.append(.additionalTrustRootsUnderNetworkFramework) }
-            if tlsPins != nil { reasons.append(.tlsPinning) }
+            if additionalTrustRoots != nil, tlsPins == nil {
+                reasons.append(.additionalTrustRootsUnderNetworkFramework)
+            }
             if renegotiationSupport != nil { reasons.append(.renegotiationSupport) }
             if signingSignatureAlgorithms != nil { reasons.append(.signingSignatureAlgorithms) }
             if verifySignatureAlgorithms != nil { reasons.append(.verifySignatureAlgorithms) }
@@ -88,15 +93,13 @@ extension Internals {
         /// Deliberately does *not* check `certificateChain`/`privateKey`/`additionalTrustRoots`/
         /// `.noHostnameVerification`/`tlsPins` -- all five are reachable under URLSession, via a
         /// Keychain round-trip (`certificateChain`/`privateKey`) or `SecTrust`/`SecPolicy`
-        /// (everything else), unlike under Network.framework (see
-        /// `networkFrameworkIncompatibilityReasons()` above, where SPKI pinning stays
-        /// incompatible -- it's wired only through `SPKIPinningConfiguration`, which
-        /// AsyncHTTPClient's NIOTransportServices bridge never consults). `Internals.ServerTrustPolicy`
-        /// recomputes each pin's SPKI digest itself from the peer's leaf certificate rather than
-        /// going through `SPKIPinningConfiguration` at all. Whether the app actually carries the
-        /// Keychain Sharing entitlement the identity round-trip needs is a runtime fact this
-        /// static check cannot see; a missing entitlement surfaces at identity-build time as its
-        /// own runtime error, not as a reason in this list.
+        /// (everything else). They're also all reachable under Network.framework now (see
+        /// `networkFrameworkIncompatibilityReasons()` above) via `Internals.NIOTrustEvaluator`/
+        /// `makeLocalIdentityForNetworkFramework()`, so this list and that one agree on every field
+        /// except `.noHostnameVerification` and `keyLogger`, which stay Network.framework-specific
+        /// gaps. Whether the app actually carries the Keychain Sharing entitlement the identity
+        /// round-trip needs is a runtime fact this static check cannot see; a missing entitlement
+        /// surfaces at identity-build time as its own runtime error, not as a reason in this list.
         package func urlSessionIncompatibilityReasons() -> [Internals.ExecutorIncompatibilityReason] {
             var reasons: [Internals.ExecutorIncompatibilityReason] = []
 
@@ -189,10 +192,21 @@ extension Internals {
                 }
             }
 
+            let trustEvaluator = try Internals.NIOTrustEvaluator.resolve(from: self)
+
+            #if canImport(Darwin)
             return try .init(
                 tlsConfiguration: tlsConfiguration,
-                tlsPinning: buildTLSPinning()
+                tlsCustomVerification: trustEvaluator?.tlsCustomVerification,
+                tlsCustomVerificationNetworkFramework: trustEvaluator?.tlsCustomVerificationNetworkFramework,
+                tlsLocalIdentityNetworkFramework: try makeLocalIdentityForNetworkFramework()
             )
+            #else
+            return .init(
+                tlsConfiguration: tlsConfiguration,
+                tlsCustomVerification: trustEvaluator?.tlsCustomVerification
+            )
+            #endif
         }
 
         // MARK: - Private methods
@@ -213,20 +227,43 @@ extension Internals {
             return tlsConfiguration
         }
 
-        private func buildTLSPinning() throws -> SPKIPinningConfiguration? {
-            guard let tlsPins else {
+        #if canImport(Darwin)
+        /// Builds the `SecIdentity` for `HTTPClient.Configuration.tlsLocalIdentityNetworkFramework`
+        /// (mTLS under Network.framework) when both `certificateChain` and `privateKey` are
+        /// configured -- the same Keychain round-trip `Internals.URLSessionIdentityPolicy` already
+        /// uses for `.urlSession`, via the shared `RawBytesIdentityBuilder` entry points.
+        ///
+        /// - Note: Unlike `URLSessionIdentityPolicy`, this doesn't hold on to the returned
+        /// `RawBytesIdentityBuilder.Handle` to remove it again later -- there's no natural place in
+        /// `.nio`'s client lifecycle to call `RawBytesIdentityBuilder.remove(_:)` from (see
+        /// `Internals.Client`'s `deinit`, which only shuts down the underlying `HTTPClient`).
+        /// `makeIdentity`'s Keychain items are labeled deterministically from the certificate's own
+        /// bytes and tolerate being re-added, so this leaves at most one item behind per distinct
+        /// client identity a process configures, rather than growing unbounded.
+        private func makeLocalIdentityForNetworkFramework() throws -> SecIdentity? {
+            switch (certificateChain, privateKey) {
+            case (nil, nil):
                 return nil
-            }
 
-            let pins = try tlsPins.reduce(into: [AsyncHTTPClient.SPKIHash]()) {
-                try $1.resolve(&$0)
-            }
+            case (.some(let certificateChain), .some(let privateKey)):
+                let derCertificates = try RawBytesIdentityBuilder.certificateDERs(from: certificateChain)
 
-            return .init(
-                pins: pins,
-                policy: tlsPinningPolicy ?? .strict
-            )
+                guard let leaf = derCertificates.first else {
+                    throw Internals.URLSessionIdentityPolicy.ConfigurationError.emptyCertificateChain
+                }
+
+                let privateKeyDER = try RawBytesIdentityBuilder.privateKeyDER(from: privateKey)
+
+                return try RawBytesIdentityBuilder.makeIdentity(
+                    certificateDER: leaf,
+                    privateKeyDER: privateKeyDER
+                ).identity
+
+            case (.some, nil), (nil, .some):
+                throw Internals.URLSessionIdentityPolicy.ConfigurationError.incompleteClientIdentity
+            }
         }
+        #endif
     }
 }
 
@@ -265,6 +302,22 @@ extension Internals.SecureConnection {
 
     package struct Output: Sendable {
         package let tlsConfiguration: TLSConfiguration
-        package let tlsPinning: SPKIPinningConfiguration?
+
+        /// Installs on `HTTPClient.Configuration.tlsCustomVerification` when SPKI pinning is
+        /// configured -- `nil` otherwise, leaving the NIOSSL backend's own native trust-root
+        /// handling completely untouched.
+        package let tlsCustomVerification:
+            (@Sendable ([NIOSSLCertificate], EventLoopPromise<NIOSSLVerificationResult>) -> Void)?
+
+        #if canImport(Darwin)
+        /// Installs on `HTTPClient.Configuration.tlsCustomVerificationNetworkFramework` when SPKI
+        /// pinning is configured.
+        package let tlsCustomVerificationNetworkFramework:
+            (@Sendable (SecTrust, @escaping @Sendable (Bool) -> Void) -> Void)?
+
+        /// Installs on `HTTPClient.Configuration.tlsLocalIdentityNetworkFramework` when both
+        /// `certificateChain` and `privateKey` are configured (mTLS).
+        package let tlsLocalIdentityNetworkFramework: SecIdentity?
+        #endif
     }
 }

--- a/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.SecureConnection.swift
+++ b/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.SecureConnection.swift
@@ -370,7 +370,7 @@ extension Internals.SecureConnection {
         /// The Keychain-backed identity for mTLS under Network.framework, when both
         /// `certificateChain` and `privateKey` are configured. Carries `.identity` for
         /// `HTTPClient.Configuration.tlsLocalIdentityNetworkFramework`; whoever ends up owning
-        /// this (`Internals.Client`, currently) just needs to hold onto it -- its own `deinit`
+        /// this (`Internals.Client`, currently) just needs to hold onto it. Its own `deinit`
         /// releases the underlying Keychain items once nothing else references them.
         package let localIdentityHandle: Internals.IdentityHandle?
         #endif

--- a/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.SecureConnection.swift
+++ b/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.SecureConnection.swift
@@ -16,23 +16,24 @@ extension Internals {
         // MARK: - Internal properties
 
         /// - Note: `certificateChain`/`privateKey` (mTLS, via `tlsLocalIdentityNetworkFramework`),
-        /// `tlsPins` (SPKI pinning), and `additionalTrustRoots` all reach Network.framework now,
-        /// through the two trust/identity hooks `Internals.NIOTrustEvaluator`/
-        /// `makeLocalIdentityForNetworkFramework()` install. `additionalTrustRoots` has no native
-        /// Network.framework counterpart at all (unlike `trustRoots`, which `getNWProtocolTLSOptions`
-        /// does carry over) -- `Internals.NIOTrustEvaluator` is what makes it work there, installing
-        /// `tlsCustomVerificationNetworkFramework` whenever `additionalTrustRoots` is configured,
-        /// independently of whether SPKI pinning is also active (`build()`'s NIOSSL-facing
-        /// `tlsCustomVerification` stays gated to pins only, since NIOSSL already honors
-        /// `additionalTrustRoots` natively via `TLSConfiguration` and doesn't need the assist).
-        /// What's left genuinely unreachable under Network.framework: `keyLogger` (no
-        /// Network.framework equivalent at all) and `.noHostnameVerification` (traps via
-        /// `precondition` unless a custom verification callback is also installed -- see
-        /// `getNWProtocolTLSOptions`). The rest (`cipherSuiteValues`, `renegotiationSupport`,
-        /// `signingSignatureAlgorithms`, `verifySignatureAlgorithms`, `sendCANameList`,
-        /// `shutdownTimeout`, `pskHint`, `pskIdentityResolver`) aren't rejected there at all —
-        /// they're read from the built `TLSConfiguration` and then never looked at again, so the
-        /// connection would silently negotiate without them rather than fail loudly.
+        /// `tlsPins` (SPKI pinning), `additionalTrustRoots`, and `.noHostnameVerification` all reach
+        /// Network.framework now, through the two trust/identity hooks `Internals.NIOTrustEvaluator`/
+        /// `makeLocalIdentityForNetworkFramework()` install. Neither `additionalTrustRoots` nor
+        /// `.noHostnameVerification` has a native Network.framework counterpart (unlike `trustRoots`,
+        /// which `getNWProtocolTLSOptions` does carry over, or NIOSSL's own `certificateVerification`
+        /// flag) -- `Internals.NIOTrustEvaluator` is what makes both work there, installing
+        /// `tlsCustomVerificationNetworkFramework` whenever either is configured, independently of
+        /// whether SPKI pinning is also active, and swapping in a hostname-less policy on the
+        /// `SecTrust` it's handed only when `.noHostnameVerification` was actually asked for
+        /// (`makeDarwinEvaluator`'s `skipsHostnameVerification`). `build()`'s NIOSSL-facing
+        /// `tlsCustomVerification` stays gated to pins only, since NIOSSL already honors both
+        /// `additionalTrustRoots` and `.noHostnameVerification` natively via `TLSConfiguration` and
+        /// doesn't need the assist. What's left genuinely unreachable under Network.framework:
+        /// `keyLogger` (no Network.framework equivalent at all). The rest (`cipherSuiteValues`,
+        /// `renegotiationSupport`, `signingSignatureAlgorithms`, `verifySignatureAlgorithms`,
+        /// `sendCANameList`, `shutdownTimeout`, `pskHint`, `pskIdentityResolver`) aren't rejected
+        /// there at all — they're read from the built `TLSConfiguration` and then never looked at
+        /// again, so the connection would silently negotiate without them rather than fail loudly.
         package var isCompatibleWithNetworkFramework: Bool {
             #if canImport(Darwin)
             return networkFrameworkIncompatibilityReasons().isEmpty
@@ -75,9 +76,6 @@ extension Internals {
             var reasons: [Internals.ExecutorIncompatibilityReason] = []
 
             if keyLogger != nil { reasons.append(.keyLogger) }
-            if certificateVerification == .noHostnameVerification {
-                reasons.append(.noHostnameVerificationUnderNetworkFramework)
-            }
             if cipherSuites != nil { reasons.append(.cipherSuites) }
             if cipherSuiteValues != nil { reasons.append(.cipherSuiteValues) }
             if renegotiationSupport != nil { reasons.append(.renegotiationSupport) }
@@ -96,11 +94,11 @@ extension Internals {
         /// Keychain round-trip (`certificateChain`/`privateKey`) or `SecTrust`/`SecPolicy`
         /// (everything else). They're also all reachable under Network.framework now (see
         /// `networkFrameworkIncompatibilityReasons()` above) via `Internals.NIOTrustEvaluator`/
-        /// `makeLocalIdentityForNetworkFramework()`, so this list and that one agree on every field
-        /// except `.noHostnameVerification` and `keyLogger`, which stay Network.framework-specific
-        /// gaps. Whether the app actually carries the Keychain Sharing entitlement the identity
-        /// round-trip needs is a runtime fact this static check cannot see; a missing entitlement
-        /// surfaces at identity-build time as its own runtime error, not as a reason in this list.
+        /// `makeLocalIdentityForNetworkFramework()`, so this list and that one now agree on every
+        /// field except `keyLogger`, the one still-genuine Network.framework-specific gap. Whether
+        /// the app actually carries the Keychain Sharing entitlement the identity round-trip needs
+        /// is a runtime fact this static check cannot see; a missing entitlement surfaces at
+        /// identity-build time as its own runtime error, not as a reason in this list.
         package func urlSessionIncompatibilityReasons() -> [Internals.ExecutorIncompatibilityReason] {
             var reasons: [Internals.ExecutorIncompatibilityReason] = []
 

--- a/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.SecureConnection.swift
+++ b/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.SecureConnection.swift
@@ -16,24 +16,28 @@ extension Internals {
         // MARK: - Internal properties
 
         /// - Note: `certificateChain`/`privateKey` (mTLS, via `tlsLocalIdentityNetworkFramework`),
-        /// `tlsPins` (SPKI pinning), `additionalTrustRoots`, and `.noHostnameVerification` all reach
-        /// Network.framework, through the two trust/identity hooks `Internals.NIOTrustEvaluator`/
-        /// `makeLocalIdentityForNetworkFramework()` install. Neither `additionalTrustRoots` nor
-        /// `.noHostnameVerification` has a native Network.framework counterpart (unlike `trustRoots`,
+        /// `tlsPins` (SPKI pinning), `additionalTrustRoots`, `.noHostnameVerification`,
+        /// `revocationPolicy`, and `trustDecisionObserver` all reach Network.framework, through the
+        /// two trust/identity hooks `Internals.NIOTrustEvaluator`/`makeLocalIdentityForNetworkFramework()`
+        /// install. None of `additionalTrustRoots`/`.noHostnameVerification`/`revocationPolicy`/
+        /// `trustDecisionObserver` has a native Network.framework counterpart (unlike `trustRoots`,
         /// which `getNWProtocolTLSOptions` does carry over, or NIOSSL's own `certificateVerification`
-        /// flag) -- `Internals.NIOTrustEvaluator` is what makes both work there: it installs
-        /// `tlsCustomVerificationNetworkFramework` whenever either is configured, independently of
-        /// whether SPKI pinning is also active, and swaps in a hostname-less policy on the
-        /// `SecTrust` it's handed only when `.noHostnameVerification` is actually configured
-        /// (`makeDarwinEvaluator`'s `skipsHostnameVerification`). `build()`'s NIOSSL-facing
-        /// `tlsCustomVerification` stays gated to pins only, since NIOSSL already honors both
-        /// `additionalTrustRoots` and `.noHostnameVerification` natively via `TLSConfiguration` and
-        /// doesn't need the assist. What's genuinely unreachable under Network.framework:
-        /// `keyLogger` (no Network.framework equivalent at all). The rest (`cipherSuiteValues`,
-        /// `renegotiationSupport`, `signingSignatureAlgorithms`, `verifySignatureAlgorithms`,
-        /// `sendCANameList`, `shutdownTimeout`, `pskHint`, `pskIdentityResolver`) aren't rejected
-        /// there at all — they're read from the built `TLSConfiguration` and then never looked at
-        /// again, so the connection silently negotiates without them rather than failing loudly.
+        /// flag) -- `Internals.NIOTrustEvaluator` is what makes all four work there: it installs
+        /// `tlsCustomVerificationNetworkFramework` whenever any one is configured, independently of
+        /// whether SPKI pinning is also active, and swaps in a hostname-less policy and/or a
+        /// revocation policy on the `SecTrust` it's handed only when those are actually configured
+        /// (`Internals.DarwinTrustEvaluation.prepare(_:skipsHostnameVerification:)`). `build()`'s
+        /// NIOSSL-facing `tlsCustomVerification` stays gated to pins only, since NIOSSL already
+        /// honors both `additionalTrustRoots` and `.noHostnameVerification` natively via
+        /// `TLSConfiguration` and doesn't need the assist for those two -- `revocationPolicy` and
+        /// `trustDecisionObserver` still route through it on `.nio` too, since NIOSSL/BoringSSL has
+        /// no revocation checking or trust-decision hook of its own at all. What's genuinely
+        /// unreachable under Network.framework: `keyLogger` (no Network.framework equivalent at
+        /// all). The rest (`cipherSuiteValues`, `renegotiationSupport`, `signingSignatureAlgorithms`,
+        /// `verifySignatureAlgorithms`, `sendCANameList`, `shutdownTimeout`, `pskHint`,
+        /// `pskIdentityResolver`) aren't rejected there at all — they're read from the built
+        /// `TLSConfiguration` and then never looked at again, so the connection silently negotiates
+        /// without them rather than failing loudly.
         package var isCompatibleWithNetworkFramework: Bool {
             #if canImport(Darwin)
             return networkFrameworkIncompatibilityReasons().isEmpty
@@ -92,15 +96,16 @@ extension Internals {
         }
 
         /// Deliberately does *not* check `certificateChain`/`privateKey`/`additionalTrustRoots`/
-        /// `.noHostnameVerification`/`tlsPins` -- all five are reachable under URLSession, via a
-        /// Keychain round-trip (`certificateChain`/`privateKey`) or `SecTrust`/`SecPolicy`
-        /// (everything else). They're also all reachable under Network.framework (see
-        /// `networkFrameworkIncompatibilityReasons()` above) via `Internals.NIOTrustEvaluator`/
-        /// `makeLocalIdentityForNetworkFramework()`, so this list and that one agree on every
-        /// field except `keyLogger`, the one genuine Network.framework-specific gap. Whether
-        /// the app actually carries the Keychain Sharing entitlement the identity round-trip needs
-        /// is a runtime fact this static check cannot see; a missing entitlement surfaces at
-        /// identity-build time as its own runtime error, not as a reason in this list.
+        /// `.noHostnameVerification`/`tlsPins`/`revocationPolicy`/`trustDecisionObserver` -- all
+        /// seven are reachable under URLSession, via a Keychain round-trip (`certificateChain`/
+        /// `privateKey`) or `SecTrust`/`SecPolicy` (everything else). They're also all reachable
+        /// under Network.framework (see `networkFrameworkIncompatibilityReasons()` above) via
+        /// `Internals.NIOTrustEvaluator`/`makeLocalIdentityForNetworkFramework()`, so this list and
+        /// that one agree on every field except `keyLogger`, the one genuine
+        /// Network.framework-specific gap. Whether the app actually carries the Keychain Sharing
+        /// entitlement the identity round-trip needs is a runtime fact this static check cannot
+        /// see; a missing entitlement surfaces at identity-build time as its own runtime error, not
+        /// as a reason in this list.
         package func urlSessionIncompatibilityReasons() -> [Internals.ExecutorIncompatibilityReason] {
             var reasons: [Internals.ExecutorIncompatibilityReason] = []
 

--- a/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.SecureConnection.swift
+++ b/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.SecureConnection.swift
@@ -279,16 +279,18 @@ extension Internals {
         }
 
         #if canImport(Darwin)
-        /// Builds the `RawBytesIdentityBuilder.Handle` for mTLS under Network.framework when both
+        /// Builds the `Internals.IdentityHandle` for mTLS under Network.framework when both
         /// `certificateChain` and `privateKey` are configured, via the same Keychain round-trip
         /// `Internals.URLSessionIdentityPolicy` already uses for `.urlSession`, through the shared
         /// `RawBytesIdentityBuilder` entry points.
         ///
-        /// Returns the whole `Handle`, not just its `.identity`. `Internals.Client` holds onto it
-        /// and calls `RawBytesIdentityBuilder.remove(_:)` from its own `deinit`, mirroring
-        /// `URLSessionIdentityPolicy`'s lifecycle exactly, just one layer further down the chain
-        /// (`Output` -> `Internals.Session.Configuration.Output` -> `Internals.Client`).
-        private func makeLocalIdentityForNetworkFramework() throws -> Internals.RawBytesIdentityBuilder.Handle? {
+        /// Returns the whole `Internals.IdentityHandle`, not just its `.identity`.
+        /// `Internals.Client` holds onto it, one layer further down the chain (`Output` ->
+        /// `Internals.Session.Configuration.Output` -> `Internals.Client`); its own `deinit`
+        /// releases the handle automatically, deleting the underlying Keychain items only once
+        /// every other live handle for the same certificate/key pair (e.g. a
+        /// `URLSessionIdentityPolicy` instance sharing the same mTLS identity) has gone away too.
+        private func makeLocalIdentityForNetworkFramework() throws -> Internals.IdentityHandle? {
             switch (certificateChain, privateKey) {
             case (nil, nil):
                 return nil
@@ -367,10 +369,10 @@ extension Internals.SecureConnection {
 
         /// The Keychain-backed identity for mTLS under Network.framework, when both
         /// `certificateChain` and `privateKey` are configured. Carries `.identity` for
-        /// `HTTPClient.Configuration.tlsLocalIdentityNetworkFramework` *and* the Keychain-item
-        /// label needed to remove it again, since whoever ends up owning this identity's lifetime
-        /// (`Internals.Client`, currently) needs both.
-        package let localIdentityHandle: Internals.RawBytesIdentityBuilder.Handle?
+        /// `HTTPClient.Configuration.tlsLocalIdentityNetworkFramework`; whoever ends up owning
+        /// this (`Internals.Client`, currently) just needs to hold onto it -- its own `deinit`
+        /// releases the underlying Keychain items once nothing else references them.
+        package let localIdentityHandle: Internals.IdentityHandle?
         #endif
     }
 }

--- a/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.SecureConnection.swift
+++ b/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.SecureConnection.swift
@@ -50,6 +50,7 @@ extension Internals {
         package var tlsPinningPolicy: Internals.SPKIPinningPolicy?
         package var tlsPins: [SPKIHash]?
         package var revocationPolicy: Internals.RevocationPolicy?
+        package var trustDecisionObserver: (any TrustDecisionObserver)?
         package var privateKey: PrivateKeySource?
         package var signingSignatureAlgorithms: [NIOSSL.SignatureAlgorithm]?
         package var verifySignatureAlgorithms: [NIOSSL.SignatureAlgorithm]?
@@ -333,6 +334,7 @@ extension Internals.SecureConnection: Equatable {
             && lhs.tlsPins == rhs.tlsPins
             && lhs.tlsPinningPolicy == rhs.tlsPinningPolicy
             && lhs.revocationPolicy == rhs.revocationPolicy
+            && lhs.trustDecisionObserver === rhs.trustDecisionObserver
     }
 }
 

--- a/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.SecureConnection.swift
+++ b/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.SecureConnection.swift
@@ -117,7 +117,15 @@ extension Internals {
             return reasons
         }
 
-        package func build() throws -> Output {
+        /// - Parameter isCompatibleWithNetworkFramework: Whether the caller is actually going to
+        /// run this over Network.framework. When `false`, skips `makeLocalIdentityForNetworkFramework()`
+        /// entirely rather than performing its Keychain round-trip only to hand back a handle
+        /// nothing will use -- e.g. a `.nio` (plain-socket) client has no use for a Network.framework
+        /// identity, and shouldn't need Keychain Sharing entitlement (or a working Keychain at
+        /// all) just because `certificateChain`/`privateKey` happen to be configured for some
+        /// other executor's mTLS. Defaults to `true`, matching this method's original unconditional
+        /// behavior, for callers that don't know or don't care which executor will consume this.
+        package func build(isCompatibleWithNetworkFramework: Bool = true) throws -> Output {
             var tlsConfiguration = try makeTLSConfigurationByContext()
 
             if let minimumTLSVersion {
@@ -195,11 +203,11 @@ extension Internals {
             let trustEvaluator = try Internals.NIOTrustEvaluator.resolve(from: self)
 
             #if canImport(Darwin)
-            return try .init(
+            return .init(
                 tlsConfiguration: tlsConfiguration,
                 tlsCustomVerification: trustEvaluator?.tlsCustomVerification,
                 tlsCustomVerificationNetworkFramework: trustEvaluator?.tlsCustomVerificationNetworkFramework,
-                localIdentityHandle: try makeLocalIdentityForNetworkFramework()
+                localIdentityHandle: isCompatibleWithNetworkFramework ? try makeLocalIdentityForNetworkFramework() : nil
             )
             #else
             return .init(

--- a/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.SecureConnection.swift
+++ b/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.SecureConnection.swift
@@ -111,6 +111,13 @@ extension Internals {
         /// Whether the app actually carries the Keychain Sharing entitlement the identity
         /// round-trip needs is a runtime fact this static check cannot see; a missing entitlement
         /// surfaces at identity-build time as its own runtime error, not as a reason in this list.
+        ///
+        /// Also deliberately does *not* check `minimumTLSVersion`, unlike its sibling
+        /// `maximumTLSVersion` right below. `minimumTLSVersion` has a real, reachable equivalent
+        /// under URLSession (an ATS `NSExceptionMinimumTLSVersion` entry in the app's Info.plist),
+        /// so flagging it here would push callers off `.urlSession` even when they have a working
+        /// alternative. `maximumTLSVersion` and `applicationProtocols` have no such alternative;
+        /// there is no ATS key for either, so those *are* flagged.
         package func urlSessionIncompatibilityReasons() -> [Internals.ExecutorIncompatibilityReason] {
             var reasons: [Internals.ExecutorIncompatibilityReason] = []
 
@@ -124,6 +131,8 @@ extension Internals {
             if keyLogger != nil { reasons.append(.keyLogger) }
             if cipherSuites != nil { reasons.append(.cipherSuites) }
             if cipherSuiteValues != nil { reasons.append(.cipherSuiteValues) }
+            if maximumTLSVersion != nil { reasons.append(.maximumTLSVersionUnderURLSession) }
+            if applicationProtocols != nil { reasons.append(.applicationProtocolsUnderURLSession) }
 
             return reasons
         }

--- a/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.SecureConnection.swift
+++ b/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.SecureConnection.swift
@@ -22,22 +22,22 @@ extension Internals {
         /// install. None of `additionalTrustRoots`/`.noHostnameVerification`/`revocationPolicy`/
         /// `trustDecisionObserver` has a native Network.framework counterpart (unlike `trustRoots`,
         /// which `getNWProtocolTLSOptions` does carry over, or NIOSSL's own `certificateVerification`
-        /// flag) -- `Internals.NIOTrustEvaluator` is what makes all four work there: it installs
+        /// flag). `Internals.NIOTrustEvaluator` is what makes all four work there: it installs
         /// `tlsCustomVerificationNetworkFramework` whenever any one is configured, independently of
         /// whether SPKI pinning is also active, and swaps in a hostname-less policy and/or a
         /// revocation policy on the `SecTrust` it's handed only when those are actually configured
         /// (`Internals.DarwinTrustEvaluation.prepare(_:skipsHostnameVerification:)`). `build()`'s
         /// NIOSSL-facing `tlsCustomVerification` stays gated to pins only, since NIOSSL already
         /// honors both `additionalTrustRoots` and `.noHostnameVerification` natively via
-        /// `TLSConfiguration` and doesn't need the assist for those two -- `revocationPolicy` and
-        /// `trustDecisionObserver` still route through it on `.nio` too, since NIOSSL/BoringSSL has
-        /// no revocation checking or trust-decision hook of its own at all. What's genuinely
-        /// unreachable under Network.framework: `keyLogger` (no Network.framework equivalent at
-        /// all). The rest (`cipherSuiteValues`, `renegotiationSupport`, `signingSignatureAlgorithms`,
-        /// `verifySignatureAlgorithms`, `sendCANameList`, `shutdownTimeout`, `pskHint`,
-        /// `pskIdentityResolver`) aren't rejected there at all — they're read from the built
-        /// `TLSConfiguration` and then never looked at again, so the connection silently negotiates
-        /// without them rather than failing loudly.
+        /// `TLSConfiguration` and doesn't need the assist for those two. `revocationPolicy` and
+        /// `trustDecisionObserver`, though, still route through it on `.nio` as well, since
+        /// NIOSSL/BoringSSL has no revocation checking or trust-decision hook of its own at all.
+        /// What's genuinely unreachable under Network.framework is `keyLogger` (no
+        /// Network.framework equivalent at all). The rest (`cipherSuiteValues`,
+        /// `renegotiationSupport`, `signingSignatureAlgorithms`, `verifySignatureAlgorithms`,
+        /// `sendCANameList`, `shutdownTimeout`, `pskHint`, `pskIdentityResolver`) aren't rejected
+        /// there at all; they're read from the built `TLSConfiguration` and then never looked at
+        /// again, so the connection silently negotiates without them rather than failing loudly.
         package var isCompatibleWithNetworkFramework: Bool {
             #if canImport(Darwin)
             return networkFrameworkIncompatibilityReasons().isEmpty
@@ -76,7 +76,7 @@ extension Internals {
 
         // MARK: - Internal methods
 
-        /// Backs `isCompatibleWithNetworkFramework` above -- single source of truth instead of
+        /// Backs `isCompatibleWithNetworkFramework` above: a single source of truth instead of
         /// two lists that can drift apart again the way the original 4-field check did.
         package func networkFrameworkIncompatibilityReasons() -> [Internals.ExecutorIncompatibilityReason] {
             var reasons: [Internals.ExecutorIncompatibilityReason] = []
@@ -96,7 +96,7 @@ extension Internals {
         }
 
         /// Deliberately does *not* check `certificateChain`/`privateKey`/`additionalTrustRoots`/
-        /// `.noHostnameVerification`/`tlsPins`/`revocationPolicy`/`trustDecisionObserver` -- all
+        /// `.noHostnameVerification`/`tlsPins`/`revocationPolicy`/`trustDecisionObserver`; all
         /// seven are reachable under URLSession, via a Keychain round-trip (`certificateChain`/
         /// `privateKey`) or `SecTrust`/`SecPolicy` (everything else). They're also all reachable
         /// under Network.framework (see `networkFrameworkIncompatibilityReasons()` above) via
@@ -127,13 +127,13 @@ extension Internals {
         /// run this over Network.framework. Cuts both ways:
         ///
         ///   - When `false`, skips `makeLocalIdentityForNetworkFramework()` entirely rather than
-        ///     performing its Keychain round-trip only to hand back a handle nothing will use --
-        ///     e.g. a `.nio` (plain-socket) client has no use for a Network.framework identity, and
-        ///     shouldn't need Keychain Sharing entitlement (or a working Keychain at all) just
-        ///     because `certificateChain`/`privateKey` happen to be configured for some other
-        ///     executor's mTLS.
+        ///     performing its Keychain round-trip only to hand back a handle nothing will use. A
+        ///     `.nio` (plain-socket) client, for example, has no use for a Network.framework
+        ///     identity, and shouldn't need Keychain Sharing entitlement (or a working Keychain at
+        ///     all) just because `certificateChain`/`privateKey` happen to be configured for some
+        ///     other executor's mTLS.
         ///   - When `true`, `makeTLSConfigurationByContext()` below leaves `certificateChain`/
-        ///     `privateKey` off the returned `TLSConfiguration` entirely -- mTLS travels through
+        ///     `privateKey` off the returned `TLSConfiguration` entirely. mTLS travels through
         ///     `tlsLocalIdentityNetworkFramework`/`localIdentityHandle` for Network.framework
         ///     instead, and leaving both set on the same `TLSConfiguration` this build also hands
         ///     to `HTTPClient.Configuration` is fatal, not just redundant: AsyncHTTPClient's
@@ -248,7 +248,7 @@ extension Internals {
         // MARK: - Private methods
 
         /// - Parameter isCompatibleWithNetworkFramework: See `build(isCompatibleWithNetworkFramework:)`'s
-        /// own doc comment -- when `true`, `certificateChain`/`privateKey` are deliberately left off
+        /// own doc comment. When `true`, `certificateChain`/`privateKey` are deliberately left off
         /// the returned `TLSConfiguration`. mTLS still travels through
         /// `tlsLocalIdentityNetworkFramework`/`localIdentityHandle` (`makeLocalIdentityForNetworkFramework()`)
         /// for Network.framework; setting these two *as well*, on the same `TLSConfiguration`
@@ -275,11 +275,11 @@ extension Internals {
 
         #if canImport(Darwin)
         /// Builds the `RawBytesIdentityBuilder.Handle` for mTLS under Network.framework when both
-        /// `certificateChain` and `privateKey` are configured -- the same Keychain round-trip
-        /// `Internals.URLSessionIdentityPolicy` already uses for `.urlSession`, via the shared
+        /// `certificateChain` and `privateKey` are configured, via the same Keychain round-trip
+        /// `Internals.URLSessionIdentityPolicy` already uses for `.urlSession`, through the shared
         /// `RawBytesIdentityBuilder` entry points.
         ///
-        /// Returns the whole `Handle`, not just its `.identity` -- `Internals.Client` holds onto it
+        /// Returns the whole `Handle`, not just its `.identity`. `Internals.Client` holds onto it
         /// and calls `RawBytesIdentityBuilder.remove(_:)` from its own `deinit`, mirroring
         /// `URLSessionIdentityPolicy`'s lifecycle exactly, just one layer further down the chain
         /// (`Output` -> `Internals.Session.Configuration.Output` -> `Internals.Client`).
@@ -349,8 +349,8 @@ extension Internals.SecureConnection {
         package let tlsConfiguration: TLSConfiguration
 
         /// Installs on `HTTPClient.Configuration.tlsCustomVerification` when SPKI pinning is
-        /// configured -- `nil` otherwise, leaving the NIOSSL backend's own native trust-root
-        /// handling completely untouched.
+        /// configured, and stays `nil` otherwise, leaving the NIOSSL backend's own native
+        /// trust-root handling completely untouched.
         package let tlsCustomVerification:
             (@Sendable ([NIOSSLCertificate], EventLoopPromise<NIOSSLVerificationResult>) -> Void)?
 
@@ -361,7 +361,7 @@ extension Internals.SecureConnection {
             (@Sendable (SecTrust, @escaping @Sendable (Bool) -> Void) -> Void)?
 
         /// The Keychain-backed identity for mTLS under Network.framework, when both
-        /// `certificateChain` and `privateKey` are configured -- carries `.identity` for
+        /// `certificateChain` and `privateKey` are configured. Carries `.identity` for
         /// `HTTPClient.Configuration.tlsLocalIdentityNetworkFramework` *and* the Keychain-item
         /// label needed to remove it again, since whoever ends up owning this identity's lifetime
         /// (`Internals.Client`, currently) needs both.

--- a/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.SecureConnection.swift
+++ b/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.SecureConnection.swift
@@ -15,20 +15,24 @@ extension Internals {
 
         // MARK: - Internal properties
 
-        /// - Note: `certificateChain`/`privateKey` (mTLS, via `tlsLocalIdentityNetworkFramework`)
-        /// and `tlsPins` (SPKI pinning, via `tlsCustomVerificationNetworkFramework`) both reach
-        /// Network.framework now, through the two trust/identity hooks
-        /// `Internals.NIOTrustEvaluator`/`makeLocalIdentityForNetworkFramework()` install. What's
-        /// left genuinely unreachable there: `keyLogger` (no Network.framework equivalent at all)
-        /// and `.noHostnameVerification` (traps via `precondition` unless a custom verification
-        /// callback is also installed -- see `getNWProtocolTLSOptions`). `additionalTrustRoots`
-        /// only reaches Network.framework's *native* trust-root handling when SPKI pinning isn't
-        /// also configured; when it is, `Internals.NIOTrustEvaluator` reads it directly instead.
-        /// The rest (`cipherSuiteValues`, `renegotiationSupport`, `signingSignatureAlgorithms`,
-        /// `verifySignatureAlgorithms`, `sendCANameList`, `shutdownTimeout`, `pskHint`,
-        /// `pskIdentityResolver`) aren't rejected there at all — they're read from the built
-        /// `TLSConfiguration` and then never looked at again, so the connection would silently
-        /// negotiate without them rather than fail loudly.
+        /// - Note: `certificateChain`/`privateKey` (mTLS, via `tlsLocalIdentityNetworkFramework`),
+        /// `tlsPins` (SPKI pinning), and `additionalTrustRoots` all reach Network.framework now,
+        /// through the two trust/identity hooks `Internals.NIOTrustEvaluator`/
+        /// `makeLocalIdentityForNetworkFramework()` install. `additionalTrustRoots` has no native
+        /// Network.framework counterpart at all (unlike `trustRoots`, which `getNWProtocolTLSOptions`
+        /// does carry over) -- `Internals.NIOTrustEvaluator` is what makes it work there, installing
+        /// `tlsCustomVerificationNetworkFramework` whenever `additionalTrustRoots` is configured,
+        /// independently of whether SPKI pinning is also active (`build()`'s NIOSSL-facing
+        /// `tlsCustomVerification` stays gated to pins only, since NIOSSL already honors
+        /// `additionalTrustRoots` natively via `TLSConfiguration` and doesn't need the assist).
+        /// What's left genuinely unreachable under Network.framework: `keyLogger` (no
+        /// Network.framework equivalent at all) and `.noHostnameVerification` (traps via
+        /// `precondition` unless a custom verification callback is also installed -- see
+        /// `getNWProtocolTLSOptions`). The rest (`cipherSuiteValues`, `renegotiationSupport`,
+        /// `signingSignatureAlgorithms`, `verifySignatureAlgorithms`, `sendCANameList`,
+        /// `shutdownTimeout`, `pskHint`, `pskIdentityResolver`) aren't rejected there at all —
+        /// they're read from the built `TLSConfiguration` and then never looked at again, so the
+        /// connection would silently negotiate without them rather than fail loudly.
         package var isCompatibleWithNetworkFramework: Bool {
             #if canImport(Darwin)
             return networkFrameworkIncompatibilityReasons().isEmpty
@@ -76,9 +80,6 @@ extension Internals {
             }
             if cipherSuites != nil { reasons.append(.cipherSuites) }
             if cipherSuiteValues != nil { reasons.append(.cipherSuiteValues) }
-            if additionalTrustRoots != nil, tlsPins == nil {
-                reasons.append(.additionalTrustRootsUnderNetworkFramework)
-            }
             if renegotiationSupport != nil { reasons.append(.renegotiationSupport) }
             if signingSignatureAlgorithms != nil { reasons.append(.signingSignatureAlgorithms) }
             if verifySignatureAlgorithms != nil { reasons.append(.verifySignatureAlgorithms) }
@@ -202,17 +203,24 @@ extension Internals {
 
             let trustEvaluator = try Internals.NIOTrustEvaluator.resolve(from: self)
 
+            // NIOSSL already honors `additionalTrustRoots` natively, via the plain
+            // `tlsConfiguration.additionalTrustRoots` assignment above -- unlike
+            // `tlsCustomVerificationNetworkFramework` below, its custom-verification callback
+            // stays reserved for what it can't do on its own (SPKI pinning), so a
+            // `trustEvaluator` built only for `additionalTrustRoots` never gets attached here.
+            let hasPins = !(tlsPins ?? []).isEmpty
+
             #if canImport(Darwin)
             return .init(
                 tlsConfiguration: tlsConfiguration,
-                tlsCustomVerification: trustEvaluator?.tlsCustomVerification,
+                tlsCustomVerification: hasPins ? trustEvaluator?.tlsCustomVerification : nil,
                 tlsCustomVerificationNetworkFramework: trustEvaluator?.tlsCustomVerificationNetworkFramework,
                 localIdentityHandle: isCompatibleWithNetworkFramework ? try makeLocalIdentityForNetworkFramework() : nil
             )
             #else
             return .init(
                 tlsConfiguration: tlsConfiguration,
-                tlsCustomVerification: trustEvaluator?.tlsCustomVerification
+                tlsCustomVerification: hasPins ? trustEvaluator?.tlsCustomVerification : nil
             )
             #endif
         }

--- a/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.SecureConnection.swift
+++ b/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.SecureConnection.swift
@@ -117,15 +117,30 @@ extension Internals {
         }
 
         /// - Parameter isCompatibleWithNetworkFramework: Whether the caller is actually going to
-        /// run this over Network.framework. When `false`, skips `makeLocalIdentityForNetworkFramework()`
-        /// entirely rather than performing its Keychain round-trip only to hand back a handle
-        /// nothing will use -- e.g. a `.nio` (plain-socket) client has no use for a Network.framework
-        /// identity, and shouldn't need Keychain Sharing entitlement (or a working Keychain at
-        /// all) just because `certificateChain`/`privateKey` happen to be configured for some
-        /// other executor's mTLS. Defaults to `true`, matching this method's original unconditional
-        /// behavior, for callers that don't know or don't care which executor will consume this.
+        /// run this over Network.framework. Cuts both ways:
+        ///
+        ///   - When `false`, skips `makeLocalIdentityForNetworkFramework()` entirely rather than
+        ///     performing its Keychain round-trip only to hand back a handle nothing will use --
+        ///     e.g. a `.nio` (plain-socket) client has no use for a Network.framework identity, and
+        ///     shouldn't need Keychain Sharing entitlement (or a working Keychain at all) just
+        ///     because `certificateChain`/`privateKey` happen to be configured for some other
+        ///     executor's mTLS.
+        ///   - When `true`, `makeTLSConfigurationByContext()` below leaves `certificateChain`/
+        ///     `privateKey` off the returned `TLSConfiguration` entirely -- mTLS travels through
+        ///     `tlsLocalIdentityNetworkFramework`/`localIdentityHandle` for Network.framework
+        ///     instead, and leaving both set on the same `TLSConfiguration` this build also hands
+        ///     to `HTTPClient.Configuration` is fatal, not just redundant: AsyncHTTPClient's
+        ///     NIOTransportServices bridge (`TLSConfiguration.getNWProtocolTLSOptions()`)
+        ///     `preconditionFailure`s the instant either is non-empty, unconditionally, regardless
+        ///     of whether a local identity was also supplied.
+        ///
+        /// Defaults to `true`, matching this method's original unconditional behavior for the
+        /// identity-building half, for callers that don't know or don't care which executor will
+        /// consume this.
         package func build(isCompatibleWithNetworkFramework: Bool = true) throws -> Output {
-            var tlsConfiguration = try makeTLSConfigurationByContext()
+            var tlsConfiguration = try makeTLSConfigurationByContext(
+                isCompatibleWithNetworkFramework: isCompatibleWithNetworkFramework
+            )
 
             if let minimumTLSVersion {
                 tlsConfiguration.minimumTLSVersion = minimumTLSVersion
@@ -225,17 +240,27 @@ extension Internals {
 
         // MARK: - Private methods
 
-        private func makeTLSConfigurationByContext() throws -> NIOSSL.TLSConfiguration {
+        /// - Parameter isCompatibleWithNetworkFramework: See `build(isCompatibleWithNetworkFramework:)`'s
+        /// own doc comment -- when `true`, `certificateChain`/`privateKey` are deliberately left off
+        /// the returned `TLSConfiguration`. mTLS still travels through
+        /// `tlsLocalIdentityNetworkFramework`/`localIdentityHandle` (`makeLocalIdentityForNetworkFramework()`)
+        /// for Network.framework; setting these two *as well*, on the same `TLSConfiguration`
+        /// AsyncHTTPClient's NIOTransportServices bridge also reads, would crash there outright.
+        private func makeTLSConfigurationByContext(
+            isCompatibleWithNetworkFramework: Bool
+        ) throws -> NIOSSL.TLSConfiguration {
             var tlsConfiguration: TLSConfiguration
 
             tlsConfiguration = .makeClientConfiguration()
 
-            if let certificateChain {
-                tlsConfiguration.certificateChain = try certificateChain.build()
-            }
+            if !isCompatibleWithNetworkFramework {
+                if let certificateChain {
+                    tlsConfiguration.certificateChain = try certificateChain.build()
+                }
 
-            if let privateKey {
-                tlsConfiguration.privateKey = try privateKey.build()
+                if let privateKey {
+                    tlsConfiguration.privateKey = try privateKey.build()
+                }
             }
 
             return tlsConfiguration

--- a/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.SecureConnection.swift
+++ b/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.SecureConnection.swift
@@ -17,23 +17,23 @@ extension Internals {
 
         /// - Note: `certificateChain`/`privateKey` (mTLS, via `tlsLocalIdentityNetworkFramework`),
         /// `tlsPins` (SPKI pinning), `additionalTrustRoots`, and `.noHostnameVerification` all reach
-        /// Network.framework now, through the two trust/identity hooks `Internals.NIOTrustEvaluator`/
+        /// Network.framework, through the two trust/identity hooks `Internals.NIOTrustEvaluator`/
         /// `makeLocalIdentityForNetworkFramework()` install. Neither `additionalTrustRoots` nor
         /// `.noHostnameVerification` has a native Network.framework counterpart (unlike `trustRoots`,
         /// which `getNWProtocolTLSOptions` does carry over, or NIOSSL's own `certificateVerification`
-        /// flag) -- `Internals.NIOTrustEvaluator` is what makes both work there, installing
+        /// flag) -- `Internals.NIOTrustEvaluator` is what makes both work there: it installs
         /// `tlsCustomVerificationNetworkFramework` whenever either is configured, independently of
-        /// whether SPKI pinning is also active, and swapping in a hostname-less policy on the
-        /// `SecTrust` it's handed only when `.noHostnameVerification` was actually asked for
+        /// whether SPKI pinning is also active, and swaps in a hostname-less policy on the
+        /// `SecTrust` it's handed only when `.noHostnameVerification` is actually configured
         /// (`makeDarwinEvaluator`'s `skipsHostnameVerification`). `build()`'s NIOSSL-facing
         /// `tlsCustomVerification` stays gated to pins only, since NIOSSL already honors both
         /// `additionalTrustRoots` and `.noHostnameVerification` natively via `TLSConfiguration` and
-        /// doesn't need the assist. What's left genuinely unreachable under Network.framework:
+        /// doesn't need the assist. What's genuinely unreachable under Network.framework:
         /// `keyLogger` (no Network.framework equivalent at all). The rest (`cipherSuiteValues`,
         /// `renegotiationSupport`, `signingSignatureAlgorithms`, `verifySignatureAlgorithms`,
         /// `sendCANameList`, `shutdownTimeout`, `pskHint`, `pskIdentityResolver`) aren't rejected
         /// there at all — they're read from the built `TLSConfiguration` and then never looked at
-        /// again, so the connection would silently negotiate without them rather than fail loudly.
+        /// again, so the connection silently negotiates without them rather than failing loudly.
         package var isCompatibleWithNetworkFramework: Bool {
             #if canImport(Darwin)
             return networkFrameworkIncompatibilityReasons().isEmpty
@@ -92,10 +92,10 @@ extension Internals {
         /// Deliberately does *not* check `certificateChain`/`privateKey`/`additionalTrustRoots`/
         /// `.noHostnameVerification`/`tlsPins` -- all five are reachable under URLSession, via a
         /// Keychain round-trip (`certificateChain`/`privateKey`) or `SecTrust`/`SecPolicy`
-        /// (everything else). They're also all reachable under Network.framework now (see
+        /// (everything else). They're also all reachable under Network.framework (see
         /// `networkFrameworkIncompatibilityReasons()` above) via `Internals.NIOTrustEvaluator`/
-        /// `makeLocalIdentityForNetworkFramework()`, so this list and that one now agree on every
-        /// field except `keyLogger`, the one still-genuine Network.framework-specific gap. Whether
+        /// `makeLocalIdentityForNetworkFramework()`, so this list and that one agree on every
+        /// field except `keyLogger`, the one genuine Network.framework-specific gap. Whether
         /// the app actually carries the Keychain Sharing entitlement the identity round-trip needs
         /// is a runtime fact this static check cannot see; a missing entitlement surfaces at
         /// identity-build time as its own runtime error, not as a reason in this list.

--- a/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.SecureConnection.swift
+++ b/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.SecureConnection.swift
@@ -224,7 +224,7 @@ extension Internals {
             let trustEvaluator = try Internals.NIOTrustEvaluator.resolve(from: self)
 
             // NIOSSL already honors `additionalTrustRoots` natively, via the plain
-            // `tlsConfiguration.additionalTrustRoots` assignment above -- unlike
+            // `tlsConfiguration.additionalTrustRoots` assignment above. Unlike
             // `tlsCustomVerificationNetworkFramework` below, its custom-verification callback
             // stays reserved for what it can't do on its own (SPKI pinning), so a
             // `trustEvaluator` built only for `additionalTrustRoots` never gets attached here.

--- a/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.SecureConnection.swift
+++ b/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Internals.SecureConnection.swift
@@ -199,7 +199,7 @@ extension Internals {
                 tlsConfiguration: tlsConfiguration,
                 tlsCustomVerification: trustEvaluator?.tlsCustomVerification,
                 tlsCustomVerificationNetworkFramework: trustEvaluator?.tlsCustomVerificationNetworkFramework,
-                tlsLocalIdentityNetworkFramework: try makeLocalIdentityForNetworkFramework()
+                localIdentityHandle: try makeLocalIdentityForNetworkFramework()
             )
             #else
             return .init(
@@ -228,19 +228,16 @@ extension Internals {
         }
 
         #if canImport(Darwin)
-        /// Builds the `SecIdentity` for `HTTPClient.Configuration.tlsLocalIdentityNetworkFramework`
-        /// (mTLS under Network.framework) when both `certificateChain` and `privateKey` are
-        /// configured -- the same Keychain round-trip `Internals.URLSessionIdentityPolicy` already
-        /// uses for `.urlSession`, via the shared `RawBytesIdentityBuilder` entry points.
+        /// Builds the `RawBytesIdentityBuilder.Handle` for mTLS under Network.framework when both
+        /// `certificateChain` and `privateKey` are configured -- the same Keychain round-trip
+        /// `Internals.URLSessionIdentityPolicy` already uses for `.urlSession`, via the shared
+        /// `RawBytesIdentityBuilder` entry points.
         ///
-        /// - Note: Unlike `URLSessionIdentityPolicy`, this doesn't hold on to the returned
-        /// `RawBytesIdentityBuilder.Handle` to remove it again later -- there's no natural place in
-        /// `.nio`'s client lifecycle to call `RawBytesIdentityBuilder.remove(_:)` from (see
-        /// `Internals.Client`'s `deinit`, which only shuts down the underlying `HTTPClient`).
-        /// `makeIdentity`'s Keychain items are labeled deterministically from the certificate's own
-        /// bytes and tolerate being re-added, so this leaves at most one item behind per distinct
-        /// client identity a process configures, rather than growing unbounded.
-        private func makeLocalIdentityForNetworkFramework() throws -> SecIdentity? {
+        /// Returns the whole `Handle`, not just its `.identity` -- `Internals.Client` holds onto it
+        /// and calls `RawBytesIdentityBuilder.remove(_:)` from its own `deinit`, mirroring
+        /// `URLSessionIdentityPolicy`'s lifecycle exactly, just one layer further down the chain
+        /// (`Output` -> `Internals.Session.Configuration.Output` -> `Internals.Client`).
+        private func makeLocalIdentityForNetworkFramework() throws -> Internals.RawBytesIdentityBuilder.Handle? {
             switch (certificateChain, privateKey) {
             case (nil, nil):
                 return nil
@@ -257,7 +254,7 @@ extension Internals {
                 return try RawBytesIdentityBuilder.makeIdentity(
                     certificateDER: leaf,
                     privateKeyDER: privateKeyDER
-                ).identity
+                )
 
             case (.some, nil), (nil, .some):
                 throw Internals.URLSessionIdentityPolicy.ConfigurationError.incompleteClientIdentity
@@ -315,9 +312,12 @@ extension Internals.SecureConnection {
         package let tlsCustomVerificationNetworkFramework:
             (@Sendable (SecTrust, @escaping @Sendable (Bool) -> Void) -> Void)?
 
-        /// Installs on `HTTPClient.Configuration.tlsLocalIdentityNetworkFramework` when both
-        /// `certificateChain` and `privateKey` are configured (mTLS).
-        package let tlsLocalIdentityNetworkFramework: SecIdentity?
+        /// The Keychain-backed identity for mTLS under Network.framework, when both
+        /// `certificateChain` and `privateKey` are configured -- carries `.identity` for
+        /// `HTTPClient.Configuration.tlsLocalIdentityNetworkFramework` *and* the Keychain-item
+        /// label needed to remove it again, since whoever ends up owning this identity's lifetime
+        /// (`Internals.Client`, currently) needs both.
+        package let localIdentityHandle: Internals.RawBytesIdentityBuilder.Handle?
         #endif
     }
 }

--- a/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Models/SSLKeyLogger.swift
+++ b/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Models/SSLKeyLogger.swift
@@ -9,7 +9,7 @@ import NIOCore
 /// ``SSLKeyLogger`` defines a method that can be used to log keys in the format expected by
 /// tools that support the `SSLKEYLOGFILE`.
 ///
-/// - Important: Reachable under `.nio` only -- this is a **permanent** limitation, not a gap
+/// - Important: Reachable under `.nio` only. This is a **permanent** limitation, not a gap
 /// awaiting a fix. Neither Network.framework nor `URLSession` exposes any public API for
 /// observing per-session TLS secrets; a session with a key logger configured that also resolves
 /// to `.nioTransportServices` crashes the process outright

--- a/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Models/SSLKeyLogger.swift
+++ b/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Models/SSLKeyLogger.swift
@@ -11,12 +11,13 @@ import NIOCore
 ///
 /// - Important: Reachable under `.nio` only. This is a **permanent** limitation, not a gap
 /// awaiting a fix. Neither Network.framework nor `URLSession` exposes any public API for
-/// observing per-session TLS secrets; a session with a key logger configured that also resolves
-/// to `.nioTransportServices` crashes the process outright
-/// (`TLSConfiguration.keyLogCallback` `preconditionFailure`s in AsyncHTTPClient's own
-/// NIOTransportServices bridge), which is exactly why `resolveExecutor()`/`requireExecutor(_:)`
-/// steer away from both non-`.nio` executors whenever this is set, rather than letting that
-/// reach the OS layer at all.
+/// observing per-session TLS secrets.
+///
+/// A session with a key logger configured that also resolves to `.nioTransportServices` crashes
+/// the process outright (`TLSConfiguration.keyLogCallback` `preconditionFailure`s in
+/// AsyncHTTPClient's own NIOTransportServices bridge), which is exactly why
+/// `resolveExecutor()`/`requireExecutor(_:)` steer away from both non-`.nio` executors whenever
+/// this is set, rather than letting that reach the OS layer at all.
 public protocol SSLKeyLogger: Sendable, AnyObject {
 
     ///

--- a/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Models/SSLKeyLogger.swift
+++ b/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Models/SSLKeyLogger.swift
@@ -8,6 +8,15 @@ import NIOCore
 ///
 /// ``SSLKeyLogger`` defines a method that can be used to log keys in the format expected by
 /// tools that support the `SSLKEYLOGFILE`.
+///
+/// - Important: Reachable under `.nio` only -- this is a **permanent** limitation, not a gap
+/// awaiting a fix. Neither Network.framework nor `URLSession` exposes any public API for
+/// observing per-session TLS secrets; a session with a key logger configured that also resolves
+/// to `.nioTransportServices` crashes the process outright
+/// (`TLSConfiguration.keyLogCallback` `preconditionFailure`s in AsyncHTTPClient's own
+/// NIOTransportServices bridge), which is exactly why `resolveExecutor()`/`requireExecutor(_:)`
+/// steer away from both non-`.nio` executors whenever this is set, rather than letting that
+/// reach the OS layer at all.
 public protocol SSLKeyLogger: Sendable, AnyObject {
 
     ///

--- a/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Models/TrustDecision.swift
+++ b/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Models/TrustDecision.swift
@@ -1,0 +1,23 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+/// A snapshot of one TLS trust evaluation's outcome, handed to a configured
+/// ``TrustDecisionObserver`` right after a peer certificate chain has been evaluated -- purely
+/// informational, produced *after* the accept/reject decision it describes has already been made.
+public struct TrustDecision: Sendable, Equatable {
+
+    /// Whether the peer's certificate chain was ultimately trusted -- the same accept/reject
+    /// outcome the connection itself acts on.
+    public let isTrusted: Bool
+
+    /// Whether SPKI pinning was configured for this connection and, if so, whether the presented
+    /// chain matched one of the configured pins. `nil` when no pins were configured at all, in
+    /// which case `isTrusted` reflects chain validity alone.
+    public let pinsMatched: Bool?
+
+    package init(isTrusted: Bool, pinsMatched: Bool?) {
+        self.isTrusted = isTrusted
+        self.pinsMatched = pinsMatched
+    }
+}

--- a/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Models/TrustDecision.swift
+++ b/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Models/TrustDecision.swift
@@ -3,11 +3,11 @@
 //
 
 /// A snapshot of one TLS trust evaluation's outcome, handed to a configured
-/// ``TrustDecisionObserver`` right after a peer certificate chain has been evaluated -- purely
+/// ``TrustDecisionObserver`` right after a peer certificate chain has been evaluated. Purely
 /// informational, produced *after* the accept/reject decision it describes has already been made.
 public struct TrustDecision: Sendable, Equatable {
 
-    /// Whether the peer's certificate chain was ultimately trusted -- the same accept/reject
+    /// Whether the peer's certificate chain was ultimately trusted: the same accept/reject
     /// outcome the connection itself acts on.
     public let isTrusted: Bool
 

--- a/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Models/TrustDecisionObserver.swift
+++ b/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Models/TrustDecisionObserver.swift
@@ -1,0 +1,26 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+/// Observes each TLS trust-evaluation decision a secure connection makes -- for observability or
+/// security-audit logging. Purely informational: a ``TrustDecision`` has already been decided by
+/// the time this is called, and nothing it does can change the outcome.
+///
+/// - Important: Only fires when a trust decision is actually evaluated through RequestDL's own
+/// logic rather than the TLS backend's native path -- under ``Session/Executor/urlSession``,
+/// that's every server-trust challenge; under ``Session/Executor/nio``/
+/// ``Session/Executor/nioTransportServices``, only when something else already requires it (SPKI
+/// pinning, ``SecureConnection/verification(_:)`` set to skip hostname verification,
+/// ``SecureConnection/revocationPolicy(_:)`` on Apple platforms, additional trust roots, ...) -- a
+/// plain connection with none of those configured resolves through NIOSSL's own native trust-root
+/// handling, which this observer never sees.
+public protocol TrustDecisionObserver: Sendable, AnyObject {
+
+    ///
+    /// Called once per evaluated peer certificate chain, right after its accept/reject decision
+    /// has been made.
+    ///
+    /// - Parameter decision: The trust decision that was just made.
+    ///
+    func callAsFunction(_ decision: TrustDecision)
+}

--- a/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Models/TrustDecisionObserver.swift
+++ b/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Models/TrustDecisionObserver.swift
@@ -7,13 +7,12 @@
 /// the time this is called, and nothing it does can change the outcome.
 ///
 /// - Important: Only fires when a trust decision is actually evaluated through RequestDL's own
-/// logic rather than the TLS backend's native path -- under ``Session/Executor/urlSession``,
-/// that's every server-trust challenge; under ``Session/Executor/nio``/
-/// ``Session/Executor/nioTransportServices``, only when something else already requires it (SPKI
-/// pinning, ``SecureConnection/verification(_:)`` set to skip hostname verification,
-/// ``SecureConnection/revocationPolicy(_:)`` on Apple platforms, additional trust roots, ...) -- a
-/// plain connection with none of those configured resolves through NIOSSL's own native trust-root
-/// handling, which this observer never sees.
+/// logic rather than the TLS backend's native path -- under `.urlSession`, that's every
+/// server-trust challenge; under `.nio`/`.nioTransportServices`, only when something else already
+/// requires it (SPKI pinning, `verification(_:)` set to skip hostname verification,
+/// `revocationPolicy(_:)` on Apple platforms, additional trust roots, ...) -- a plain connection
+/// with none of those configured resolves through NIOSSL's own native trust-root handling, which
+/// this observer never sees.
 public protocol TrustDecisionObserver: Sendable, AnyObject {
 
     ///

--- a/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Models/TrustDecisionObserver.swift
+++ b/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Models/TrustDecisionObserver.swift
@@ -2,15 +2,15 @@
 // See LICENSE for this package's licensing information.
 //
 
-/// Observes each TLS trust-evaluation decision a secure connection makes -- for observability or
+/// Observes each TLS trust-evaluation decision a secure connection makes, for observability or
 /// security-audit logging. Purely informational: a ``TrustDecision`` has already been decided by
 /// the time this is called, and nothing it does can change the outcome.
 ///
 /// - Important: Only fires when a trust decision is actually evaluated through RequestDL's own
-/// logic rather than the TLS backend's native path -- under `.urlSession`, that's every
+/// logic rather than the TLS backend's native path. Under `.urlSession`, that's every
 /// server-trust challenge; under `.nio`/`.nioTransportServices`, only when something else already
 /// requires it (SPKI pinning, `verification(_:)` set to skip hostname verification,
-/// `revocationPolicy(_:)` on Apple platforms, additional trust roots, ...) -- a plain connection
+/// `revocationPolicy(_:)` on Apple platforms, additional trust roots, ...). A plain connection
 /// with none of those configured resolves through NIOSSL's own native trust-root handling, which
 /// this observer never sees.
 public protocol TrustDecisionObserver: Sendable, AnyObject {

--- a/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Models/TrustDecisionObserver.swift
+++ b/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Models/TrustDecisionObserver.swift
@@ -10,9 +10,10 @@
 /// logic rather than the TLS backend's native path. Under `.urlSession`, that's every
 /// server-trust challenge; under `.nio`/`.nioTransportServices`, only when something else already
 /// requires it (SPKI pinning, `verification(_:)` set to skip hostname verification,
-/// `revocationPolicy(_:)` on Apple platforms, additional trust roots, ...). A plain connection
-/// with none of those configured resolves through NIOSSL's own native trust-root handling, which
-/// this observer never sees.
+/// `revocationPolicy(_:)` on Apple platforms, additional trust roots, ...).
+///
+/// A plain connection with none of those configured resolves through NIOSSL's own native
+/// trust-root handling, which this observer never sees.
 public protocol TrustDecisionObserver: Sendable, AnyObject {
 
     ///

--- a/Sources/RequestDLInternals/Sources/Secure Connection/Trust Roots/Internals.TrustRoots.swift
+++ b/Sources/RequestDLInternals/Sources/Secure Connection/Trust Roots/Internals.TrustRoots.swift
@@ -47,5 +47,19 @@ extension Internals {
                 )
             }
         }
+
+        /// The flat list of `NIOSSLCertificate`s this configuration resolves to -- what a trust
+        /// evaluator needs to set as anchors, as opposed to `build()`'s `NIOSSLTrustRoots`, which
+        /// stays a `.file` reference rather than reading it eagerly.
+        package func resolvedCertificates() throws -> [NIOSSLCertificate] {
+            switch self {
+            case .file(let file):
+                return try Internals.Certificate(file, format: .pem).build()
+            case .bytes(let bytes):
+                return try Internals.Certificate(bytes, format: .pem).build()
+            case .certificates(let certificates):
+                return try certificates.flatMap { try $0.build() }
+            }
+        }
     }
 }

--- a/Sources/RequestDLInternals/Sources/Secure Connection/Trust Roots/Internals.TrustRoots.swift
+++ b/Sources/RequestDLInternals/Sources/Secure Connection/Trust Roots/Internals.TrustRoots.swift
@@ -48,7 +48,7 @@ extension Internals {
             }
         }
 
-        /// The flat list of `NIOSSLCertificate`s this configuration resolves to -- what a trust
+        /// The flat list of `NIOSSLCertificate`s this configuration resolves to: what a trust
         /// evaluator needs to set as anchors, as opposed to `build()`'s `NIOSSLTrustRoots`, which
         /// stays a `.file` reference rather than reading it eagerly.
         package func resolvedCertificates() throws -> [NIOSSLCertificate] {

--- a/Sources/RequestDLInternals/Sources/Session/Session Configuration/Internals.Session.Configuration.swift
+++ b/Sources/RequestDLInternals/Sources/Session/Session Configuration/Internals.Session.Configuration.swift
@@ -136,20 +136,20 @@ extension Internals.Session {
 extension Internals.Session.Configuration {
 
     /// `build()`'s result: the `HTTPClient.Configuration` to hand `AsyncHTTPClient.HTTPClient`,
-    /// plus (on Darwin) the mTLS identity's `RawBytesIdentityBuilder.Handle`, if any. Kept
-    /// alongside the configuration rather than folded into it because whoever constructs the
-    /// actual `HTTPClient` needs both: the configuration to build it with, and the handle to hold
-    /// onto for as long as that client lives, so it can remove the identity's Keychain items once
-    /// the client itself goes away. See `Internals.Client.deinit`.
+    /// plus (on Darwin) the mTLS identity's `Internals.IdentityHandle`, if any. Kept alongside
+    /// the configuration rather than folded into it because whoever constructs the actual
+    /// `HTTPClient` needs both: the configuration to build it with, and the handle to hold onto
+    /// for as long as that client lives, so `IdentityHandle`'s own `deinit` can release the
+    /// identity's Keychain items once the client itself goes away. See `Internals.Client`.
     package struct Output: Sendable {
         package let httpClientConfiguration: HTTPClient.Configuration
 
         #if canImport(Darwin)
-        package let localIdentityHandle: Internals.RawBytesIdentityBuilder.Handle?
+        package let localIdentityHandle: Internals.IdentityHandle?
 
         package init(
             httpClientConfiguration: HTTPClient.Configuration,
-            localIdentityHandle: Internals.RawBytesIdentityBuilder.Handle? = nil
+            localIdentityHandle: Internals.IdentityHandle? = nil
         ) {
             self.httpClientConfiguration = httpClientConfiguration
             self.localIdentityHandle = localIdentityHandle

--- a/Sources/RequestDLInternals/Sources/Session/Session Configuration/Internals.Session.Configuration.swift
+++ b/Sources/RequestDLInternals/Sources/Session/Session Configuration/Internals.Session.Configuration.swift
@@ -84,7 +84,6 @@ extension Internals.Session {
 
             var configuration = HTTPClient.Configuration.init(
                 tlsConfiguration: secureConnectionOutput?.tlsConfiguration,
-                tlsPinning: secureConnectionOutput?.tlsPinning,
                 redirectConfiguration: redirectConfiguration?.build(),
                 timeout: timeout.build(),
                 connectionPool: connectionPool,
@@ -92,6 +91,13 @@ extension Internals.Session {
                 decompression: decompression.build(),
                 tracing: .init()
             )
+
+            configuration.tlsCustomVerification = secureConnectionOutput?.tlsCustomVerification
+            #if canImport(Darwin)
+            configuration.tlsCustomVerificationNetworkFramework =
+                secureConnectionOutput?.tlsCustomVerificationNetworkFramework
+            configuration.tlsLocalIdentityNetworkFramework = secureConnectionOutput?.tlsLocalIdentityNetworkFramework
+            #endif
 
             configuration.dnsOverride = dnsOverride
             configuration.enableMultipath = (multipathServiceType != .none)

--- a/Sources/RequestDLInternals/Sources/Session/Session Configuration/Internals.Session.Configuration.swift
+++ b/Sources/RequestDLInternals/Sources/Session/Session Configuration/Internals.Session.Configuration.swift
@@ -79,8 +79,17 @@ extension Internals.Session {
 
         // MARK: - Internal methods
 
-        package func build() throws -> Output {
-            let secureConnectionOutput = try secureConnection?.build()
+        /// - Parameter isCompatibleWithNetworkFramework: Whether the client this builds for will
+        /// actually run over Network.framework (`.nioTransportServices`) -- forwarded to
+        /// `SecureConnection.build(isCompatibleWithNetworkFramework:)` to decide whether it's
+        /// worth paying for the mTLS identity's Keychain round-trip at all. Defaults to `true` so
+        /// every caller that doesn't yet know which executor won (every test call site, plus any
+        /// future caller) keeps the original always-build behavior; `Internals.ClientManager` is
+        /// the one caller that does know, and passes its actual answer.
+        package func build(isCompatibleWithNetworkFramework: Bool = true) throws -> Output {
+            let secureConnectionOutput = try secureConnection?.build(
+                isCompatibleWithNetworkFramework: isCompatibleWithNetworkFramework
+            )
 
             var configuration = HTTPClient.Configuration.init(
                 tlsConfiguration: secureConnectionOutput?.tlsConfiguration,

--- a/Sources/RequestDLInternals/Sources/Session/Session Configuration/Internals.Session.Configuration.swift
+++ b/Sources/RequestDLInternals/Sources/Session/Session Configuration/Internals.Session.Configuration.swift
@@ -82,10 +82,12 @@ extension Internals.Session {
         /// - Parameter isCompatibleWithNetworkFramework: Whether the client this builds for will
         /// actually run over Network.framework (`.nioTransportServices`). Forwarded to
         /// `SecureConnection.build(isCompatibleWithNetworkFramework:)` to decide whether it's
-        /// worth paying for the mTLS identity's Keychain round-trip at all. Defaults to `true` so
-        /// every caller that doesn't yet know which executor won (every test call site, plus any
-        /// future caller) keeps the original always-build behavior; `Internals.ClientManager` is
-        /// the one caller that does know, and passes its actual answer.
+        /// worth paying for the mTLS identity's Keychain round-trip at all.
+        ///
+        /// Defaults to `true` so every caller that doesn't yet know which executor won (every
+        /// test call site, plus any future caller) keeps the original always-build behavior;
+        /// `Internals.ClientManager` is the one caller that does know, and passes its actual
+        /// answer.
         package func build(isCompatibleWithNetworkFramework: Bool = true) throws -> Output {
             let secureConnectionOutput = try secureConnection?.build(
                 isCompatibleWithNetworkFramework: isCompatibleWithNetworkFramework
@@ -433,12 +435,14 @@ extension Internals.Session.Configuration {
     /// distinct connect-phase timeout to receive `timeout.connect`. `secureConnection`'s
     /// `minimumTLSVersion`/`maximumTLSVersion` map onto `tlsMinimumSupportedProtocolVersion`/
     /// `tlsMaximumSupportedProtocolVersion`, the one other `SecureConnection` field with a
-    /// direct `URLSessionConfiguration` counterpart. Every other field this configuration could
-    /// carry that has no `URLSessionConfiguration` counterpart (`connectionPool`,
-    /// `ignoreUncleanSSLShutdown`, `networkFrameworkWaitForConnectivity`) is either NIO/NIOTS-specific
-    /// with nothing to translate to, or, for the fields that matter, like
-    /// `dnsOverride`/`httpVersion == .http1Only`/`proxy.connectHeaders`/`.socks`/`.bearer`/
-    /// `decompression == .disabled`, already excluded from resolving to `.urlSession` at all by
+    /// direct `URLSessionConfiguration` counterpart.
+    ///
+    /// Every other field this configuration could carry that has no `URLSessionConfiguration`
+    /// counterpart (`connectionPool`, `ignoreUncleanSSLShutdown`,
+    /// `networkFrameworkWaitForConnectivity`) is either NIO/NIOTS-specific with nothing to
+    /// translate to, or, for the fields that matter, like `dnsOverride`/`httpVersion ==
+    /// .http1Only`/`proxy.connectHeaders`/`.socks`/`.bearer`/`decompression == .disabled`,
+    /// already excluded from resolving to `.urlSession` at all by
     /// `urlSessionIncompatibilityReasons()`, so there is nothing left for a compatible
     /// configuration to lose in translation.
     ///

--- a/Sources/RequestDLInternals/Sources/Session/Session Configuration/Internals.Session.Configuration.swift
+++ b/Sources/RequestDLInternals/Sources/Session/Session Configuration/Internals.Session.Configuration.swift
@@ -383,10 +383,40 @@ extension Internals.Session.Configuration {
 
 #if canImport(Darwin)
 
+import NIOSSL
+
 #if canImport(FoundationEssentials)
 import FoundationEssentials
 #else
 import Foundation
+#endif
+
+#if canImport(Network)
+import Network
+#endif
+
+#if canImport(Network)
+extension NIOSSL.TLSVersion {
+
+    /// `URLSessionConfiguration.tlsMinimumSupportedProtocolVersion`/
+    /// `tlsMaximumSupportedProtocolVersion`'s type -- present unconditionally on every platform
+    /// this package targets (iOS 13/macOS 10.15, both below this package's own deployment
+    /// floor), so there's no availability branch to take here the way AsyncHTTPClient's own
+    /// NIOTransportServices bridge still needs for its pre-iOS-13 `SSLProtocol` fallback.
+    ///
+    /// - Note: `.TLSv10`/`.TLSv11` are deprecated (macOS 12+) but not unavailable -- mirrored
+    /// here anyway, deliberately: a caller who explicitly asked NIOSSL for TLS 1.0/1.1 (interop
+    /// with a legacy server, say) gets the same answer under `.urlSession`, not a silent upgrade
+    /// to whatever Apple currently recommends instead.
+    var urlSessionProtocolVersion: tls_protocol_version_t {
+        switch self {
+        case .tlsv1: return .TLSv10
+        case .tlsv11: return .TLSv11
+        case .tlsv12: return .TLSv12
+        case .tlsv13: return .TLSv13
+        }
+    }
+}
 #endif
 
 extension Internals.Session.Configuration {
@@ -399,12 +429,15 @@ extension Internals.Session.Configuration {
     /// `Internals.ClientManager` pools and later shuts down. Cookies are additionally disabled
     /// unconditionally in `Internals.URLSessionClient.init` itself regardless of what this builds.
     ///
-    /// Only `timeout.read` maps onto `timeoutIntervalForRequest` -- `URLSessionConfiguration` has
-    /// no distinct connect-phase timeout to receive `timeout.connect`. Every other field this
-    /// configuration could carry that has no `URLSessionConfiguration` counterpart
-    /// (`connectionPool`, `ignoreUncleanSSLShutdown`, `networkFrameworkWaitForConnectivity`) is
-    /// either NIO/NIOTS-specific with nothing to translate to, or -- for the fields that matter,
-    /// like `dnsOverride`/`httpVersion == .http1Only`/`proxy.connectHeaders`/`.socks`/`.bearer`/
+    /// `timeout.read` maps onto `timeoutIntervalForRequest` -- `URLSessionConfiguration` has no
+    /// distinct connect-phase timeout to receive `timeout.connect`. `secureConnection`'s
+    /// `minimumTLSVersion`/`maximumTLSVersion` map onto `tlsMinimumSupportedProtocolVersion`/
+    /// `tlsMaximumSupportedProtocolVersion` -- the one other `SecureConnection` field with a
+    /// direct `URLSessionConfiguration` counterpart. Every other field this configuration could
+    /// carry that has no `URLSessionConfiguration` counterpart (`connectionPool`,
+    /// `ignoreUncleanSSLShutdown`, `networkFrameworkWaitForConnectivity`) is either NIO/NIOTS-specific
+    /// with nothing to translate to, or -- for the fields that matter, like
+    /// `dnsOverride`/`httpVersion == .http1Only`/`proxy.connectHeaders`/`.socks`/`.bearer`/
     /// `decompression == .disabled` -- already excluded from resolving to `.urlSession` at all by
     /// `urlSessionIncompatibilityReasons()`, so there is nothing left for a compatible
     /// configuration to lose in translation.
@@ -435,6 +468,16 @@ extension Internals.Session.Configuration {
         if let read = timeout.read {
             configuration.timeoutIntervalForRequest = TimeInterval(read) / 1_000_000_000
         }
+
+        #if canImport(Network)
+        if let minimumTLSVersion = secureConnection?.minimumTLSVersion {
+            configuration.tlsMinimumSupportedProtocolVersion = minimumTLSVersion.urlSessionProtocolVersion
+        }
+
+        if let maximumTLSVersion = secureConnection?.maximumTLSVersion {
+            configuration.tlsMaximumSupportedProtocolVersion = maximumTLSVersion.urlSessionProtocolVersion
+        }
+        #endif
 
         return configuration
     }

--- a/Sources/RequestDLInternals/Sources/Session/Session Configuration/Internals.Session.Configuration.swift
+++ b/Sources/RequestDLInternals/Sources/Session/Session Configuration/Internals.Session.Configuration.swift
@@ -80,7 +80,7 @@ extension Internals.Session {
         // MARK: - Internal methods
 
         /// - Parameter isCompatibleWithNetworkFramework: Whether the client this builds for will
-        /// actually run over Network.framework (`.nioTransportServices`) -- forwarded to
+        /// actually run over Network.framework (`.nioTransportServices`). Forwarded to
         /// `SecureConnection.build(isCompatibleWithNetworkFramework:)` to decide whether it's
         /// worth paying for the mTLS identity's Keychain round-trip at all. Defaults to `true` so
         /// every caller that doesn't yet know which executor won (every test call site, plus any
@@ -134,7 +134,7 @@ extension Internals.Session {
 extension Internals.Session.Configuration {
 
     /// `build()`'s result: the `HTTPClient.Configuration` to hand `AsyncHTTPClient.HTTPClient`,
-    /// plus (on Darwin) the mTLS identity's `RawBytesIdentityBuilder.Handle`, if any -- kept
+    /// plus (on Darwin) the mTLS identity's `RawBytesIdentityBuilder.Handle`, if any. Kept
     /// alongside the configuration rather than folded into it because whoever constructs the
     /// actual `HTTPClient` needs both: the configuration to build it with, and the handle to hold
     /// onto for as long as that client lives, so it can remove the identity's Keychain items once
@@ -399,15 +399,15 @@ import Network
 extension NIOSSL.TLSVersion {
 
     /// `URLSessionConfiguration.tlsMinimumSupportedProtocolVersion`/
-    /// `tlsMaximumSupportedProtocolVersion`'s type -- present unconditionally on every platform
+    /// `tlsMaximumSupportedProtocolVersion`'s type. Present unconditionally on every platform
     /// this package targets (iOS 13/macOS 10.15, both below this package's own deployment
     /// floor), so there's no availability branch to take here the way AsyncHTTPClient's own
     /// NIOTransportServices bridge still needs for its pre-iOS-13 `SSLProtocol` fallback.
     ///
-    /// - Note: `.TLSv10`/`.TLSv11` are deprecated (macOS 12+) but not unavailable -- mirrored
-    /// here anyway, deliberately: a caller who explicitly asked NIOSSL for TLS 1.0/1.1 (interop
-    /// with a legacy server, say) gets the same answer under `.urlSession`, not a silent upgrade
-    /// to whatever Apple currently recommends instead.
+    /// - Note: `.TLSv10`/`.TLSv11` are deprecated (macOS 12+) but not unavailable, and are
+    /// mirrored here anyway, deliberately: a caller who explicitly asked NIOSSL for TLS 1.0/1.1
+    /// (interop with a legacy server, say) gets the same answer under `.urlSession`, not a
+    /// silent upgrade to whatever Apple currently recommends instead.
     var urlSessionProtocolVersion: tls_protocol_version_t {
         switch self {
         case .tlsv1: return .TLSv10
@@ -429,16 +429,16 @@ extension Internals.Session.Configuration {
     /// `Internals.ClientManager` pools and later shuts down. Cookies are additionally disabled
     /// unconditionally in `Internals.URLSessionClient.init` itself regardless of what this builds.
     ///
-    /// `timeout.read` maps onto `timeoutIntervalForRequest` -- `URLSessionConfiguration` has no
+    /// `timeout.read` maps onto `timeoutIntervalForRequest`; `URLSessionConfiguration` has no
     /// distinct connect-phase timeout to receive `timeout.connect`. `secureConnection`'s
     /// `minimumTLSVersion`/`maximumTLSVersion` map onto `tlsMinimumSupportedProtocolVersion`/
-    /// `tlsMaximumSupportedProtocolVersion` -- the one other `SecureConnection` field with a
+    /// `tlsMaximumSupportedProtocolVersion`, the one other `SecureConnection` field with a
     /// direct `URLSessionConfiguration` counterpart. Every other field this configuration could
     /// carry that has no `URLSessionConfiguration` counterpart (`connectionPool`,
     /// `ignoreUncleanSSLShutdown`, `networkFrameworkWaitForConnectivity`) is either NIO/NIOTS-specific
-    /// with nothing to translate to, or -- for the fields that matter, like
+    /// with nothing to translate to, or, for the fields that matter, like
     /// `dnsOverride`/`httpVersion == .http1Only`/`proxy.connectHeaders`/`.socks`/`.bearer`/
-    /// `decompression == .disabled` -- already excluded from resolving to `.urlSession` at all by
+    /// `decompression == .disabled`, already excluded from resolving to `.urlSession` at all by
     /// `urlSessionIncompatibilityReasons()`, so there is nothing left for a compatible
     /// configuration to lose in translation.
     ///

--- a/Sources/RequestDLInternals/Sources/Session/Session Configuration/Internals.Session.Configuration.swift
+++ b/Sources/RequestDLInternals/Sources/Session/Session Configuration/Internals.Session.Configuration.swift
@@ -79,7 +79,7 @@ extension Internals.Session {
 
         // MARK: - Internal methods
 
-        package func build() throws -> HTTPClient.Configuration {
+        package func build() throws -> Output {
             let secureConnectionOutput = try secureConnection?.build()
 
             var configuration = HTTPClient.Configuration.init(
@@ -96,7 +96,7 @@ extension Internals.Session {
             #if canImport(Darwin)
             configuration.tlsCustomVerificationNetworkFramework =
                 secureConnectionOutput?.tlsCustomVerificationNetworkFramework
-            configuration.tlsLocalIdentityNetworkFramework = secureConnectionOutput?.tlsLocalIdentityNetworkFramework
+            configuration.tlsLocalIdentityNetworkFramework = secureConnectionOutput?.localIdentityHandle?.identity
             #endif
 
             configuration.dnsOverride = dnsOverride
@@ -110,8 +110,44 @@ extension Internals.Session {
             // property for why `async-http-client`'s own built-in tracing is never engaged.
             configuration.tracing.tracer = NoOpTracer()
 
-            return configuration
+            #if canImport(Darwin)
+            return Output(
+                httpClientConfiguration: configuration,
+                localIdentityHandle: secureConnectionOutput?.localIdentityHandle
+            )
+            #else
+            return Output(httpClientConfiguration: configuration)
+            #endif
         }
+    }
+}
+
+extension Internals.Session.Configuration {
+
+    /// `build()`'s result: the `HTTPClient.Configuration` to hand `AsyncHTTPClient.HTTPClient`,
+    /// plus (on Darwin) the mTLS identity's `RawBytesIdentityBuilder.Handle`, if any -- kept
+    /// alongside the configuration rather than folded into it because whoever constructs the
+    /// actual `HTTPClient` needs both: the configuration to build it with, and the handle to hold
+    /// onto for as long as that client lives, so it can remove the identity's Keychain items once
+    /// the client itself goes away. See `Internals.Client.deinit`.
+    package struct Output: Sendable {
+        package let httpClientConfiguration: HTTPClient.Configuration
+
+        #if canImport(Darwin)
+        package let localIdentityHandle: Internals.RawBytesIdentityBuilder.Handle?
+
+        package init(
+            httpClientConfiguration: HTTPClient.Configuration,
+            localIdentityHandle: Internals.RawBytesIdentityBuilder.Handle? = nil
+        ) {
+            self.httpClientConfiguration = httpClientConfiguration
+            self.localIdentityHandle = localIdentityHandle
+        }
+        #else
+        package init(httpClientConfiguration: HTTPClient.Configuration) {
+            self.httpClientConfiguration = httpClientConfiguration
+        }
+        #endif
     }
 }
 

--- a/Sources/RequestDLInternals/Sources/Session/Session Configuration/Models/Internals.ExecutorIncompatibilityReason.swift
+++ b/Sources/RequestDLInternals/Sources/Session/Session Configuration/Models/Internals.ExecutorIncompatibilityReason.swift
@@ -30,8 +30,16 @@ extension Internals {
         /// The mirror image of the `UnderURLSession` cases above: a configured
         /// `Decompressor.requiresURLSession` algorithm (`BrotliURLSessionOnlyAlgorithm`, or a
         /// third-party one answering the same way) rules out `.nio`/`.nioTransportServices`
-        /// instead of `.urlSession` -- neither goes through CFNetwork, and `NIOHTTPCompression`
+        /// instead of `.urlSession`. Neither goes through CFNetwork, and `NIOHTTPCompression`
         /// has no decoder for whatever such an algorithm stands in for.
         case decompressionRequiresURLSession
+        /// `URLSessionConfiguration` has no maximum-TLS-version API. Unlike `minimumTLSVersion`
+        /// (reachable under URLSession via an ATS `NSExceptionMinimumTLSVersion` entry in
+        /// Info.plist), there is no App Transport Security key for a maximum either, so this has
+        /// no reachable equivalent under URLSession at all.
+        case maximumTLSVersionUnderURLSession
+        /// `URLSession` negotiates ALPN automatically and Info.plist has no key to override the
+        /// protocol list it offers, so this has no reachable equivalent under URLSession at all.
+        case applicationProtocolsUnderURLSession
     }
 }

--- a/Sources/RequestDLInternals/Sources/Session/Session Configuration/Models/Internals.ExecutorIncompatibilityReason.swift
+++ b/Sources/RequestDLInternals/Sources/Session/Session Configuration/Models/Internals.ExecutorIncompatibilityReason.swift
@@ -10,8 +10,6 @@ extension Internals {
     /// not another -- the `*IncompatibilityReasons()` functions decide which of these apply for
     /// which executor.
     package enum ExecutorIncompatibilityReason: Sendable, Hashable {
-        case certificateChain
-        case privateKey
         case keyLogger
         case cipherSuites
         case cipherSuiteValues
@@ -23,11 +21,10 @@ extension Internals {
         case pskHint
         case pskIdentityResolver
         case noHostnameVerificationUnderNetworkFramework
+        /// Only a problem when SPKI pinning (`.tlsPinning`) *isn't* also active -- when it is,
+        /// `Internals.NIOTrustEvaluator` reads `additionalTrustRoots` itself as part of building
+        /// its own custom verification, on both the NIOSSL and Network.framework backends.
         case additionalTrustRootsUnderNetworkFramework
-        /// SPKI pinning is wired only through `SPKIPinningConfiguration`/`AsyncHTTPClient.SPKIHash`,
-        /// which neither Network.framework's `getNWProtocolTLSOptions` bridge nor
-        /// `Internals.URLSessionClient`'s `SecTrust`-based trust evaluation ever consults.
-        case tlsPinning
         case dnsOverrideUnderURLSession
         case http1OnlyUnderURLSession
         case proxyConnectHeadersUnderURLSession

--- a/Sources/RequestDLInternals/Sources/Session/Session Configuration/Models/Internals.ExecutorIncompatibilityReason.swift
+++ b/Sources/RequestDLInternals/Sources/Session/Session Configuration/Models/Internals.ExecutorIncompatibilityReason.swift
@@ -20,7 +20,6 @@ extension Internals {
         case shutdownTimeout
         case pskHint
         case pskIdentityResolver
-        case noHostnameVerificationUnderNetworkFramework
         case dnsOverrideUnderURLSession
         case http1OnlyUnderURLSession
         case proxyConnectHeadersUnderURLSession

--- a/Sources/RequestDLInternals/Sources/Session/Session Configuration/Models/Internals.ExecutorIncompatibilityReason.swift
+++ b/Sources/RequestDLInternals/Sources/Session/Session Configuration/Models/Internals.ExecutorIncompatibilityReason.swift
@@ -21,10 +21,6 @@ extension Internals {
         case pskHint
         case pskIdentityResolver
         case noHostnameVerificationUnderNetworkFramework
-        /// Only a problem when SPKI pinning (`.tlsPinning`) *isn't* also active -- when it is,
-        /// `Internals.NIOTrustEvaluator` reads `additionalTrustRoots` itself as part of building
-        /// its own custom verification, on both the NIOSSL and Network.framework backends.
-        case additionalTrustRootsUnderNetworkFramework
         case dnsOverrideUnderURLSession
         case http1OnlyUnderURLSession
         case proxyConnectHeadersUnderURLSession

--- a/Tests/RequestDLInternalsTests/Sources/Client/URLSession Client/Identity/InternalsRawBytesIdentityBuilderTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Client/URLSession Client/Identity/InternalsRawBytesIdentityBuilderTests.swift
@@ -5,6 +5,7 @@
 #if canImport(Darwin)
 
 import CryptoKit
+import NIOSSL
 import Security
 import Testing
 
@@ -76,6 +77,70 @@ struct InternalsRawBytesIdentityBuilderTests {
         let der = try Internals.RawBytesIdentityBuilder.privateKeyDER(fromPEM: pem)
 
         #expect(der == pkcs8)
+    }
+
+    // MARK: - Password-protected RSA (PKCS#1)
+
+    /// The encrypted/plain pair is a real key, generated once with `openssl genrsa -aes256
+    /// -passout pass:\(Self.encryptedRSAPassword) 2048` and `openssl rsa -in <that> -passin
+    /// pass:... ` -- not hand-assembled the way the plain-PKCS#1/SEC1 fixtures above are, since
+    /// there's no in-process way to produce the legacy `Proc-Type`/`DEK-Info` encrypted PEM form
+    /// at all (`_RSA.Signing.PrivateKey` -- what production itself decrypts this with -- has no
+    /// encrypt-to-PEM direction, only decrypt-from-PEM).
+    @Test
+    func privateKeyDER_whenGivenPasswordProtectedPKCS1RSAPEM_decryptsToSameDERAsThePlainKey() throws {
+        let source = Internals.PrivateKeySource.privateKey(
+            .init(
+                Array(Self.encryptedRSAPEM.utf8),
+                format: .pem,
+                password: NIOSSLSecureBytes(Self.encryptedRSAPassword.utf8)
+            )
+        )
+
+        let decryptedDER = try Internals.RawBytesIdentityBuilder.privateKeyDER(from: source)
+        let plainDER = try Internals.RawBytesIdentityBuilder.privateKeyDER(fromPEM: Data(Self.plainRSAPEM.utf8))
+
+        #expect(decryptedDER == plainDER)
+
+        // The whole point of decrypting here at all: the result still has to actually build a
+        // working `SecKey`, the same as any other RSA key this executor hands off to Security.
+        let secKey = try Internals.RawBytesIdentityBuilder.secKey(fromDER: decryptedDER)
+        #expect(Self.keyType(of: secKey) == (kSecAttrKeyTypeRSA as String))
+    }
+
+    @Test
+    func privateKeyDER_whenGivenPasswordProtectedPKCS1RSAPEMWithWrongPassword_throwsUnsupportedKeyFormat() {
+        let source = Internals.PrivateKeySource.privateKey(
+            .init(
+                Array(Self.encryptedRSAPEM.utf8),
+                format: .pem,
+                password: NIOSSLSecureBytes("not the right password".utf8)
+            )
+        )
+
+        #expect(throws: Internals.RawBytesIdentityBuilder.Error.self) {
+            try Internals.RawBytesIdentityBuilder.privateKeyDER(from: source)
+        }
+    }
+
+    /// `_RSA.Signing.PrivateKey(encryptedPEMRepresentation:passphraseCallback:)` -- the only
+    /// encrypted-key entry point available -- takes a PEM string, never raw DER, so a
+    /// password-protected key sourced as `.der` has no decryption path at all and must fail
+    /// before even attempting one.
+    @Test
+    func privateKeyDER_whenGivenPasswordProtectedKeyInDERFormat_throwsUnsupportedKeyFormat() throws {
+        let plainDER = try Internals.RawBytesIdentityBuilder.privateKeyDER(fromPEM: Data(Self.plainRSAPEM.utf8))
+        let source = Internals.PrivateKeySource.privateKey(
+            .init(
+                [UInt8](plainDER),
+                format: .der,
+                password: NIOSSLSecureBytes(Self.encryptedRSAPassword.utf8)
+            )
+        )
+
+        #expect(throws: Internals.RawBytesIdentityBuilder.Error.self) {
+            try Internals.RawBytesIdentityBuilder.privateKeyDER(from: source)
+        }
     }
 
     // MARK: - EC
@@ -219,6 +284,75 @@ extension InternalsRawBytesIdentityBuilderTests {
     fileprivate static let rsaEncryptionOID: [UInt8] = [
         0x06, 0x09, 0x2A, 0x86, 0x48, 0x86, 0xF7, 0x0D, 0x01, 0x01, 0x01,
     ]
+
+    fileprivate static let encryptedRSAPassword = "testpassword123"
+
+    /// `openssl genrsa -aes256 -passout pass:testpassword123 -out key.pem 2048`
+    fileprivate static let encryptedRSAPEM = """
+        -----BEGIN RSA PRIVATE KEY-----
+        Proc-Type: 4,ENCRYPTED
+        DEK-Info: AES-256-CBC,B2B9857B451A6912AE8C66D3C7542B2C
+
+        mV/lX3n3MWwfliaoPi7EOeri1SPRxUH1KTOrzrAYmf0e+A1ftNvz7EDD2qpvh6Pr
+        dXb7BqbTSktZHJc8r2J7KZOZJ8KELd5Tp6OaEqzbBh4FtmAhJ1tfdtjN5J4MVzdS
+        UPCr64vj7Bs06lGj4r+/S0xqC+QsR64/Ujdwv7KT7pwsSc4cw1mOSdcA+5R4YPNM
+        HsKDBBKy+IooNY4zoq/ZTnXuUxfZ/4oPVGWB4wsztt7ULdTCexImSJufukQJ5MvZ
+        kDGMIh4fe8Qax2wvZycfYRBuovOxfOav8cjCggMo9Z0utV8d0Fo2ca6NRm57Hv14
+        vc0JdP2tdKc2t9FVWX/MI3H1CQiJLGXkU1Ev50Diuf+MPeSbCCqSDywsC/h1w8MB
+        evS7ZVgWPBjhrF9g5BkiMUyq7FTX1SZ3hEXjVbGFlVm1OZQzu6WI3Ak61wIgNyt6
+        W/eKqG6vnYAEsSGgNQ6e/bZh/2zB1pMv2B8G/Ujhtg6bM5LZQ0nTuGFeK3EFdkSG
+        C9Uo5lYfT+bKZVBGsW2zRDC9LkMKeHkRYJ75EcmmV3So1nQ+njeRM1c95qX2DzPv
+        2rtSZVWtZ2w59lsJKgu+ff5CNSfmY15lR3ksQBvc7zVdc0xGdGqHSp6LIo9JIBrF
+        S6qzVpnTrovLCGGGWdMoJXGsjjTwrFpRWrWjZLRA9f5ncXa0fDajggy1btTpE8d8
+        Or8IuZ+P1POqnNlON/8QUq/lxBkYdP+gECJKRibIbK2NkYlXX37xK0D5+PlC1zdX
+        QHQFh0F5fImwJbpM7n2+nXLC6PILN9w3cARII2nZC/HLo5oEbCH62Gn9IDMQ6OvV
+        1KIX+u0g8WAIDi/fIS4CglHLA1SiJQPDFATTs+Iftf6/Sft8u9rwpJB77IE6ZDDv
+        hKAAagtWUNYUw0zgNFeH2rdgOP5gFlGErTDIDqKvS6ZB/2ybCYoOM/FiSTVu8+JH
+        A/rvqTWPx6+szHdHbrGK6OQnJ4rWVXb/GFiasCS1M58DDIQ3BsUFyFkf5tq9AMJa
+        GkkWYnoUG3TuSEamx34YkKlrsXj1nLlP6MDYNtmdTWbp0lgWrzIwxiPMdM8541H+
+        tRJ9WikupoknK5g40++brvEJpdyVsc429w6ADIRCko6PvffAdg3uin6bS3sdIWpm
+        36BAw9eO59nAfXUVRvtd4e+PVivgnQv51Hlv84v5Am3af5iiqz+boo1HauSEq/Xc
+        SiNTYoDaMnYUqFD2YtEpVIbTnXnXFZKKqgOZhHnQRpRoC3HEbpuald8VLDg5mvpF
+        tNlJOuIBhyjMtKx6Un2Z5IHTWK8YblqnxPPvp9+DcRRubUjFP2NxLyLisUzG3FGs
+        1cAyMhmuYxvU7g7iJLzxHAM2mIgcN/1c+Kd2CUjxoa3to+1a8nzBtruA8PDfw4Bx
+        EgbMVVDkDFPc/vmQ23VlB1V2uFyWbuFeUNnfnswenjyKyVpOa5XsBLamchDPEptf
+        Z6FWFFdLM/1DAYhdtTROH36Po2suEqN/6qNuSlqZIvVkaA6nRQ5tnfp/t4Y7zhCv
+        m++ZisgcVLP/EcgX8j5bGmOnjyfs9HKhpOA0FiYkjp0A/Kcst3Ci2z+Sa3wSe/D3
+        -----END RSA PRIVATE KEY-----
+        """
+
+    /// The same key as ``encryptedRSAPEM``, decrypted once via
+    /// `openssl rsa -in encrypted.pem -passin pass:testpassword123` -- kept alongside it as the
+    /// independent "known good" DER these tests compare the decrypted result against.
+    fileprivate static let plainRSAPEM = """
+        -----BEGIN RSA PRIVATE KEY-----
+        MIIEogIBAAKCAQEA6OnR4SnI47vjlIxbZ2slMYbodYpEHx3haepYOf4pm0CfxeyQ
+        xrn8V4vRaG5bPQOSAg41nNIn19kf5iDERT5UsAGBlv9yKd2BSvZT50OfJdF6A4Xo
+        nzkfhQ19eL8d4HVV7NxnyVMQLcqqkLqb3roKwEPyRT5yjcqIpAjM02e/L5PmuEI/
+        0+ezdEmYHWI5NAIbVSWwScZuWepFneHehFLg74SIkbWusAoRw21ihboZXUGhUk8M
+        sTqCjjl+4Ii6UF59NJPs+5m6u2kxgzKpfVPyeSluBiTpNB9s/7aCyCOrPvb3D6xQ
+        7ta0w8ToZWMXFf0WanO4k9s9CZk+eevERLKsawIDAQABAoIBAHqYmKCsHdHBVEkc
+        mAAXpbwsBq/X14OJdt0JPOdJoRzXJ0JHAu2Xd/uc3NzbOasj9fafBBlHhTFYWDIJ
+        jUXlSS5bnJqeWrkunp+WiRNxxJNjb5XrJkapCq4+K40jC9bZ7CCA4yBVWG7B/oWv
+        s9vIkWAiY6OO+z0nHkU5XJbqRPgFIJvfTIaKJnUjRPDcVQG++ePRLYvvl7aVWmht
+        81voYVmpt6BvyY44jD7g4ZriQQ9tUSsLQDeF+3qfC+OO/8fPrR/X2FeXWehEBxU/
+        rDcvyIEgCUp5Y8OdvQH240TH1c7l/kOf5IzYcfrokKnryDPECD1ise2BqBv3NTak
+        2lRuRAECgYEA9XeEpVTnOr53xr74UQ9kaSah5F4+fk2MEw71c8SMFEzmuF/KSzBv
+        NYxXv7Ngusa+QSwyCiSsedwyEbCgohr9Z7vzHu8Y74HjM9SPz3t6NUW4GL2zAXvx
+        qWPlVmIQNaM6YRRMHgEcTc6HMSJo1t5sT5LCZ8dwfY8qADfW7+mMs6MCgYEA8uhm
+        Yx7klxzP9kQLWPVygfQDbiNb+jbHgteHhUX7iiBlo/Lu4G0Q7WCLqI1zwm85Cnn4
+        HhNlSM9HfzdObBskXzYZBrD1Q92inJqjUNA/YaWbDT/gOeic5guFYSaWWWrY/ENY
+        TTGrNl572VIz0r5cj7zGz/dBRD7VOxFxUcsscJkCgYBP4iV46LiXlYTFWUDWoHu8
+        /KWS/Fi6IeKEEUov8rbjpGMxfXsIHSsT8ihcarQAFM21x/xA8M5wmghxWVntZ3sw
+        Vyo31vf2ef7Gz1Y936FV1Oqkopeu0/dBeREZm7BKxGQrU7+xxArCB4RXqSsVQi1d
+        eBVsUKt7MSwqBgIc8ZSooQKBgGLxZRtE7ynac59FUjX3LKBgi7EmOAXwoE3civgv
+        bGl0DtK8Vq8V3gpDBEAw9hEiCuMIkZd2oRAKVn4sQgZo++TIfWMrW4w8UEtn9dQq
+        L1cQBNtdxHDyHk7aLIdJF37utdnzeJlg/POVgu8fu7pBDiUCaR03At/QlDyOO1Fs
+        5/opAoGALyaUDeMa/eX5hNjS7y+5ozBBBiWFQnnLGJY5HB1qtb3ujljQS2aj7Tlt
+        vVyXj9KNL3mWgC7r3S0SSMzLIizTRO7DM3Gu2UCTbYBbwRKtYfT0jHrtG31y8dau
+        N//PITY6Xld3pjHHji5em50I5davZaIHlv3n9A4Gdl08GHSYTCA=
+        -----END RSA PRIVATE KEY-----
+        """
 
     /// PKCS#8's `PrivateKeyInfo ::= SEQUENCE { version INTEGER, algorithm SEQUENCE, privateKey
     /// OCTET STRING }`, hand-assembled -- the deliberate inverse of production's own `DERReader`

--- a/Tests/RequestDLInternalsTests/Sources/Client/URLSession Client/Identity/InternalsRawBytesIdentityBuilderTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Client/URLSession Client/Identity/InternalsRawBytesIdentityBuilderTests.swift
@@ -17,11 +17,11 @@ import FoundationEssentials
 import Foundation
 #endif
 
-/// Covers `Internals.RawBytesIdentityBuilder.secKey(fromDER:)`'s own format classification --
-/// RSA/PKCS#1, RSA/PKCS#8, EC/SEC1, EC/PKCS#8 -- independent of the Keychain round trip
+/// Covers `Internals.RawBytesIdentityBuilder.secKey(fromDER:)`'s own format classification,
+/// namely RSA/PKCS#1, RSA/PKCS#8, EC/SEC1, EC/PKCS#8, independent of the Keychain round trip
 /// `makeIdentity(certificateDER:privateKeyDER:)` wraps around it. That round trip is a confirmed,
 /// unconditional `withKnownIssue` on this SwiftPM test harness regardless of key type (no Keychain
-/// Sharing entitlement -- see `RequestConfigurationURLSessionClientMTLSTests`'s own doc comment),
+/// Sharing entitlement; see `RequestConfigurationURLSessionClientMTLSTests`'s own doc comment),
 /// so testing the actual new logic here, which needs no Keychain access at all
 /// (`SecKeyCreateWithData` builds an ephemeral, non-persistent `SecKey` purely in memory), is what
 /// actually proves PKCS#8/EC support works, in an environment where the full round trip can't.
@@ -29,7 +29,7 @@ import Foundation
 /// Test fixtures are generated fresh per run rather than checked in as static files: RSA keys via
 /// `SecKeyCreateRandomKey` (no Keychain persistence needed since `kSecAttrIsPermanent` isn't set),
 /// EC keys via `CryptoKit`. `DERWriter`/PKCS#8- and SEC1-shaping below is the deliberate inverse of
-/// production's own minimal `DERReader` -- confirmed correct against `SecKeyCreateWithData`/
+/// production's own minimal `DERReader`, confirmed correct against `SecKeyCreateWithData`/
 /// `CryptoKit`'s own encoders, not just internally consistent with itself.
 struct InternalsRawBytesIdentityBuilderTests {
 
@@ -83,10 +83,10 @@ struct InternalsRawBytesIdentityBuilderTests {
 
     /// The encrypted/plain pair is a real key, generated once with `openssl genrsa -aes256
     /// -passout pass:\(Self.encryptedRSAPassword) 2048` and `openssl rsa -in <that> -passin
-    /// pass:... ` -- not hand-assembled the way the plain-PKCS#1/SEC1 fixtures above are, since
+    /// pass:... `. Not hand-assembled the way the plain-PKCS#1/SEC1 fixtures above are, since
     /// there's no in-process way to produce the legacy `Proc-Type`/`DEK-Info` encrypted PEM form
-    /// at all (`_RSA.Signing.PrivateKey` -- what production itself decrypts this with -- has no
-    /// encrypt-to-PEM direction, only decrypt-from-PEM).
+    /// at all: `_RSA.Signing.PrivateKey`, what production itself decrypts this with, has no
+    /// encrypt-to-PEM direction, only decrypt-from-PEM.
     @Test
     func privateKeyDER_whenGivenPasswordProtectedPKCS1RSAPEM_decryptsToSameDERAsThePlainKey() throws {
         let source = Internals.PrivateKeySource.privateKey(
@@ -123,8 +123,8 @@ struct InternalsRawBytesIdentityBuilderTests {
         }
     }
 
-    /// `_RSA.Signing.PrivateKey(encryptedPEMRepresentation:passphraseCallback:)` -- the only
-    /// encrypted-key entry point available -- takes a PEM string, never raw DER, so a
+    /// `_RSA.Signing.PrivateKey(encryptedPEMRepresentation:passphraseCallback:)`, the only
+    /// encrypted-key entry point available, takes a PEM string, never raw DER, so a
     /// password-protected key sourced as `.der` has no decryption path at all and must fail
     /// before even attempting one.
     @Test
@@ -157,7 +157,7 @@ struct InternalsRawBytesIdentityBuilderTests {
         #expect(Self.keySizeInBits(of: secKey) == curve.keySizeInBits)
     }
 
-    /// SEC1's own `publicKey` field is optional -- a real-world EC key can omit it, and
+    /// SEC1's own `publicKey` field is optional: a real-world EC key can omit it, and
     /// `secKey(fromDER:)` (via CryptoKit) must derive the public point from the private scalar
     /// alone rather than require it. Distinct from the test above, not redundant with it.
     @Test(arguments: [Self.Curve.p256, .p384, .p521])
@@ -211,7 +211,7 @@ struct InternalsRawBytesIdentityBuilderTests {
     }
 
     /// Curve25519 has no `SecKeyCreateWithData` entry point at all, and CryptoKit's `Curve25519`
-    /// types have no DER export to even attempt -- so a real, well-formed key of a genuinely
+    /// types have no DER export to even attempt, so a real, well-formed key of a genuinely
     /// unsupported kind is exercised here via its raw scalar instead, confirming the cascade
     /// fails closed on it rather than misidentifying it as something else.
     @Test
@@ -322,7 +322,7 @@ extension InternalsRawBytesIdentityBuilderTests {
         """
 
     /// The same key as ``encryptedRSAPEM``, decrypted once via
-    /// `openssl rsa -in encrypted.pem -passin pass:testpassword123` -- kept alongside it as the
+    /// `openssl rsa -in encrypted.pem -passin pass:testpassword123`, kept alongside it as the
     /// independent "known good" DER these tests compare the decrypted result against.
     fileprivate static let plainRSAPEM = """
         -----BEGIN RSA PRIVATE KEY-----
@@ -355,7 +355,7 @@ extension InternalsRawBytesIdentityBuilderTests {
         """
 
     /// PKCS#8's `PrivateKeyInfo ::= SEQUENCE { version INTEGER, algorithm SEQUENCE, privateKey
-    /// OCTET STRING }`, hand-assembled -- the deliberate inverse of production's own `DERReader`
+    /// OCTET STRING }`, hand-assembled, the deliberate inverse of production's own `DERReader`
     /// unwrap, confirmed correct via the round trip these tests actually run, not just by
     /// construction.
     fileprivate static func pkcs8(wrapping innerKeyDER: Data, algorithmOID: [UInt8]) -> Data {
@@ -371,7 +371,7 @@ extension InternalsRawBytesIdentityBuilderTests {
 
     /// SEC1's `ECPrivateKey ::= SEQUENCE { version INTEGER, privateKey OCTET STRING, [0]
     /// parameters ECParameters OPTIONAL, [1] publicKey BIT STRING OPTIONAL }`. `publicKeyPoint`
-    /// (X9.63 `04 || X || Y`) is genuinely optional, matching the real ASN.1 grammar -- see
+    /// (X9.63 `04 || X || Y`) is genuinely optional, matching the real ASN.1 grammar. See
     /// `secKey_whenGivenBareSEC1ECDERWithoutPublicKey_derivesItAndSucceeds`.
     fileprivate static func sec1ECPrivateKeyDER(scalar: Data, curveOID: [UInt8], publicKeyPoint: Data?) -> Data {
         var children: [[UInt8]] = [
@@ -442,7 +442,7 @@ extension InternalsRawBytesIdentityBuilderTests {
     }
 }
 
-/// Minimal DER TLV writer -- the deliberate inverse of production's `DERReader`
+/// Minimal DER TLV writer, the deliberate inverse of production's `DERReader`
 /// (`Internals.RawBytesIdentityBuilder.swift`), used only to hand-assemble PKCS#8/SEC1 test
 /// fixtures. Not shipped: this lives in the test target only.
 private enum DERWriter {
@@ -477,12 +477,12 @@ private enum DERWriter {
         tlv(tag: 0x04, content: bytes)
     }
 
-    /// A BIT STRING with zero unused bits -- every use here wraps a byte-aligned EC point.
+    /// A BIT STRING with zero unused bits: every use here wraps a byte-aligned EC point.
     static func bitString(_ bytes: [UInt8]) -> [UInt8] {
         tlv(tag: 0x03, content: [0x00] + bytes)
     }
 
-    /// EXPLICIT context-specific tagging (`[n]`) -- `content` is the complete inner TLV
+    /// EXPLICIT context-specific tagging (`[n]`). `content` is the complete inner TLV
     /// (including its own tag and length), wrapped in an outer `0xA0 | n` tag.
     static func explicit(_ number: UInt8, _ content: [UInt8]) -> [UInt8] {
         tlv(tag: 0xA0 | number, content: content)

--- a/Tests/RequestDLInternalsTests/Sources/Secure Connection/Secure Connection/InternalsDarwinTrustEvaluationTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Secure Connection/Secure Connection/InternalsDarwinTrustEvaluationTests.swift
@@ -114,6 +114,43 @@ struct InternalsDarwinTrustEvaluationTests {
         #expect(!isTrusted)
     }
 
+    /// Regression coverage for `prepare(_:skipsHostnameVerification:)`'s revocation-policy
+    /// composition: `SecTrustSetPolicies` replaces a trust's whole policy array rather than
+    /// appending to it, so appending a revocation policy without first reading the trust's
+    /// existing array back via `SecTrustCopyPolicies` would silently drop the base SSL/X.509
+    /// policy `SecTrustCreateWithCertificates` installed it with -- this asserts the array grows
+    /// by exactly one rather than being replaced outright.
+    @Test
+    func prepare_whenRevocationPolicyConfiguredWithoutSkippingHostnameVerification_appendsToExistingPolicies() throws {
+        // Given
+        let certificate = try Self.selfSignedCertificate(Certificates(.der).server())
+
+        var trust: SecTrust?
+        let status = SecTrustCreateWithCertificates(certificate as CFArray, SecPolicyCreateBasicX509(), &trust)
+        let sut = try #require(status == errSecSuccess ? trust : nil)
+
+        var policiesBefore: CFArray?
+        _ = SecTrustCopyPolicies(sut, &policiesBefore)
+        let countBefore = (policiesBefore as? [SecPolicy])?.count ?? 0
+
+        let evaluation = Internals.DarwinTrustEvaluation(
+            trustRootCertificates: [],
+            pins: [],
+            isStrict: true,
+            revocationPolicy: .strict
+        )
+
+        // When
+        evaluation.prepare(sut, skipsHostnameVerification: false)
+
+        // Then
+        var policiesAfter: CFArray?
+        _ = SecTrustCopyPolicies(sut, &policiesAfter)
+        let countAfter = (policiesAfter as? [SecPolicy])?.count ?? 0
+
+        #expect(countAfter == countBefore + 1)
+    }
+
     // MARK: - Private methods
 
     private static func selfSignedCertificate(_ resource: CertificateResource) throws -> [SecCertificate] {

--- a/Tests/RequestDLInternalsTests/Sources/Secure Connection/Secure Connection/InternalsDarwinTrustEvaluationTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Secure Connection/Secure Connection/InternalsDarwinTrustEvaluationTests.swift
@@ -1,0 +1,123 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+import Security
+import Testing
+
+@testable import RequestDLInternals
+@testable import RequestDLTestSupport
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import struct Foundation.Data
+#endif
+
+struct InternalsDarwinTrustEvaluationTests {
+
+    @Test
+    func passes_whenNoPinsConfigured_isAlwaysTrue() throws {
+        // Given -- nothing to pin against, so chain validity (already confirmed by the caller's
+        // own SecTrustEvaluate... call before this runs) is the whole check.
+        let evaluation = Internals.DarwinTrustEvaluation(trustRootCertificates: [], pins: [], isStrict: true)
+
+        var trust: SecTrust?
+        let status = SecTrustCreateWithCertificates(
+            try Self.selfSignedCertificate(Certificates(.der).server()) as CFArray,
+            SecPolicyCreateBasicX509(),
+            &trust
+        )
+        let sut = try #require(status == errSecSuccess ? trust : nil)
+
+        // When / Then
+        #expect(evaluation.passes(chain: sut))
+    }
+
+    @Test
+    func passes_whenPinMismatchUnderStrictPolicy_isFalse() throws {
+        // Given
+        let unrelatedPin = Internals.ResolvedSPKIPin { _ in false }
+        let evaluation = Internals.DarwinTrustEvaluation(
+            trustRootCertificates: [],
+            pins: [unrelatedPin],
+            isStrict: true
+        )
+
+        var trust: SecTrust?
+        let status = SecTrustCreateWithCertificates(
+            try Self.selfSignedCertificate(Certificates(.der).server()) as CFArray,
+            SecPolicyCreateBasicX509(),
+            &trust
+        )
+        let sut = try #require(status == errSecSuccess ? trust : nil)
+
+        // When / Then
+        #expect(!evaluation.passes(chain: sut))
+    }
+
+    @Test
+    func passes_whenPinMismatchUnderAuditPolicy_isTrue() throws {
+        // Given -- `.audit` only ever relaxes a pin mismatch, matching `ServerTrustPolicy`'s own
+        // longstanding semantics.
+        let unrelatedPin = Internals.ResolvedSPKIPin { _ in false }
+        let evaluation = Internals.DarwinTrustEvaluation(
+            trustRootCertificates: [],
+            pins: [unrelatedPin],
+            isStrict: false
+        )
+
+        var trust: SecTrust?
+        let status = SecTrustCreateWithCertificates(
+            try Self.selfSignedCertificate(Certificates(.der).server()) as CFArray,
+            SecPolicyCreateBasicX509(),
+            &trust
+        )
+        let sut = try #require(status == errSecSuccess ? trust : nil)
+
+        // When / Then
+        #expect(evaluation.passes(chain: sut))
+    }
+
+    /// Regression coverage for the correctness fix folded into the `NIOTrustEvaluator`/
+    /// `ServerTrustPolicy` unification: `prepare(_:skipsHostnameVerification:)` uses
+    /// `SecPolicyCreateSSL(true, nil)` -- a real SSL server policy that still requires proper
+    /// server-auth `extendedKeyUsage`, just without the hostname match -- not
+    /// `SecPolicyCreateBasicX509()` (a bare chain-of-trust policy with no purpose/EKU checks at
+    /// all), which is what `NIOTrustEvaluator`'s Network.framework closure used to build before
+    /// this type existed. The fixtures' "client" certificate is self-signed with
+    /// `extendedKeyUsage=clientAuth` only (no `serverAuth`) -- exactly the shape a bare X.509
+    /// policy would still accept but a real SSL server policy correctly rejects.
+    @Test
+    func prepare_whenSkipsHostnameVerification_stillEnforcesServerAuthExtendedKeyUsage() throws {
+        // Given
+        let certificate = try Self.selfSignedCertificate(Certificates(.der).client())
+
+        var trust: SecTrust?
+        let status = SecTrustCreateWithCertificates(certificate as CFArray, SecPolicyCreateBasicX509(), &trust)
+        let sut = try #require(status == errSecSuccess ? trust : nil)
+
+        let evaluation = Internals.DarwinTrustEvaluation(
+            trustRootCertificates: certificate,
+            pins: [],
+            isStrict: false
+        )
+
+        // When -- self-anchored on its own (self-signed) certificate, so the only reason this
+        // could still fail is a policy check beyond bare chain-of-trust.
+        evaluation.prepare(sut, skipsHostnameVerification: true)
+
+        // Then -- a bare X.509 policy would accept this outright; a real SSL server policy
+        // rejects it for lacking the serverAuth EKU.
+        var evaluationError: CFError?
+        let isTrusted = SecTrustEvaluateWithError(sut, &evaluationError)
+        #expect(!isTrusted)
+    }
+
+    // MARK: - Private methods
+
+    private static func selfSignedCertificate(_ resource: CertificateResource) throws -> [SecCertificate] {
+        let der = try Data(contentsOf: resource.certificateURL)
+        return [try #require(SecCertificateCreateWithData(nil, der as CFData))]
+    }
+}

--- a/Tests/RequestDLInternalsTests/Sources/Secure Connection/Secure Connection/InternalsDarwinTrustEvaluationTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Secure Connection/Secure Connection/InternalsDarwinTrustEvaluationTests.swift
@@ -2,7 +2,6 @@
 // See LICENSE for this package's licensing information.
 //
 
-import Security
 import Testing
 
 @testable import RequestDLInternals
@@ -13,6 +12,10 @@ import FoundationEssentials
 #else
 import struct Foundation.Data
 #endif
+
+#if canImport(Darwin)
+
+import Security
 
 struct InternalsDarwinTrustEvaluationTests {
 
@@ -245,3 +248,5 @@ private final class RecordingTrustDecisionObserver: TrustDecisionObserver, @unch
         decisions.append(decision)
     }
 }
+
+#endif

--- a/Tests/RequestDLInternalsTests/Sources/Secure Connection/Secure Connection/InternalsDarwinTrustEvaluationTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Secure Connection/Secure Connection/InternalsDarwinTrustEvaluationTests.swift
@@ -159,9 +159,11 @@ struct InternalsDarwinTrustEvaluationTests {
     /// server-auth `extendedKeyUsage`, just without the hostname match, rather than
     /// `SecPolicyCreateBasicX509()` (a bare chain-of-trust policy with no purpose/EKU checks at
     /// all), which is what `NIOTrustEvaluator`'s Network.framework closure used to build before
-    /// this type existed. The fixtures' "client" certificate is self-signed with
-    /// `extendedKeyUsage=clientAuth` only (no `serverAuth`): exactly the shape a bare X.509
-    /// policy would still accept but a real SSL server policy correctly rejects.
+    /// this type existed.
+    ///
+    /// The fixtures' "client" certificate is self-signed with `extendedKeyUsage=clientAuth` only
+    /// (no `serverAuth`): exactly the shape a bare X.509 policy would still accept but a real SSL
+    /// server policy correctly rejects.
     @Test
     func prepare_whenSkipsHostnameVerification_stillEnforcesServerAuthExtendedKeyUsage() throws {
         // Given

--- a/Tests/RequestDLInternalsTests/Sources/Secure Connection/Secure Connection/InternalsDarwinTrustEvaluationTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Secure Connection/Secure Connection/InternalsDarwinTrustEvaluationTests.swift
@@ -18,7 +18,7 @@ struct InternalsDarwinTrustEvaluationTests {
 
     @Test
     func evaluate_whenNoPinsConfigured_isAlwaysTrue() throws {
-        // Given -- nothing to pin against, so chain validity (already confirmed by the caller's
+        // Given: nothing to pin against, so chain validity (already confirmed by the caller's
         // own SecTrustEvaluate... call before this runs) is the whole check.
         let evaluation = Internals.DarwinTrustEvaluation(trustRootCertificates: [], pins: [], isStrict: true)
 
@@ -36,7 +36,7 @@ struct InternalsDarwinTrustEvaluationTests {
 
     @Test
     func evaluate_whenChainNotTrusted_isFalseRegardlessOfPins() throws {
-        // Given -- the caller's own `SecTrustEvaluate...` already rejected the chain; no pin
+        // Given: the caller's own `SecTrustEvaluate...` already rejected the chain; no pin
         // configuration should be able to override that.
         let evaluation = Internals.DarwinTrustEvaluation(trustRootCertificates: [], pins: [], isStrict: false)
 
@@ -76,7 +76,7 @@ struct InternalsDarwinTrustEvaluationTests {
 
     @Test
     func evaluate_whenPinMismatchUnderAuditPolicy_isTrue() throws {
-        // Given -- `.audit` only ever relaxes a pin mismatch, matching `ServerTrustPolicy`'s own
+        // Given: `.audit` only ever relaxes a pin mismatch, matching `ServerTrustPolicy`'s own
         // longstanding semantics.
         let unrelatedPin = Internals.ResolvedSPKIPin { _ in false }
         let evaluation = Internals.DarwinTrustEvaluation(
@@ -99,7 +99,7 @@ struct InternalsDarwinTrustEvaluationTests {
 
     @Test
     func evaluate_notifiesObserverWithTheSameOutcomeAndPinMatchState() throws {
-        // Given -- the observer must see exactly the accept/reject decision (and pin-match state)
+        // Given: the observer must see exactly the accept/reject decision (and pin-match state)
         // `evaluate(chain:chainIsTrusted:)` itself returns, not some separately recomputed value.
         let unrelatedPin = Internals.ResolvedSPKIPin { _ in false }
         let observer = RecordingTrustDecisionObserver()
@@ -129,7 +129,7 @@ struct InternalsDarwinTrustEvaluationTests {
 
     @Test
     func evaluate_whenChainNotTrusted_notifiesObserverWithNilPinsMatched() throws {
-        // Given -- a broken chain never gets far enough to consult pins at all.
+        // Given: a broken chain never gets far enough to consult pins at all.
         let observer = RecordingTrustDecisionObserver()
         let evaluation = Internals.DarwinTrustEvaluation(
             trustRootCertificates: [],
@@ -177,11 +177,11 @@ struct InternalsDarwinTrustEvaluationTests {
             isStrict: false
         )
 
-        // When -- self-anchored on its own (self-signed) certificate, so the only reason this
+        // When: self-anchored on its own (self-signed) certificate, so the only reason this
         // could still fail is a policy check beyond bare chain-of-trust.
         evaluation.prepare(sut, skipsHostnameVerification: true)
 
-        // Then -- a bare X.509 policy would accept this outright; a real SSL server policy
+        // Then: a bare X.509 policy would accept this outright; a real SSL server policy
         // rejects it for lacking the serverAuth EKU.
         var evaluationError: CFError?
         let isTrusted = SecTrustEvaluateWithError(sut, &evaluationError)

--- a/Tests/RequestDLInternalsTests/Sources/Secure Connection/Secure Connection/InternalsDarwinTrustEvaluationTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Secure Connection/Secure Connection/InternalsDarwinTrustEvaluationTests.swift
@@ -155,12 +155,12 @@ struct InternalsDarwinTrustEvaluationTests {
 
     /// Regression coverage for the correctness fix folded into the `NIOTrustEvaluator`/
     /// `ServerTrustPolicy` unification: `prepare(_:skipsHostnameVerification:)` uses
-    /// `SecPolicyCreateSSL(true, nil)` -- a real SSL server policy that still requires proper
-    /// server-auth `extendedKeyUsage`, just without the hostname match -- not
+    /// `SecPolicyCreateSSL(true, nil)`, a real SSL server policy that still requires proper
+    /// server-auth `extendedKeyUsage`, just without the hostname match, rather than
     /// `SecPolicyCreateBasicX509()` (a bare chain-of-trust policy with no purpose/EKU checks at
     /// all), which is what `NIOTrustEvaluator`'s Network.framework closure used to build before
     /// this type existed. The fixtures' "client" certificate is self-signed with
-    /// `extendedKeyUsage=clientAuth` only (no `serverAuth`) -- exactly the shape a bare X.509
+    /// `extendedKeyUsage=clientAuth` only (no `serverAuth`): exactly the shape a bare X.509
     /// policy would still accept but a real SSL server policy correctly rejects.
     @Test
     func prepare_whenSkipsHostnameVerification_stillEnforcesServerAuthExtendedKeyUsage() throws {
@@ -192,7 +192,7 @@ struct InternalsDarwinTrustEvaluationTests {
     /// composition: `SecTrustSetPolicies` replaces a trust's whole policy array rather than
     /// appending to it, so appending a revocation policy without first reading the trust's
     /// existing array back via `SecTrustCopyPolicies` would silently drop the base SSL/X.509
-    /// policy `SecTrustCreateWithCertificates` installed it with -- this asserts the array grows
+    /// policy `SecTrustCreateWithCertificates` installed it with. This asserts the array grows
     /// by exactly one rather than being replaced outright.
     @Test
     func prepare_whenRevocationPolicyConfiguredWithoutSkippingHostnameVerification_appendsToExistingPolicies() throws {
@@ -234,7 +234,7 @@ struct InternalsDarwinTrustEvaluationTests {
 }
 
 /// A test double recording every ``TrustDecision`` it's notified of, in order. `@unchecked
-/// Sendable` is safe here -- every test in this file calls `evaluate(chain:chainIsTrusted:)`
+/// Sendable` is safe here, since every test in this file calls `evaluate(chain:chainIsTrusted:)`
 /// synchronously, from a single thread, never concurrently.
 private final class RecordingTrustDecisionObserver: TrustDecisionObserver, @unchecked Sendable {
     private(set) var decisions: [TrustDecision] = []

--- a/Tests/RequestDLInternalsTests/Sources/Secure Connection/Secure Connection/InternalsDarwinTrustEvaluationTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Secure Connection/Secure Connection/InternalsDarwinTrustEvaluationTests.swift
@@ -17,7 +17,7 @@ import struct Foundation.Data
 struct InternalsDarwinTrustEvaluationTests {
 
     @Test
-    func passes_whenNoPinsConfigured_isAlwaysTrue() throws {
+    func evaluate_whenNoPinsConfigured_isAlwaysTrue() throws {
         // Given -- nothing to pin against, so chain validity (already confirmed by the caller's
         // own SecTrustEvaluate... call before this runs) is the whole check.
         let evaluation = Internals.DarwinTrustEvaluation(trustRootCertificates: [], pins: [], isStrict: true)
@@ -31,11 +31,29 @@ struct InternalsDarwinTrustEvaluationTests {
         let sut = try #require(status == errSecSuccess ? trust : nil)
 
         // When / Then
-        #expect(evaluation.passes(chain: sut))
+        #expect(evaluation.evaluate(chain: sut, chainIsTrusted: true))
     }
 
     @Test
-    func passes_whenPinMismatchUnderStrictPolicy_isFalse() throws {
+    func evaluate_whenChainNotTrusted_isFalseRegardlessOfPins() throws {
+        // Given -- the caller's own `SecTrustEvaluate...` already rejected the chain; no pin
+        // configuration should be able to override that.
+        let evaluation = Internals.DarwinTrustEvaluation(trustRootCertificates: [], pins: [], isStrict: false)
+
+        var trust: SecTrust?
+        let status = SecTrustCreateWithCertificates(
+            try Self.selfSignedCertificate(Certificates(.der).server()) as CFArray,
+            SecPolicyCreateBasicX509(),
+            &trust
+        )
+        let sut = try #require(status == errSecSuccess ? trust : nil)
+
+        // When / Then
+        #expect(!evaluation.evaluate(chain: sut, chainIsTrusted: false))
+    }
+
+    @Test
+    func evaluate_whenPinMismatchUnderStrictPolicy_isFalse() throws {
         // Given
         let unrelatedPin = Internals.ResolvedSPKIPin { _ in false }
         let evaluation = Internals.DarwinTrustEvaluation(
@@ -53,11 +71,11 @@ struct InternalsDarwinTrustEvaluationTests {
         let sut = try #require(status == errSecSuccess ? trust : nil)
 
         // When / Then
-        #expect(!evaluation.passes(chain: sut))
+        #expect(!evaluation.evaluate(chain: sut, chainIsTrusted: true))
     }
 
     @Test
-    func passes_whenPinMismatchUnderAuditPolicy_isTrue() throws {
+    func evaluate_whenPinMismatchUnderAuditPolicy_isTrue() throws {
         // Given -- `.audit` only ever relaxes a pin mismatch, matching `ServerTrustPolicy`'s own
         // longstanding semantics.
         let unrelatedPin = Internals.ResolvedSPKIPin { _ in false }
@@ -76,7 +94,63 @@ struct InternalsDarwinTrustEvaluationTests {
         let sut = try #require(status == errSecSuccess ? trust : nil)
 
         // When / Then
-        #expect(evaluation.passes(chain: sut))
+        #expect(evaluation.evaluate(chain: sut, chainIsTrusted: true))
+    }
+
+    @Test
+    func evaluate_notifiesObserverWithTheSameOutcomeAndPinMatchState() throws {
+        // Given -- the observer must see exactly the accept/reject decision (and pin-match state)
+        // `evaluate(chain:chainIsTrusted:)` itself returns, not some separately recomputed value.
+        let unrelatedPin = Internals.ResolvedSPKIPin { _ in false }
+        let observer = RecordingTrustDecisionObserver()
+        let evaluation = Internals.DarwinTrustEvaluation(
+            trustRootCertificates: [],
+            pins: [unrelatedPin],
+            isStrict: true,
+            observer: observer
+        )
+
+        var trust: SecTrust?
+        let status = SecTrustCreateWithCertificates(
+            try Self.selfSignedCertificate(Certificates(.der).server()) as CFArray,
+            SecPolicyCreateBasicX509(),
+            &trust
+        )
+        let sut = try #require(status == errSecSuccess ? trust : nil)
+
+        // When
+        let accepted = evaluation.evaluate(chain: sut, chainIsTrusted: true)
+
+        // Then
+        #expect(observer.decisions.count == 1)
+        #expect(observer.decisions.first?.isTrusted == accepted)
+        #expect(observer.decisions.first?.pinsMatched == false)
+    }
+
+    @Test
+    func evaluate_whenChainNotTrusted_notifiesObserverWithNilPinsMatched() throws {
+        // Given -- a broken chain never gets far enough to consult pins at all.
+        let observer = RecordingTrustDecisionObserver()
+        let evaluation = Internals.DarwinTrustEvaluation(
+            trustRootCertificates: [],
+            pins: [Internals.ResolvedSPKIPin { _ in true }],
+            isStrict: true,
+            observer: observer
+        )
+
+        var trust: SecTrust?
+        let status = SecTrustCreateWithCertificates(
+            try Self.selfSignedCertificate(Certificates(.der).server()) as CFArray,
+            SecPolicyCreateBasicX509(),
+            &trust
+        )
+        let sut = try #require(status == errSecSuccess ? trust : nil)
+
+        // When
+        _ = evaluation.evaluate(chain: sut, chainIsTrusted: false)
+
+        // Then
+        #expect(observer.decisions == [TrustDecision(isTrusted: false, pinsMatched: nil)])
     }
 
     /// Regression coverage for the correctness fix folded into the `NIOTrustEvaluator`/
@@ -156,5 +230,16 @@ struct InternalsDarwinTrustEvaluationTests {
     private static func selfSignedCertificate(_ resource: CertificateResource) throws -> [SecCertificate] {
         let der = try Data(contentsOf: resource.certificateURL)
         return [try #require(SecCertificateCreateWithData(nil, der as CFData))]
+    }
+}
+
+/// A test double recording every ``TrustDecision`` it's notified of, in order. `@unchecked
+/// Sendable` is safe here -- every test in this file calls `evaluate(chain:chainIsTrusted:)`
+/// synchronously, from a single thread, never concurrently.
+private final class RecordingTrustDecisionObserver: TrustDecisionObserver, @unchecked Sendable {
+    private(set) var decisions: [TrustDecision] = []
+
+    func callAsFunction(_ decision: TrustDecision) {
+        decisions.append(decision)
     }
 }

--- a/Tests/RequestDLInternalsTests/Sources/Secure Connection/Secure Connection/InternalsNIOTrustEvaluatorTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Secure Connection/Secure Connection/InternalsNIOTrustEvaluatorTests.swift
@@ -19,12 +19,16 @@ import Testing
 struct InternalsNIOTrustEvaluatorTests {
 
     @Test
-    func resolve_whenNoPinsConfigured_returnsNil() throws {
-        // Given
+    func resolve_whenNothingConfigured_returnsNil() throws {
+        // Given -- SPKI pinning is the trigger this file's own chain-validation tests exercise,
+        // but it's not the only one: on Darwin, `additionalTrustRoots`/`.noHostnameVerification`
+        // alone also install this evaluator (see `InternalsSecureConnectionTests`'s
+        // `secureConnection_whenNetworkFrameworkReachableFieldSet_remainsCompatible` for that).
+        // With none of the three configured at all, though, no custom verification is installed,
+        // so the TLS backend's own native trust-root handling stays untouched.
         let secureConnection = Internals.SecureConnection()
 
-        // Then -- no custom verification installed at all when pinning isn't configured, so the
-        // TLS backend's own native trust-root handling stays untouched.
+        // Then
         #expect(try Internals.NIOTrustEvaluator.resolve(from: secureConnection) == nil)
     }
 

--- a/Tests/RequestDLInternalsTests/Sources/Secure Connection/Secure Connection/InternalsNIOTrustEvaluatorTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Secure Connection/Secure Connection/InternalsNIOTrustEvaluatorTests.swift
@@ -45,6 +45,21 @@ struct InternalsNIOTrustEvaluatorTests {
         // Then
         #expect(try Internals.NIOTrustEvaluator.resolve(from: secureConnection) != nil)
     }
+
+    private final class NoOpTrustDecisionObserver: TrustDecisionObserver, @unchecked Sendable {
+        func callAsFunction(_ decision: TrustDecision) {}
+    }
+
+    @Test
+    func resolve_whenOnlyObserverConfigured_installsEvaluator() throws {
+        // Given -- the observer alone is a reason to install custom verification on Darwin, even
+        // with every other trigger left at its default.
+        var secureConnection = Internals.SecureConnection()
+        secureConnection.trustDecisionObserver = NoOpTrustDecisionObserver()
+
+        // Then
+        #expect(try Internals.NIOTrustEvaluator.resolve(from: secureConnection) != nil)
+    }
     #endif
 
     @Test

--- a/Tests/RequestDLInternalsTests/Sources/Secure Connection/Secure Connection/InternalsNIOTrustEvaluatorTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Secure Connection/Secure Connection/InternalsNIOTrustEvaluatorTests.swift
@@ -11,7 +11,7 @@ import Testing
 @testable import RequestDLInternals
 
 /// Tests `Internals.NIOTrustEvaluator` against a real, `openssl`-generated and
-/// `openssl verify`-checked three-level certificate chain (root CA -> intermediate CA -> leaf) --
+/// `openssl verify`-checked three-level certificate chain (root CA -> intermediate CA -> leaf),
 /// not mocks, so a broken chain genuinely fails to validate and a matching SPKI pin genuinely
 /// hashes to the configured digest. Covers the behavior this type exists for: pinning the
 /// intermediate (not just the leaf) matches, a pin mismatch only rejects under `.strict`, and a
@@ -20,7 +20,7 @@ struct InternalsNIOTrustEvaluatorTests {
 
     @Test
     func resolve_whenNothingConfigured_returnsNil() throws {
-        // Given -- SPKI pinning is the trigger this file's own chain-validation tests exercise,
+        // Given: SPKI pinning is the trigger this file's own chain-validation tests exercise,
         // but it's not the only one: on Darwin, `additionalTrustRoots`/`.noHostnameVerification`
         // alone also install this evaluator (see `InternalsSecureConnectionTests`'s
         // `secureConnection_whenNetworkFrameworkReachableFieldSet_remainsCompatible` for that).
@@ -35,7 +35,7 @@ struct InternalsNIOTrustEvaluatorTests {
     #if canImport(Darwin)
     @Test
     func resolve_whenOnlyRevocationPolicyConfigured_installsEvaluator() throws {
-        // Given -- NIOSSL/BoringSSL implements no revocation checking of its own, so this only
+        // Given: NIOSSL/BoringSSL implements no revocation checking of its own, so this only
         // ever installs the custom-verification evaluator on Darwin, the same way
         // `additionalTrustRoots`/`.noHostnameVerification` alone do (see
         // `resolve_whenNothingConfigured_returnsNil` above).
@@ -52,7 +52,7 @@ struct InternalsNIOTrustEvaluatorTests {
 
     @Test
     func resolve_whenOnlyObserverConfigured_installsEvaluator() throws {
-        // Given -- the observer alone is a reason to install custom verification on Darwin, even
+        // Given: the observer alone is a reason to install custom verification on Darwin, even
         // with every other trigger left at its default.
         var secureConnection = Internals.SecureConnection()
         secureConnection.trustDecisionObserver = NoOpTrustDecisionObserver()
@@ -87,7 +87,7 @@ struct InternalsNIOTrustEvaluatorTests {
     @Test
     func tlsCustomVerification_whenTrustRootNotConfigured_rejectsRegardlessOfPolicy() async throws {
         // The self-signed test root isn't in the real system trust store, so chain validation
-        // itself fails when it's never installed as a trust anchor here -- and that must reject
+        // itself fails when it's never installed as a trust anchor here, and that must reject
         // even under `.audit`, which only ever relaxes a *pin* mismatch, never a broken chain.
         try await assertVerification(
             pinningBase64: Self.leafSPKIPinBase64,
@@ -131,7 +131,7 @@ struct InternalsNIOTrustEvaluatorTests {
     // MARK: - Test fixtures
     //
     // A real chain, generated with openssl and confirmed with `openssl verify -CAfile root.crt
-    // -untrusted intermediate.crt leaf.crt` before being pasted in here -- root and intermediate
+    // -untrusted intermediate.crt leaf.crt` before being pasted in here. Root and intermediate
     // are P-256, the intermediate has `basicConstraints=critical,CA:TRUE,pathlen:0`, and the leaf
     // has `basicConstraints=critical,CA:FALSE` with `extendedKeyUsage=serverAuth`.
 

--- a/Tests/RequestDLInternalsTests/Sources/Secure Connection/Secure Connection/InternalsNIOTrustEvaluatorTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Secure Connection/Secure Connection/InternalsNIOTrustEvaluatorTests.swift
@@ -32,6 +32,21 @@ struct InternalsNIOTrustEvaluatorTests {
         #expect(try Internals.NIOTrustEvaluator.resolve(from: secureConnection) == nil)
     }
 
+    #if canImport(Darwin)
+    @Test
+    func resolve_whenOnlyRevocationPolicyConfigured_installsEvaluator() throws {
+        // Given -- NIOSSL/BoringSSL implements no revocation checking of its own, so this only
+        // ever installs the custom-verification evaluator on Darwin, the same way
+        // `additionalTrustRoots`/`.noHostnameVerification` alone do (see
+        // `resolve_whenNothingConfigured_returnsNil` above).
+        var secureConnection = Internals.SecureConnection()
+        secureConnection.revocationPolicy = .strict
+
+        // Then
+        #expect(try Internals.NIOTrustEvaluator.resolve(from: secureConnection) != nil)
+    }
+    #endif
+
     @Test
     func tlsCustomVerification_whenPinningLeaf_acceptsChain() async throws {
         try await assertVerification(pinningBase64: Self.leafSPKIPinBase64, expectVerified: true)

--- a/Tests/RequestDLInternalsTests/Sources/Secure Connection/Secure Connection/InternalsNIOTrustEvaluatorTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Secure Connection/Secure Connection/InternalsNIOTrustEvaluatorTests.swift
@@ -1,0 +1,152 @@
+//
+// See LICENSE for this package's licensing information.
+//
+
+import Crypto
+import NIOCore
+import NIOPosix
+import NIOSSL
+import Testing
+
+@testable import RequestDLInternals
+
+/// Tests `Internals.NIOTrustEvaluator` against a real, `openssl`-generated and
+/// `openssl verify`-checked three-level certificate chain (root CA -> intermediate CA -> leaf) --
+/// not mocks, so a broken chain genuinely fails to validate and a matching SPKI pin genuinely
+/// hashes to the configured digest. Covers the behavior this type exists for: pinning the
+/// intermediate (not just the leaf) matches, a pin mismatch only rejects under `.strict`, and a
+/// broken chain rejects unconditionally regardless of policy.
+struct InternalsNIOTrustEvaluatorTests {
+
+    @Test
+    func resolve_whenNoPinsConfigured_returnsNil() throws {
+        // Given
+        let secureConnection = Internals.SecureConnection()
+
+        // Then -- no custom verification installed at all when pinning isn't configured, so the
+        // TLS backend's own native trust-root handling stays untouched.
+        #expect(try Internals.NIOTrustEvaluator.resolve(from: secureConnection) == nil)
+    }
+
+    @Test
+    func tlsCustomVerification_whenPinningLeaf_acceptsChain() async throws {
+        try await assertVerification(pinningBase64: Self.leafSPKIPinBase64, expectVerified: true)
+    }
+
+    @Test
+    func tlsCustomVerification_whenPinningIntermediate_acceptsChain() async throws {
+        // The whole point of leaf+intermediate pinning (OWASP's recommended backup-pin practice):
+        // a pin on the intermediate, which rotates far less often than the leaf, matches too.
+        try await assertVerification(pinningBase64: Self.intermediateSPKIPinBase64, expectVerified: true)
+    }
+
+    @Test
+    func tlsCustomVerification_whenPinMismatchUnderStrictPolicy_rejects() async throws {
+        try await assertVerification(pinningBase64: Self.unrelatedPinBase64, policy: .strict, expectVerified: false)
+    }
+
+    @Test
+    func tlsCustomVerification_whenPinMismatchUnderAuditPolicy_stillAccepts() async throws {
+        try await assertVerification(pinningBase64: Self.unrelatedPinBase64, policy: .audit, expectVerified: true)
+    }
+
+    @Test
+    func tlsCustomVerification_whenTrustRootNotConfigured_rejectsRegardlessOfPolicy() async throws {
+        // The self-signed test root isn't in the real system trust store, so chain validation
+        // itself fails when it's never installed as a trust anchor here -- and that must reject
+        // even under `.audit`, which only ever relaxes a *pin* mismatch, never a broken chain.
+        try await assertVerification(
+            pinningBase64: Self.leafSPKIPinBase64,
+            policy: .audit,
+            includeTrustRoot: false,
+            expectVerified: false
+        )
+    }
+
+    // MARK: - Private methods
+
+    private func assertVerification(
+        pinningBase64: String,
+        policy: Internals.SPKIPinningPolicy = .strict,
+        includeTrustRoot: Bool = true,
+        expectVerified: Bool
+    ) async throws {
+        var secureConnection = Internals.SecureConnection()
+        if includeTrustRoot {
+            secureConnection.trustRoots = .certificates([.init(Array(Self.rootPEM.utf8), format: .pem)])
+        }
+        secureConnection.tlsPins = [.init(source: .base64String(pinningBase64), algorithm: SHA256.self)]
+        secureConnection.tlsPinningPolicy = policy
+
+        let evaluator = try #require(try Internals.NIOTrustEvaluator.resolve(from: secureConnection))
+
+        let leaf = try NIOSSLCertificate(bytes: Array(Self.leafPEM.utf8), format: .pem)
+        let intermediate = try NIOSSLCertificate(bytes: Array(Self.intermediatePEM.utf8), format: .pem)
+
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        let promise = group.next().makePromise(of: NIOSSLVerificationResult.self)
+
+        evaluator.tlsCustomVerification([leaf, intermediate], promise)
+
+        let result = try await promise.futureResult.get()
+        try await group.shutdownGracefully()
+
+        #expect((result == .certificateVerified) == expectVerified)
+    }
+
+    // MARK: - Test fixtures
+    //
+    // A real chain, generated with openssl and confirmed with `openssl verify -CAfile root.crt
+    // -untrusted intermediate.crt leaf.crt` before being pasted in here -- root and intermediate
+    // are P-256, the intermediate has `basicConstraints=critical,CA:TRUE,pathlen:0`, and the leaf
+    // has `basicConstraints=critical,CA:FALSE` with `extendedKeyUsage=serverAuth`.
+
+    private static let rootPEM = """
+        -----BEGIN CERTIFICATE-----
+        MIIBMDCB2AIJAJn1z1LZ3C5OMAoGCCqGSM49BAMCMCExHzAdBgNVBAMMFlJlcXVl
+        c3RETCBUZXN0IFJvb3QgQ0EwHhcNMjYwOTA4MjI0MjUzWhcNMzYwOTA1MjI0MjUz
+        WjAhMR8wHQYDVQQDDBZSZXF1ZXN0REwgVGVzdCBSb290IENBMFkwEwYHKoZIzj0C
+        AQYIKoZIzj0DAQcDQgAEoF93a/3YNMpbMWInI3+vSci+u8AOQ/U/UkYkqSaB1gzm
+        0jPvRqtVxO84OT+l+7rsjMtr3Bq7pQNi3pVJvZYsZTAKBggqhkjOPQQDAgNHADBE
+        AiBRoOg8Bc4+QBFM+WF/ISad8cbUPYYpokhcOb9NAaDTRQIgZa8nv6eTKug1jLEc
+        ZfhyirOmWGAvNaGKd1f0Nsg3fV0=
+        -----END CERTIFICATE-----
+        """
+
+    private static let intermediatePEM = """
+        -----BEGIN CERTIFICATE-----
+        MIIBZjCCAQ2gAwIBAgIJAMSyavHobm5wMAoGCCqGSM49BAMCMCExHzAdBgNVBAMM
+        FlJlcXVlc3RETCBUZXN0IFJvb3QgQ0EwHhcNMjYwOTA4MjI0MjUzWhcNMzEwOTA3
+        MjI0MjUzWjApMScwJQYDVQQDDB5SZXF1ZXN0REwgVGVzdCBJbnRlcm1lZGlhdGUg
+        Q0EwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAAT5bjXBe2Yy0yokxdnPtb15xXuY
+        qe0uXVrkbJ68tWzZFvddbSdbzBTBl+JtJM5EzTtq+UdrYSn9NrlaejoTRSm8oyYw
+        JDASBgNVHRMBAf8ECDAGAQH/AgEAMA4GA1UdDwEB/wQEAwIBBjAKBggqhkjOPQQD
+        AgNHADBEAiBZu3vsZhCHabe7HEg1G+ihwpUB9CqxBtU6dkUYt1lsFAIgPgEoFhv8
+        4OxDy7akMrmhjYF8tss+3Egp2chJHt7HjoI=
+        -----END CERTIFICATE-----
+        """
+
+    private static let leafPEM = """
+        -----BEGIN CERTIFICATE-----
+        MIIBjjCCATOgAwIBAgIJAI7yfkO2eqn0MAoGCCqGSM49BAMCMCkxJzAlBgNVBAMM
+        HlJlcXVlc3RETCBUZXN0IEludGVybWVkaWF0ZSBDQTAeFw0yNjA5MDgyMjQyNTNa
+        Fw0yODEyMTEyMjQyNTNaMBsxGTAXBgNVBAMMEGxlYWYuZXhhbXBsZS5jb20wWTAT
+        BgcqhkjOPQIBBggqhkjOPQMBBwNCAATJWysghI3r7ZYFneo8Dnvp8PcCgg97NYsR
+        +74XzDpHLTiqSohx+D0v2G0vvGP7kmAxrrtoO8RyD2ne2bQAhPaxo1IwUDAMBgNV
+        HRMBAf8EAjAAMA4GA1UdDwEB/wQEAwIHgDATBgNVHSUEDDAKBggrBgEFBQcDATAb
+        BgNVHREEFDASghBsZWFmLmV4YW1wbGUuY29tMAoGCCqGSM49BAMCA0kAMEYCIQCl
+        mCofAAWSYQ7ePRnKPgMY+SIIj0rdmKZglhiNYCvrsQIhALJVr92AyseZbc4Mkopg
+        L8EpopmdnbqqsW7jzb1SL9mC
+        -----END CERTIFICATE-----
+        """
+
+    /// `openssl x509 -in leaf.crt -pubkey -noout | openssl pkey -pubin -outform der | openssl
+    /// dgst -sha256 -binary | base64` -- computed independently of any code under test.
+    private static let leafSPKIPinBase64 = "IikJpHu0p+Tm4dpFCXRFXMkLLYsRjwePLjgvHYMYnJw="
+
+    /// Same recipe as `leafSPKIPinBase64`, run against `intermediate.crt`.
+    private static let intermediateSPKIPinBase64 = "0715ggkh3Sde/vilUaD01AjS05rQT2NopWpK584Krrc="
+
+    /// `openssl rand -base64 32` -- doesn't match any certificate in the chain, on purpose.
+    private static let unrelatedPinBase64 = "tH0BF9jVlk3y2e1huTk41UtsPgrhf4cFbJLczhAfH3g="
+}

--- a/Tests/RequestDLInternalsTests/Sources/Secure Connection/Secure Connection/InternalsNIOTrustEvaluatorTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Secure Connection/Secure Connection/InternalsNIOTrustEvaluatorTests.swift
@@ -175,12 +175,12 @@ struct InternalsNIOTrustEvaluatorTests {
         """
 
     /// `openssl x509 -in leaf.crt -pubkey -noout | openssl pkey -pubin -outform der | openssl
-    /// dgst -sha256 -binary | base64` -- computed independently of any code under test.
+    /// dgst -sha256 -binary | base64`, computed independently of any code under test.
     private static let leafSPKIPinBase64 = "IikJpHu0p+Tm4dpFCXRFXMkLLYsRjwePLjgvHYMYnJw="
 
     /// Same recipe as `leafSPKIPinBase64`, run against `intermediate.crt`.
     private static let intermediateSPKIPinBase64 = "0715ggkh3Sde/vilUaD01AjS05rQT2NopWpK584Krrc="
 
-    /// `openssl rand -base64 32` -- doesn't match any certificate in the chain, on purpose.
+    /// `openssl rand -base64 32`, doesn't match any certificate in the chain, on purpose.
     private static let unrelatedPinBase64 = "tH0BF9jVlk3y2e1huTk41UtsPgrhf4cFbJLczhAfH3g="
 }

--- a/Tests/RequestDLInternalsTests/Sources/Secure Connection/Secure Connection/InternalsSecureConnectionTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Secure Connection/Secure Connection/InternalsSecureConnectionTests.swift
@@ -384,9 +384,9 @@ extension InternalsSecureConnectionTests {
     }
 
     /// Regression coverage for the fields AsyncHTTPClient's NIOTransportServices bridge either
-    /// traps on (`keyLogger`, with no custom verification callback able to work around it -- unlike
+    /// traps on (`keyLogger`, with no custom verification callback able to work around it, unlike
     /// `.noHostnameVerification`, see the doc comment below) or silently drops (everything else
-    /// here -- they're read from the built `TLSConfiguration` and then never looked at again) when
+    /// here; they're read from the built `TLSConfiguration` and then never looked at again) when
     /// running on Network.framework. Each one must flip `isCompatibleWithNetworkFramework` to
     /// `false` so the caller falls back to plain NIO instead of crashing or losing the setting
     /// without any signal. `certificateChain`/`privateKey` (mTLS), `tlsPins` (SPKI pinning),
@@ -434,7 +434,7 @@ extension InternalsSecureConnectionTests {
     /// and `.noHostnameVerification` all reach Network.framework: mTLS through
     /// `tlsLocalIdentityNetworkFramework`, and the other three through
     /// `Internals.NIOTrustEvaluator` installing `tlsCustomVerificationNetworkFramework` on its own,
-    /// independently of whether SPKI pinning is also configured -- `skipsHostnameVerification`
+    /// independently of whether SPKI pinning is also configured. `skipsHostnameVerification`
     /// additionally swaps in a hostname-less trust policy for the `.noHostnameVerification` case
     /// specifically. Mirrors `secureConnection_whenURLSessionReachableFieldSet_remainsCompatible`
     /// below, but for the Network.framework-facing reason list.
@@ -481,7 +481,7 @@ extension InternalsSecureConnectionTests {
     }
 
     /// Mirrors `secureConnection_whenNetworkFrameworkUnsupportedFieldSet_isIncompatible` above,
-    /// but for the URLSession-facing reason list -- deliberately a *different* field set, since
+    /// but for the URLSession-facing reason list: deliberately a *different* field set, since
     /// the two executors aren't a strict hierarchy of each other.
     @Test(
         arguments: [
@@ -562,12 +562,12 @@ extension InternalsSecureConnectionTests {
         #expect(secureConnection.urlSessionIncompatibilityReasons().contains(.keyLogger))
     }
 
-    /// Regression coverage: `build()` used to call `makeLocalIdentityForNetworkFramework()` -- a
-    /// Keychain round-trip -- unconditionally on Darwin whenever both `certificateChain`/
+    /// Regression coverage: `build()` used to call `makeLocalIdentityForNetworkFramework()`, a
+    /// Keychain round-trip, unconditionally on Darwin whenever both `certificateChain`/
     /// `privateKey` were configured, even for a caller that was never going to run over
     /// Network.framework at all. That meant configuring mTLS for `.urlSession`/
     /// `.nioTransportServices` silently broke a `.nio`-pinned request too, on any process without
-    /// Keychain Sharing entitlement (e.g. this SwiftPM test harness) -- see
+    /// Keychain Sharing entitlement (e.g. this SwiftPM test harness). See
     /// `DataTaskTests.dataTask_whenCAEnabled()`, which pins `.requiredExecutor(.nio)` specifically
     /// to avoid this and used to hit it anyway.
     @Test
@@ -595,11 +595,11 @@ extension InternalsSecureConnectionTests {
 
     /// Regression coverage for a crash: `TLSConfiguration.getNWProtocolTLSOptions()`
     /// (AsyncHTTPClient's NIOTransportServices bridge) `preconditionFailure`s the instant
-    /// `certificateChain`/`privateKey` is non-empty, unconditionally -- so leaving either set,
+    /// `certificateChain`/`privateKey` is non-empty, unconditionally, so leaving either set,
     /// even alongside a correctly-built `localIdentityHandle`, would crash the process the moment
     /// this configuration actually ran over `.nioTransportServices`. `build()` bundles that
     /// `TLSConfiguration` and the Network.framework identity into one throwing call, so this can't
-    /// inspect the former without the latter's Keychain round-trip also succeeding -- a known gap
+    /// inspect the former without the latter's Keychain round-trip also succeeding, a known gap
     /// on this bare SwiftPM test harness (see `InternalsClientIdentityDescriptorTests`) unrelated
     /// to what's actually being checked here, hence the `withKnownIssue` wrapper.
     @Test

--- a/Tests/RequestDLInternalsTests/Sources/Secure Connection/Secure Connection/InternalsSecureConnectionTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Secure Connection/Secure Connection/InternalsSecureConnectionTests.swift
@@ -558,4 +558,35 @@ extension InternalsSecureConnectionTests {
         // Then
         #expect(secureConnection.urlSessionIncompatibilityReasons().contains(.keyLogger))
     }
+
+    /// Regression coverage: `build()` used to call `makeLocalIdentityForNetworkFramework()` -- a
+    /// Keychain round-trip -- unconditionally on Darwin whenever both `certificateChain`/
+    /// `privateKey` were configured, even for a caller that was never going to run over
+    /// Network.framework at all. That meant configuring mTLS for `.urlSession`/
+    /// `.nioTransportServices` silently broke a `.nio`-pinned request too, on any process without
+    /// Keychain Sharing entitlement (e.g. this SwiftPM test harness) -- see
+    /// `DataTaskTests.dataTask_whenCAEnabled()`, which pins `.requiredExecutor(.nio)` specifically
+    /// to avoid this and used to hit it anyway.
+    @Test
+    func secureConnection_whenMTLSConfiguredButNetworkFrameworkNotNeeded_skipsKeychainIdentityBuild() async throws {
+        // Given
+        let client = Certificates().client()
+
+        var secureConnection = Internals.SecureConnection()
+        secureConnection.certificateChain = .file(client.certificateURL.absolutePath(percentEncoded: false))
+        secureConnection.privateKey = .privateKey(
+            .init(client.privateKeyURL.absolutePath(percentEncoded: false), format: .pem)
+        )
+
+        // When
+        let sut = try secureConnection.build(isCompatibleWithNetworkFramework: false)
+
+        // Then -- completes without ever attempting the Keychain round-trip, even on a machine
+        // with no Keychain Sharing entitlement at all. `tlsConfiguration.certificateChain` still
+        // carries the mTLS cert, proving `build()` did real work rather than short-circuiting.
+        #expect(!sut.tlsConfiguration.certificateChain.isEmpty)
+        #if canImport(Darwin)
+        #expect(sut.localIdentityHandle == nil)
+        #endif
+    }
 }

--- a/Tests/RequestDLInternalsTests/Sources/Secure Connection/Secure Connection/InternalsSecureConnectionTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Secure Connection/Secure Connection/InternalsSecureConnectionTests.swift
@@ -592,4 +592,37 @@ extension InternalsSecureConnectionTests {
         #expect(sut.localIdentityHandle == nil)
         #endif
     }
+
+    /// Regression coverage for a crash: `TLSConfiguration.getNWProtocolTLSOptions()`
+    /// (AsyncHTTPClient's NIOTransportServices bridge) `preconditionFailure`s the instant
+    /// `certificateChain`/`privateKey` is non-empty, unconditionally -- so leaving either set,
+    /// even alongside a correctly-built `localIdentityHandle`, would crash the process the moment
+    /// this configuration actually ran over `.nioTransportServices`. `build()` bundles that
+    /// `TLSConfiguration` and the Network.framework identity into one throwing call, so this can't
+    /// inspect the former without the latter's Keychain round-trip also succeeding -- a known gap
+    /// on this bare SwiftPM test harness (see `InternalsClientIdentityDescriptorTests`) unrelated
+    /// to what's actually being checked here, hence the `withKnownIssue` wrapper.
+    @Test
+    func secureConnection_whenMTLSConfiguredAndNetworkFrameworkNeeded_omitsRawCertificateChainFromTLSConfiguration()
+        async throws
+    {
+        // Given
+        let client = Certificates().client()
+
+        var secureConnection = Internals.SecureConnection()
+        secureConnection.certificateChain = .file(client.certificateURL.absolutePath(percentEncoded: false))
+        secureConnection.privateKey = .privateKey(
+            .init(client.privateKeyURL.absolutePath(percentEncoded: false), format: .pem)
+        )
+
+        // When / Then
+        await withKnownIssue(
+            "this SwiftPM test harness has no Keychain Sharing entitlement on any platform -- see RequestConfigurationURLSessionClientMTLSTests's type doc comment"
+        ) {
+            let sut = try secureConnection.build(isCompatibleWithNetworkFramework: true)
+
+            #expect(sut.tlsConfiguration.certificateChain.isEmpty)
+            #expect(sut.tlsConfiguration.privateKey == nil)
+        }
+    }
 }

--- a/Tests/RequestDLInternalsTests/Sources/Secure Connection/Secure Connection/InternalsSecureConnectionTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Secure Connection/Secure Connection/InternalsSecureConnectionTests.swift
@@ -431,7 +431,7 @@ extension InternalsSecureConnectionTests {
     }
 
     /// mTLS (`certificateChain`/`privateKey`), SPKI pinning (`tlsPins`), `additionalTrustRoots`,
-    /// and `.noHostnameVerification` all reach Network.framework now: mTLS through
+    /// and `.noHostnameVerification` all reach Network.framework: mTLS through
     /// `tlsLocalIdentityNetworkFramework`, and the other three through
     /// `Internals.NIOTrustEvaluator` installing `tlsCustomVerificationNetworkFramework` on its own,
     /// independently of whether SPKI pinning is also configured -- `skipsHostnameVerification`

--- a/Tests/RequestDLInternalsTests/Sources/Secure Connection/Secure Connection/InternalsSecureConnectionTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Secure Connection/Secure Connection/InternalsSecureConnectionTests.swift
@@ -2,6 +2,7 @@
 // See LICENSE for this package's licensing information.
 //
 
+import Crypto
 import NIOCore
 import NIOSSL
 import Testing
@@ -383,10 +384,14 @@ extension InternalsSecureConnectionTests {
     }
 
     /// Regression coverage for the fields AsyncHTTPClient's NIOTransportServices bridge either
-    /// traps on (`certificateChain`, `privateKey`, `keyLogger`, `.noHostnameVerification`) or
-    /// silently drops (everything else here) when running on Network.framework. Each one must
-    /// flip `isCompatibleWithNetworkFramework` to `false` so the caller falls back to plain NIO
-    /// instead of crashing or losing the setting without any signal.
+    /// traps on (`keyLogger`, `.noHostnameVerification` -- unless a custom verification callback
+    /// is also installed, which none of these cases do) or silently drops (everything else here,
+    /// when SPKI pinning isn't also configured -- see `additionalTrustRootsUnderNetworkFramework`'s
+    /// doc comment) when running on Network.framework. Each one must flip
+    /// `isCompatibleWithNetworkFramework` to `false` so the caller falls back to plain NIO instead
+    /// of crashing or losing the setting without any signal. `certificateChain`/`privateKey`
+    /// (mTLS) and `tlsPins` (SPKI pinning) are deliberately *not* in this list any more -- see
+    /// `secureConnection_whenNetworkFrameworkReachableFieldSet_remainsCompatible` below.
     @Test(
         arguments: [
             { (secureConnection: inout Internals.SecureConnection) in
@@ -429,6 +434,38 @@ extension InternalsSecureConnectionTests {
 
         // Then
         #expect(!secureConnection.isCompatibleWithNetworkFramework)
+    }
+
+    /// mTLS (`certificateChain`/`privateKey`) and SPKI pinning (`tlsPins`) both reach
+    /// Network.framework now, through `tlsLocalIdentityNetworkFramework` and
+    /// `tlsCustomVerificationNetworkFramework` respectively (AsyncHTTPClient fork, 1.38.0+) --
+    /// mirrors `secureConnection_whenURLSessionReachableFieldSet_remainsCompatible` below, but for
+    /// the Network.framework-facing reason list.
+    @Test(
+        arguments: [
+            { (secureConnection: inout Internals.SecureConnection) in
+                secureConnection.certificateChain = .certificates([])
+                secureConnection.privateKey = .privateKey(.init([], format: .pem))
+            },
+            { (secureConnection: inout Internals.SecureConnection) in
+                secureConnection.tlsPins = [.init(source: .rawData(.init()), algorithm: SHA256.self)]
+            },
+        ] as [@Sendable (inout Internals.SecureConnection) -> Void]
+    )
+    func secureConnection_whenNetworkFrameworkReachableFieldSet_remainsCompatible(
+        _ mutate: @Sendable (inout Internals.SecureConnection) -> Void
+    ) async throws {
+        // Given
+        var secureConnection = Internals.SecureConnection()
+
+        // When
+        mutate(&secureConnection)
+
+        // Then -- `networkFrameworkIncompatibilityReasons()` (the platform-independent logic this
+        // test actually exercises), not `isCompatibleWithNetworkFramework` (which is unconditionally
+        // `false` off Darwin regardless of reasons, since Network.framework doesn't exist there at
+        // all -- see `secureConnection_whenDefault_isCompatibleWithNetworkFramework` above).
+        #expect(secureConnection.networkFrameworkIncompatibilityReasons().isEmpty)
     }
 
     @Test

--- a/Tests/RequestDLInternalsTests/Sources/Secure Connection/Secure Connection/InternalsSecureConnectionTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Secure Connection/Secure Connection/InternalsSecureConnectionTests.swift
@@ -513,6 +513,12 @@ extension InternalsSecureConnectionTests {
             { (secureConnection: inout Internals.SecureConnection) in
                 secureConnection.cipherSuites = "DEFAULT"
             },
+            { (secureConnection: inout Internals.SecureConnection) in
+                secureConnection.maximumTLSVersion = .tlsv12
+            },
+            { (secureConnection: inout Internals.SecureConnection) in
+                secureConnection.applicationProtocols = ["h2"]
+            },
         ] as [@Sendable (inout Internals.SecureConnection) -> Void]
     )
     func secureConnection_whenURLSessionUnsupportedFieldSet_isIncompatible(
@@ -631,5 +637,39 @@ extension InternalsSecureConnectionTests {
             #expect(sut.tlsConfiguration.certificateChain.isEmpty)
             #expect(sut.tlsConfiguration.privateKey == nil)
         }
+    }
+
+    @Test
+    func secureConnection_whenMaximumTLSVersionSet_urlSessionIncompatibilityReasonsContainsIt() async throws {
+        // Given
+        var secureConnection = Internals.SecureConnection()
+        secureConnection.maximumTLSVersion = .tlsv12
+
+        // Then
+        #expect(secureConnection.urlSessionIncompatibilityReasons().contains(.maximumTLSVersionUnderURLSession))
+    }
+
+    @Test
+    func secureConnection_whenApplicationProtocolsSet_urlSessionIncompatibilityReasonsContainsIt() async throws {
+        // Given
+        var secureConnection = Internals.SecureConnection()
+        secureConnection.applicationProtocols = ["h2"]
+
+        // Then
+        #expect(secureConnection.urlSessionIncompatibilityReasons().contains(.applicationProtocolsUnderURLSession))
+    }
+
+    /// `minimumTLSVersion` is deliberately excluded from `urlSessionIncompatibilityReasons()`,
+    /// unlike its sibling `maximumTLSVersion` above. It has a real, reachable equivalent under
+    /// URLSession (an ATS `NSExceptionMinimumTLSVersion` entry in the app's Info.plist), so it
+    /// must never force a fallback away from `.urlSession` or trip `requiredExecutor(.urlSession)`.
+    @Test
+    func secureConnection_whenMinimumTLSVersionSet_remainsCompatibleWithURLSession() async throws {
+        // Given
+        var secureConnection = Internals.SecureConnection()
+        secureConnection.minimumTLSVersion = .tlsv12
+
+        // Then
+        #expect(secureConnection.urlSessionIncompatibilityReasons().isEmpty)
     }
 }

--- a/Tests/RequestDLInternalsTests/Sources/Secure Connection/Secure Connection/InternalsSecureConnectionTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Secure Connection/Secure Connection/InternalsSecureConnectionTests.swift
@@ -390,7 +390,7 @@ extension InternalsSecureConnectionTests {
     /// running on Network.framework. Each one must flip `isCompatibleWithNetworkFramework` to
     /// `false` so the caller falls back to plain NIO instead of crashing or losing the setting
     /// without any signal. `certificateChain`/`privateKey` (mTLS), `tlsPins` (SPKI pinning),
-    /// `additionalTrustRoots`, and `.noHostnameVerification` are deliberately *not* in this list --
+    /// `additionalTrustRoots`, and `.noHostnameVerification` are deliberately *not* in this list;
     /// see `secureConnection_whenNetworkFrameworkReachableFieldSet_remainsCompatible` below.
     @Test(
         arguments: [
@@ -464,10 +464,10 @@ extension InternalsSecureConnectionTests {
         // When
         mutate(&secureConnection)
 
-        // Then -- `networkFrameworkIncompatibilityReasons()` (the platform-independent logic this
+        // Then: `networkFrameworkIncompatibilityReasons()` (the platform-independent logic this
         // test actually exercises), not `isCompatibleWithNetworkFramework` (which is unconditionally
         // `false` off Darwin regardless of reasons, since Network.framework doesn't exist there at
-        // all -- see `secureConnection_whenDefault_isCompatibleWithNetworkFramework` above).
+        // all; see `secureConnection_whenDefault_isCompatibleWithNetworkFramework` above).
         #expect(secureConnection.networkFrameworkIncompatibilityReasons().isEmpty)
     }
 
@@ -584,7 +584,7 @@ extension InternalsSecureConnectionTests {
         // When
         let sut = try secureConnection.build(isCompatibleWithNetworkFramework: false)
 
-        // Then -- completes without ever attempting the Keychain round-trip, even on a machine
+        // Then: completes without ever attempting the Keychain round-trip, even on a machine
         // with no Keychain Sharing entitlement at all. `tlsConfiguration.certificateChain` still
         // carries the mTLS cert, proving `build()` did real work rather than short-circuiting.
         #expect(!sut.tlsConfiguration.certificateChain.isEmpty)

--- a/Tests/RequestDLInternalsTests/Sources/Secure Connection/Secure Connection/InternalsSecureConnectionTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Secure Connection/Secure Connection/InternalsSecureConnectionTests.swift
@@ -384,19 +384,16 @@ extension InternalsSecureConnectionTests {
     }
 
     /// Regression coverage for the fields AsyncHTTPClient's NIOTransportServices bridge either
-    /// traps on (`keyLogger`, `.noHostnameVerification` -- unless a custom verification callback
-    /// is also installed, which none of these cases do) or silently drops (everything else here --
-    /// they're read from the built `TLSConfiguration` and then never looked at again) when running
-    /// on Network.framework. Each one must flip `isCompatibleWithNetworkFramework` to `false` so
-    /// the caller falls back to plain NIO instead of crashing or losing the setting without any
-    /// signal. `certificateChain`/`privateKey` (mTLS), `tlsPins` (SPKI pinning), and
-    /// `additionalTrustRoots` are deliberately *not* in this list -- see
-    /// `secureConnection_whenNetworkFrameworkReachableFieldSet_remainsCompatible` below.
+    /// traps on (`keyLogger`, with no custom verification callback able to work around it -- unlike
+    /// `.noHostnameVerification`, see the doc comment below) or silently drops (everything else
+    /// here -- they're read from the built `TLSConfiguration` and then never looked at again) when
+    /// running on Network.framework. Each one must flip `isCompatibleWithNetworkFramework` to
+    /// `false` so the caller falls back to plain NIO instead of crashing or losing the setting
+    /// without any signal. `certificateChain`/`privateKey` (mTLS), `tlsPins` (SPKI pinning),
+    /// `additionalTrustRoots`, and `.noHostnameVerification` are deliberately *not* in this list --
+    /// see `secureConnection_whenNetworkFrameworkReachableFieldSet_remainsCompatible` below.
     @Test(
         arguments: [
-            { (secureConnection: inout Internals.SecureConnection) in
-                secureConnection.certificateVerification = .noHostnameVerification
-            },
             { (secureConnection: inout Internals.SecureConnection) in
                 secureConnection.renegotiationSupport = .once
             },
@@ -433,12 +430,13 @@ extension InternalsSecureConnectionTests {
         #expect(!secureConnection.isCompatibleWithNetworkFramework)
     }
 
-    /// mTLS (`certificateChain`/`privateKey`), SPKI pinning (`tlsPins`), and `additionalTrustRoots`
-    /// all reach Network.framework now: the first two through `tlsLocalIdentityNetworkFramework`
-    /// and `tlsCustomVerificationNetworkFramework` respectively (AsyncHTTPClient fork, 1.38.0+),
-    /// the last through `Internals.NIOTrustEvaluator` installing that same
-    /// `tlsCustomVerificationNetworkFramework` hook on its own, independently of whether SPKI
-    /// pinning is also configured -- mirrors `secureConnection_whenURLSessionReachableFieldSet_remainsCompatible`
+    /// mTLS (`certificateChain`/`privateKey`), SPKI pinning (`tlsPins`), `additionalTrustRoots`,
+    /// and `.noHostnameVerification` all reach Network.framework now: mTLS through
+    /// `tlsLocalIdentityNetworkFramework`, and the other three through
+    /// `Internals.NIOTrustEvaluator` installing `tlsCustomVerificationNetworkFramework` on its own,
+    /// independently of whether SPKI pinning is also configured -- `skipsHostnameVerification`
+    /// additionally swaps in a hostname-less trust policy for the `.noHostnameVerification` case
+    /// specifically. Mirrors `secureConnection_whenURLSessionReachableFieldSet_remainsCompatible`
     /// below, but for the Network.framework-facing reason list.
     @Test(
         arguments: [
@@ -451,6 +449,9 @@ extension InternalsSecureConnectionTests {
             },
             { (secureConnection: inout Internals.SecureConnection) in
                 secureConnection.additionalTrustRoots = [.file("/dev/null")]
+            },
+            { (secureConnection: inout Internals.SecureConnection) in
+                secureConnection.certificateVerification = .noHostnameVerification
             },
         ] as [@Sendable (inout Internals.SecureConnection) -> Void]
     )

--- a/Tests/RequestDLInternalsTests/Sources/Secure Connection/Secure Connection/InternalsSecureConnectionTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Secure Connection/Secure Connection/InternalsSecureConnectionTests.swift
@@ -387,11 +387,13 @@ extension InternalsSecureConnectionTests {
     /// traps on (`keyLogger`, with no custom verification callback able to work around it, unlike
     /// `.noHostnameVerification`, see the doc comment below) or silently drops (everything else
     /// here; they're read from the built `TLSConfiguration` and then never looked at again) when
-    /// running on Network.framework. Each one must flip `isCompatibleWithNetworkFramework` to
-    /// `false` so the caller falls back to plain NIO instead of crashing or losing the setting
-    /// without any signal. `certificateChain`/`privateKey` (mTLS), `tlsPins` (SPKI pinning),
-    /// `additionalTrustRoots`, and `.noHostnameVerification` are deliberately *not* in this list;
-    /// see `secureConnection_whenNetworkFrameworkReachableFieldSet_remainsCompatible` below.
+    /// running on Network.framework.
+    ///
+    /// Each one must flip `isCompatibleWithNetworkFramework` to `false` so the caller falls back
+    /// to plain NIO instead of crashing or losing the setting without any signal.
+    /// `certificateChain`/`privateKey` (mTLS), `tlsPins` (SPKI pinning), `additionalTrustRoots`,
+    /// and `.noHostnameVerification` are deliberately *not* in this list; see
+    /// `secureConnection_whenNetworkFrameworkReachableFieldSet_remainsCompatible` below.
     @Test(
         arguments: [
             { (secureConnection: inout Internals.SecureConnection) in
@@ -436,8 +438,10 @@ extension InternalsSecureConnectionTests {
     /// `Internals.NIOTrustEvaluator` installing `tlsCustomVerificationNetworkFramework` on its own,
     /// independently of whether SPKI pinning is also configured. `skipsHostnameVerification`
     /// additionally swaps in a hostname-less trust policy for the `.noHostnameVerification` case
-    /// specifically. Mirrors `secureConnection_whenURLSessionReachableFieldSet_remainsCompatible`
-    /// below, but for the Network.framework-facing reason list.
+    /// specifically.
+    ///
+    /// Mirrors `secureConnection_whenURLSessionReachableFieldSet_remainsCompatible` below, but for
+    /// the Network.framework-facing reason list.
     @Test(
         arguments: [
             { (secureConnection: inout Internals.SecureConnection) in
@@ -567,9 +571,10 @@ extension InternalsSecureConnectionTests {
     /// `privateKey` were configured, even for a caller that was never going to run over
     /// Network.framework at all. That meant configuring mTLS for `.urlSession`/
     /// `.nioTransportServices` silently broke a `.nio`-pinned request too, on any process without
-    /// Keychain Sharing entitlement (e.g. this SwiftPM test harness). See
-    /// `DataTaskTests.dataTask_whenCAEnabled()`, which pins `.requiredExecutor(.nio)` specifically
-    /// to avoid this and used to hit it anyway.
+    /// Keychain Sharing entitlement (e.g. this SwiftPM test harness).
+    ///
+    /// See `DataTaskTests.dataTask_whenCAEnabled()`, which pins `.requiredExecutor(.nio)`
+    /// specifically to avoid this and used to hit it anyway.
     @Test
     func secureConnection_whenMTLSConfiguredButNetworkFrameworkNotNeeded_skipsKeychainIdentityBuild() async throws {
         // Given
@@ -597,11 +602,13 @@ extension InternalsSecureConnectionTests {
     /// (AsyncHTTPClient's NIOTransportServices bridge) `preconditionFailure`s the instant
     /// `certificateChain`/`privateKey` is non-empty, unconditionally, so leaving either set,
     /// even alongside a correctly-built `localIdentityHandle`, would crash the process the moment
-    /// this configuration actually ran over `.nioTransportServices`. `build()` bundles that
-    /// `TLSConfiguration` and the Network.framework identity into one throwing call, so this can't
-    /// inspect the former without the latter's Keychain round-trip also succeeding, a known gap
-    /// on this bare SwiftPM test harness (see `InternalsClientIdentityDescriptorTests`) unrelated
-    /// to what's actually being checked here, hence the `withKnownIssue` wrapper.
+    /// this configuration actually ran over `.nioTransportServices`.
+    ///
+    /// `build()` bundles that `TLSConfiguration` and the Network.framework identity into one
+    /// throwing call, so this can't inspect the former without the latter's Keychain round-trip
+    /// also succeeding, a known gap on this bare SwiftPM test harness (see
+    /// `InternalsClientIdentityDescriptorTests`) unrelated to what's actually being checked here,
+    /// hence the `withKnownIssue` wrapper.
     @Test
     func secureConnection_whenMTLSConfiguredAndNetworkFrameworkNeeded_omitsRawCertificateChainFromTLSConfiguration()
         async throws

--- a/Tests/RequestDLInternalsTests/Sources/Secure Connection/Secure Connection/InternalsSecureConnectionTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Secure Connection/Secure Connection/InternalsSecureConnectionTests.swift
@@ -617,7 +617,7 @@ extension InternalsSecureConnectionTests {
 
         // When / Then
         await withKnownIssue(
-            "this SwiftPM test harness has no Keychain Sharing entitlement on any platform -- see RequestConfigurationURLSessionClientMTLSTests's type doc comment"
+            "this SwiftPM test harness has no Keychain Sharing entitlement on any platform; see RequestConfigurationURLSessionClientMTLSTests's type doc comment"
         ) {
             let sut = try secureConnection.build(isCompatibleWithNetworkFramework: true)
 

--- a/Tests/RequestDLInternalsTests/Sources/Secure Connection/Secure Connection/InternalsSecureConnectionTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Secure Connection/Secure Connection/InternalsSecureConnectionTests.swift
@@ -629,14 +629,27 @@ extension InternalsSecureConnectionTests {
         )
 
         // When / Then
-        await withKnownIssue(
-            "this SwiftPM test harness has no Keychain Sharing entitlement on any platform; see RequestConfigurationURLSessionClientMTLSTests's type doc comment"
-        ) {
+        func verify() throws {
             let sut = try secureConnection.build(isCompatibleWithNetworkFramework: true)
 
             #expect(sut.tlsConfiguration.certificateChain.isEmpty)
             #expect(sut.tlsConfiguration.privateKey == nil)
         }
+
+        // The Keychain round-trip this "known issue" is about only happens inside
+        // `#if canImport(Darwin)` code (`makeLocalIdentityForNetworkFramework()`); off Darwin,
+        // `build(isCompatibleWithNetworkFramework:)` never touches the Keychain at all, so `verify()`
+        // succeeds outright there and `withKnownIssue` would fail the test for "not" hitting an
+        // issue that was never reachable off Darwin to begin with.
+        #if canImport(Darwin)
+        await withKnownIssue(
+            "this SwiftPM test harness has no Keychain Sharing entitlement on any platform; see RequestConfigurationURLSessionClientMTLSTests's type doc comment"
+        ) {
+            try verify()
+        }
+        #else
+        try verify()
+        #endif
     }
 
     @Test

--- a/Tests/RequestDLInternalsTests/Sources/Secure Connection/Secure Connection/InternalsSecureConnectionTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Secure Connection/Secure Connection/InternalsSecureConnectionTests.swift
@@ -385,20 +385,17 @@ extension InternalsSecureConnectionTests {
 
     /// Regression coverage for the fields AsyncHTTPClient's NIOTransportServices bridge either
     /// traps on (`keyLogger`, `.noHostnameVerification` -- unless a custom verification callback
-    /// is also installed, which none of these cases do) or silently drops (everything else here,
-    /// when SPKI pinning isn't also configured -- see `additionalTrustRootsUnderNetworkFramework`'s
-    /// doc comment) when running on Network.framework. Each one must flip
-    /// `isCompatibleWithNetworkFramework` to `false` so the caller falls back to plain NIO instead
-    /// of crashing or losing the setting without any signal. `certificateChain`/`privateKey`
-    /// (mTLS) and `tlsPins` (SPKI pinning) are deliberately *not* in this list any more -- see
+    /// is also installed, which none of these cases do) or silently drops (everything else here --
+    /// they're read from the built `TLSConfiguration` and then never looked at again) when running
+    /// on Network.framework. Each one must flip `isCompatibleWithNetworkFramework` to `false` so
+    /// the caller falls back to plain NIO instead of crashing or losing the setting without any
+    /// signal. `certificateChain`/`privateKey` (mTLS), `tlsPins` (SPKI pinning), and
+    /// `additionalTrustRoots` are deliberately *not* in this list -- see
     /// `secureConnection_whenNetworkFrameworkReachableFieldSet_remainsCompatible` below.
     @Test(
         arguments: [
             { (secureConnection: inout Internals.SecureConnection) in
                 secureConnection.certificateVerification = .noHostnameVerification
-            },
-            { (secureConnection: inout Internals.SecureConnection) in
-                secureConnection.additionalTrustRoots = [.file("/dev/null")]
             },
             { (secureConnection: inout Internals.SecureConnection) in
                 secureConnection.renegotiationSupport = .once
@@ -436,11 +433,13 @@ extension InternalsSecureConnectionTests {
         #expect(!secureConnection.isCompatibleWithNetworkFramework)
     }
 
-    /// mTLS (`certificateChain`/`privateKey`) and SPKI pinning (`tlsPins`) both reach
-    /// Network.framework now, through `tlsLocalIdentityNetworkFramework` and
-    /// `tlsCustomVerificationNetworkFramework` respectively (AsyncHTTPClient fork, 1.38.0+) --
-    /// mirrors `secureConnection_whenURLSessionReachableFieldSet_remainsCompatible` below, but for
-    /// the Network.framework-facing reason list.
+    /// mTLS (`certificateChain`/`privateKey`), SPKI pinning (`tlsPins`), and `additionalTrustRoots`
+    /// all reach Network.framework now: the first two through `tlsLocalIdentityNetworkFramework`
+    /// and `tlsCustomVerificationNetworkFramework` respectively (AsyncHTTPClient fork, 1.38.0+),
+    /// the last through `Internals.NIOTrustEvaluator` installing that same
+    /// `tlsCustomVerificationNetworkFramework` hook on its own, independently of whether SPKI
+    /// pinning is also configured -- mirrors `secureConnection_whenURLSessionReachableFieldSet_remainsCompatible`
+    /// below, but for the Network.framework-facing reason list.
     @Test(
         arguments: [
             { (secureConnection: inout Internals.SecureConnection) in
@@ -449,6 +448,9 @@ extension InternalsSecureConnectionTests {
             },
             { (secureConnection: inout Internals.SecureConnection) in
                 secureConnection.tlsPins = [.init(source: .rawData(.init()), algorithm: SHA256.self)]
+            },
+            { (secureConnection: inout Internals.SecureConnection) in
+                secureConnection.additionalTrustRoots = [.file("/dev/null")]
             },
         ] as [@Sendable (inout Internals.SecureConnection) -> Void]
     )

--- a/Tests/RequestDLInternalsTests/Sources/Session/Proxy/InternalsProxyTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Session/Proxy/InternalsProxyTests.swift
@@ -31,7 +31,7 @@ struct InternalsProxyTests {
             authorization: nil
         )
 
-        let resolved = try configuration.build()
+        let resolved = try configuration.build().httpClientConfiguration
 
         // Then
         #expect(resolved.proxy?.host == host)
@@ -55,7 +55,7 @@ struct InternalsProxyTests {
             authorization: .basicRawCredentials(credentials)
         )
 
-        let resolved = try configuration.build()
+        let resolved = try configuration.build().httpClientConfiguration
 
         // Then
         #expect(resolved.proxy?.host == host)
@@ -79,7 +79,7 @@ struct InternalsProxyTests {
             authorization: nil
         )
 
-        let resolved = try configuration.build()
+        let resolved = try configuration.build().httpClientConfiguration
 
         // Then
         #expect(resolved.proxy?.host == host)
@@ -107,7 +107,7 @@ struct InternalsProxyTests {
             connectHeaders: connectHeaders
         )
 
-        let resolved = try configuration.build()
+        let resolved = try configuration.build().httpClientConfiguration
 
         // Then
         #expect(resolved.proxy?.connectHeaders["X-Proxy-Token"] == ["first", "second"])

--- a/Tests/RequestDLInternalsTests/Sources/Session/Session Configuration/InternalsSessionConfigurationExecutorTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Session/Session Configuration/InternalsSessionConfigurationExecutorTests.swift
@@ -390,11 +390,12 @@ struct InternalsSessionConfigurationExecutorTests {
     /// A preference the configuration can't actually satisfy is not an override. Resolution must
     /// fall through to whatever the default priority order would have picked among the
     /// compatible candidates, not honor the preference anyway. Here, that's all the way to `.nio`,
-    /// since the field used also rules out `.urlSession`. There's no longer a field that rules
-    /// out only `.nioTransportServices` while sparing `.urlSession`: `additionalTrustRoots` and
-    /// `.noHostnameVerification` were the last two, and `Internals.NIOTrustEvaluator` closed both
-    /// gaps (see the `..._resolvesToItOverURLSession` tests above). Every remaining incompatible
-    /// field rejects both executors identically (see
+    /// since the field used also rules out `.urlSession`.
+    ///
+    /// There's no longer a field that rules out only `.nioTransportServices` while sparing
+    /// `.urlSession`: `additionalTrustRoots` and `.noHostnameVerification` were the last two, and
+    /// `Internals.NIOTrustEvaluator` closed both gaps (see the `..._resolvesToItOverURLSession`
+    /// tests above). Every remaining incompatible field rejects both executors identically (see
     /// `resolveExecutor_whenIncompatibleWithBothURLSessionAndNIOTransportServices_resolvesToNIO`).
     @Test
     func resolveExecutor_whenNIOTransportServicesPreferredButIncompatible_fallsBackToNIO() async throws {

--- a/Tests/RequestDLInternalsTests/Sources/Session/Session Configuration/InternalsSessionConfigurationExecutorTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Session/Session Configuration/InternalsSessionConfigurationExecutorTests.swift
@@ -280,7 +280,7 @@ struct InternalsSessionConfigurationExecutorTests {
 
     @Test
     func resolveExecutor_whenAdditionalTrustRootsSet_resolvesToURLSessionOnDarwin() async throws {
-        // Given -- reachable under both URLSession and NIOTransportServices (the latter via
+        // Given: reachable under both URLSession and NIOTransportServices (the latter via
         // `Internals.NIOTrustEvaluator`), so this exercises the default priority order
         // (URLSession first) rather than URLSession being the only compatible option.
         var configuration = Internals.Session.Configuration()
@@ -305,7 +305,7 @@ struct InternalsSessionConfigurationExecutorTests {
     func resolveExecutor_whenAdditionalTrustRootsSetAndNIOTransportServicesPreferred_resolvesToItOverURLSession()
         async throws
     {
-        // Given -- `additionalTrustRoots` alone (no SPKI pinning) doesn't rule out NIOTransportServices,
+        // Given: `additionalTrustRoots` alone (no SPKI pinning) doesn't rule out NIOTransportServices,
         // so an explicit preference for it wins instead of falling back to URLSession.
         var configuration = Internals.Session.Configuration()
         configuration.decompression = .enabled(algorithms: [], limit: .none)
@@ -330,7 +330,7 @@ struct InternalsSessionConfigurationExecutorTests {
     func resolveExecutor_whenNoHostnameVerificationSetAndNIOTransportServicesPreferred_resolvesToItOverURLSession()
         async throws
     {
-        // Given -- `.noHostnameVerification` alone doesn't rule out NIOTransportServices either
+        // Given: `.noHostnameVerification` alone doesn't rule out NIOTransportServices either
         // (`Internals.NIOTrustEvaluator` installs the custom verification callback AsyncHTTPClient's
         // own `precondition` trap otherwise requires), so an explicit preference for it wins.
         var configuration = Internals.Session.Configuration()
@@ -638,8 +638,8 @@ struct InternalsSessionConfigurationExecutorTests {
 
     @Test
     func requireExecutor_whenNIOTransportServicesPinnedAndIncompatible_throwsWithExactReasons() async throws {
-        // Given -- `keyLogger` (and the rest of "bucket D") stays a genuine Network.framework gap,
-        // unlike `additionalTrustRoots`/`.noHostnameVerification` -- see the two
+        // Given: `keyLogger` (and the rest of "bucket D") stays a genuine Network.framework gap,
+        // unlike `additionalTrustRoots`/`.noHostnameVerification`. See the two
         // `..._doesNotThrow` tests below for those.
         var configuration = Internals.Session.Configuration()
 
@@ -660,7 +660,7 @@ struct InternalsSessionConfigurationExecutorTests {
 
     @Test
     func requireExecutor_whenNIOTransportServicesPinnedWithAdditionalTrustRootsOnly_doesNotThrow() async throws {
-        // Given -- regression coverage for the gap `Internals.NIOTrustEvaluator` closed:
+        // Given: regression coverage for the gap `Internals.NIOTrustEvaluator` closed:
         // `additionalTrustRoots` alone, with no SPKI pinning, used to throw here.
         var configuration = Internals.Session.Configuration()
 
@@ -674,7 +674,7 @@ struct InternalsSessionConfigurationExecutorTests {
 
     @Test
     func requireExecutor_whenNIOTransportServicesPinnedWithNoHostnameVerificationOnly_doesNotThrow() async throws {
-        // Given -- AsyncHTTPClient's NIOTransportServices bridge traps on `.noHostnameVerification`
+        // Given: AsyncHTTPClient's NIOTransportServices bridge traps on `.noHostnameVerification`
         // via `precondition` unless a custom Network.framework verification callback is installed.
         // `Internals.NIOTrustEvaluator` installs exactly that callback whenever
         // `.noHostnameVerification` is configured, and swaps in a hostname-less trust policy

--- a/Tests/RequestDLInternalsTests/Sources/Session/Session Configuration/InternalsSessionConfigurationExecutorTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Session/Session Configuration/InternalsSessionConfigurationExecutorTests.swift
@@ -389,11 +389,11 @@ struct InternalsSessionConfigurationExecutorTests {
 
     /// A preference the configuration can't actually satisfy is not an override. Resolution must
     /// fall through to whatever the default priority order would have picked among the
-    /// compatible candidates, not honor the preference anyway -- here, all the way to `.nio`,
+    /// compatible candidates, not honor the preference anyway. Here, that's all the way to `.nio`,
     /// since the field used also rules out `.urlSession`. There's no longer a field that rules
     /// out only `.nioTransportServices` while sparing `.urlSession`: `additionalTrustRoots` and
     /// `.noHostnameVerification` were the last two, and `Internals.NIOTrustEvaluator` closed both
-    /// gaps (see the `..._resolvesToItOverURLSession` tests above) -- every remaining incompatible
+    /// gaps (see the `..._resolvesToItOverURLSession` tests above). Every remaining incompatible
     /// field rejects both executors identically (see
     /// `resolveExecutor_whenIncompatibleWithBothURLSessionAndNIOTransportServices_resolvesToNIO`).
     @Test

--- a/Tests/RequestDLInternalsTests/Sources/Session/Session Configuration/InternalsSessionConfigurationExecutorTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Session/Session Configuration/InternalsSessionConfigurationExecutorTests.swift
@@ -268,7 +268,7 @@ struct InternalsSessionConfigurationExecutorTests {
         configuration.httpVersion = .http1Only
 
         var secureConnection = Internals.SecureConnection()
-        secureConnection.certificateVerification = .noHostnameVerification
+        secureConnection.cipherSuiteValues = [.TLS_AES_128_GCM_SHA256]
         configuration.secureConnection = secureConnection
 
         // When
@@ -327,6 +327,32 @@ struct InternalsSessionConfigurationExecutorTests {
         #endif
     }
 
+    @Test
+    func resolveExecutor_whenNoHostnameVerificationSetAndNIOTransportServicesPreferred_resolvesToItOverURLSession()
+        async throws
+    {
+        // Given -- `.noHostnameVerification` alone used to keep NIOTransportServices off the
+        // table entirely (AsyncHTTPClient's own `precondition` trap); `Internals.NIOTrustEvaluator`
+        // closed that gap too, so an explicit preference for it now actually wins.
+        var configuration = Internals.Session.Configuration()
+        configuration.decompression = .enabled(algorithms: [], limit: .none)
+        configuration.preferredExecutor = .nioTransportServices
+
+        var secureConnection = Internals.SecureConnection()
+        secureConnection.certificateVerification = .noHostnameVerification
+        configuration.secureConnection = secureConnection
+
+        // When
+        let sut = configuration.resolveExecutor()
+
+        // Then
+        #if canImport(Darwin)
+        #expect(sut == .nioTransportServices)
+        #else
+        #expect(sut == .nio)
+        #endif
+    }
+
     // MARK: - resolveExecutor() with preferredExecutor
 
     @Test
@@ -364,27 +390,29 @@ struct InternalsSessionConfigurationExecutorTests {
 
     /// A preference the configuration can't actually satisfy is not an override. Resolution must
     /// fall through to whatever the default priority order would have picked among the
-    /// compatible candidates, not honor the preference anyway.
+    /// compatible candidates, not honor the preference anyway -- here, all the way to `.nio`,
+    /// since the field used also rules out `.urlSession`. There's no longer a field that rules
+    /// out only `.nioTransportServices` while sparing `.urlSession`: `additionalTrustRoots` and
+    /// `.noHostnameVerification` were the last two, and `Internals.NIOTrustEvaluator` closed both
+    /// gaps (see the `..._resolvesToItOverURLSession` tests above) -- every remaining incompatible
+    /// field rejects both executors identically (see
+    /// `resolveExecutor_whenIncompatibleWithBothURLSessionAndNIOTransportServices_resolvesToNIO`).
     @Test
-    func resolveExecutor_whenNIOTransportServicesPreferredButIncompatible_fallsBackToURLSession() async throws {
-        // Given -- reachable under URLSession, unreachable under NIOTransportServices
+    func resolveExecutor_whenNIOTransportServicesPreferredButIncompatible_fallsBackToNIO() async throws {
+        // Given
         var configuration = Internals.Session.Configuration()
         configuration.decompression = .enabled(algorithms: [], limit: .none)
         configuration.preferredExecutor = .nioTransportServices
 
         var secureConnection = Internals.SecureConnection()
-        secureConnection.certificateVerification = .noHostnameVerification
+        secureConnection.cipherSuiteValues = [.TLS_AES_128_GCM_SHA256]
         configuration.secureConnection = secureConnection
 
         // When
         let sut = configuration.resolveExecutor()
 
         // Then
-        #if canImport(Darwin)
-        #expect(sut == .urlSession)
-        #else
         #expect(sut == .nio)
-        #endif
     }
 
     @Test
@@ -462,27 +490,23 @@ struct InternalsSessionConfigurationExecutorTests {
     /// The flag's implicit preference is still just a preference, not a guarantee -- a
     /// NIOTransportServices-incompatible field must still fall through past it, the same way an
     /// explicit `preferredExecutor(.nioTransportServices)` already does two tests above this
-    /// section.
+    /// section (including why the fallback lands on `.nio`, not `.urlSession`).
     @Test
-    func resolveExecutor_whenNetworkFrameworkEnabledButIncompatible_fallsThroughToURLSession() async throws {
-        // Given -- reachable under URLSession, unreachable under NIOTransportServices
+    func resolveExecutor_whenNetworkFrameworkEnabledButIncompatible_fallsThroughToNIO() async throws {
+        // Given
         var configuration = Internals.Session.Configuration()
         configuration.decompression = .enabled(algorithms: [], limit: .none)
         configuration.enableNetworkFramework = true
 
         var secureConnection = Internals.SecureConnection()
-        secureConnection.certificateVerification = .noHostnameVerification
+        secureConnection.cipherSuiteValues = [.TLS_AES_128_GCM_SHA256]
         configuration.secureConnection = secureConnection
 
         // When
         let sut = configuration.resolveExecutor()
 
         // Then
-        #if canImport(Darwin)
-        #expect(sut == .urlSession)
-        #else
         #expect(sut == .nio)
-        #endif
     }
 
     // MARK: - resolveExecutor() with requiredExecutor
@@ -615,15 +639,13 @@ struct InternalsSessionConfigurationExecutorTests {
 
     @Test
     func requireExecutor_whenNIOTransportServicesPinnedAndIncompatible_throwsWithExactReasons() async throws {
-        // Given -- `.noHostnameVerification` stays a genuine Network.framework gap (traps via
-        // `precondition` in AsyncHTTPClient's own bridge unless a custom verification callback is
-        // installed, which nothing here does), unlike `additionalTrustRoots` -- see
-        // `requireExecutor_whenNIOTransportServicesPinnedWithAdditionalTrustRootsOnly_doesNotThrow`
-        // below for that one.
+        // Given -- `keyLogger` (and the rest of "bucket D") stays a genuine Network.framework gap,
+        // unlike `additionalTrustRoots`/`.noHostnameVerification` -- see the two
+        // `..._doesNotThrow` tests below for those.
         var configuration = Internals.Session.Configuration()
 
         var secureConnection = Internals.SecureConnection()
-        secureConnection.certificateVerification = .noHostnameVerification
+        secureConnection.cipherSuiteValues = [.TLS_AES_128_GCM_SHA256]
         configuration.secureConnection = secureConnection
 
         // When
@@ -633,7 +655,7 @@ struct InternalsSessionConfigurationExecutorTests {
         } catch let error as Internals.IncompatibleExecutorConfigurationError {
             // Then
             #expect(error.requiredExecutor == .nioTransportServices)
-            #expect(error.reasons == [.noHostnameVerificationUnderNetworkFramework])
+            #expect(error.reasons == [.cipherSuiteValues])
         }
     }
 
@@ -645,6 +667,24 @@ struct InternalsSessionConfigurationExecutorTests {
 
         var secureConnection = Internals.SecureConnection()
         secureConnection.additionalTrustRoots = [.file("/dev/null")]
+        configuration.secureConnection = secureConnection
+
+        // When / Then
+        try configuration.requireExecutor(.nioTransportServices)
+    }
+
+    @Test
+    func requireExecutor_whenNIOTransportServicesPinnedWithNoHostnameVerificationOnly_doesNotThrow() async throws {
+        // Given -- regression coverage for the gap `Internals.NIOTrustEvaluator` closed:
+        // `.noHostnameVerification` alone used to throw here, because AsyncHTTPClient's
+        // NIOTransportServices bridge traps on it via `precondition` unless a custom Network.framework
+        // verification callback is installed. `Internals.NIOTrustEvaluator` now installs exactly
+        // that callback whenever `.noHostnameVerification` is configured, and swaps in a
+        // hostname-less trust policy inside it.
+        var configuration = Internals.Session.Configuration()
+
+        var secureConnection = Internals.SecureConnection()
+        secureConnection.certificateVerification = .noHostnameVerification
         configuration.secureConnection = secureConnection
 
         // When / Then

--- a/Tests/RequestDLInternalsTests/Sources/Session/Session Configuration/InternalsSessionConfigurationExecutorTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Session/Session Configuration/InternalsSessionConfigurationExecutorTests.swift
@@ -352,6 +352,54 @@ struct InternalsSessionConfigurationExecutorTests {
         #endif
     }
 
+    /// Mirrors `resolveExecutor_whenAdditionalTrustRootsSet_resolvesToURLSessionOnDarwin` above,
+    /// but for a field that has *no* URLSession-reachable equivalent (no ATS `Info.plist` key for
+    /// a maximum TLS version), so it must fall back away from `.urlSession` instead.
+    @Test
+    func resolveExecutor_whenMaximumTLSVersionSet_resolvesToNIOTransportServicesOnDarwin() async throws {
+        // Given: fine under NIOTransportServices, unsupported under URLSession
+        var configuration = Internals.Session.Configuration()
+        configuration.decompression = .enabled(algorithms: [], limit: .none)
+
+        var secureConnection = Internals.SecureConnection()
+        secureConnection.maximumTLSVersion = .tlsv12
+        configuration.secureConnection = secureConnection
+
+        // When
+        let sut = configuration.resolveExecutor()
+
+        // Then
+        #if canImport(Darwin)
+        #expect(sut == .nioTransportServices)
+        #else
+        #expect(sut == .nio)
+        #endif
+    }
+
+    /// `minimumTLSVersion` is the deliberate exception: it has a real equivalent under URLSession
+    /// (an ATS `NSExceptionMinimumTLSVersion` entry in the app's Info.plist), so unlike
+    /// `maximumTLSVersion` above, it must never force a fallback away from `.urlSession`.
+    @Test
+    func resolveExecutor_whenMinimumTLSVersionSet_resolvesToURLSessionOnDarwin() async throws {
+        // Given
+        var configuration = Internals.Session.Configuration()
+        configuration.decompression = .enabled(algorithms: [], limit: .none)
+
+        var secureConnection = Internals.SecureConnection()
+        secureConnection.minimumTLSVersion = .tlsv12
+        configuration.secureConnection = secureConnection
+
+        // When
+        let sut = configuration.resolveExecutor()
+
+        // Then
+        #if canImport(Darwin)
+        #expect(sut == .urlSession)
+        #else
+        #expect(sut == .nio)
+        #endif
+    }
+
     // MARK: - resolveExecutor() with preferredExecutor
 
     @Test

--- a/Tests/RequestDLInternalsTests/Sources/Session/Session Configuration/InternalsSessionConfigurationExecutorTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Session/Session Configuration/InternalsSessionConfigurationExecutorTests.swift
@@ -3,6 +3,7 @@
 //
 
 import NIOHTTP1
+import NIOSSL
 import Testing
 
 @testable import RequestDLInternals
@@ -267,7 +268,7 @@ struct InternalsSessionConfigurationExecutorTests {
         configuration.httpVersion = .http1Only
 
         var secureConnection = Internals.SecureConnection()
-        secureConnection.additionalTrustRoots = [.file("/dev/null")]
+        secureConnection.certificateVerification = .noHostnameVerification
         configuration.secureConnection = secureConnection
 
         // When
@@ -279,7 +280,9 @@ struct InternalsSessionConfigurationExecutorTests {
 
     @Test
     func resolveExecutor_whenAdditionalTrustRootsSet_resolvesToURLSessionOnDarwin() async throws {
-        // Given -- reachable under URLSession, unlike under NIOTransportServices
+        // Given -- reachable under both URLSession and NIOTransportServices (the latter via
+        // `Internals.NIOTrustEvaluator`), so this exercises the default priority order
+        // (URLSession first) rather than URLSession being the only compatible option.
         var configuration = Internals.Session.Configuration()
         configuration.decompression = .enabled(algorithms: [], limit: .none)
 
@@ -293,6 +296,32 @@ struct InternalsSessionConfigurationExecutorTests {
         // Then
         #if canImport(Darwin)
         #expect(sut == .urlSession)
+        #else
+        #expect(sut == .nio)
+        #endif
+    }
+
+    @Test
+    func resolveExecutor_whenAdditionalTrustRootsSetAndNIOTransportServicesPreferred_resolvesToItOverURLSession()
+        async throws
+    {
+        // Given -- `additionalTrustRoots` alone (no SPKI pinning) used to keep NIOTransportServices
+        // off the table entirely; `Internals.NIOTrustEvaluator` closed that gap, so an explicit
+        // preference for it now actually wins instead of silently falling back to URLSession.
+        var configuration = Internals.Session.Configuration()
+        configuration.decompression = .enabled(algorithms: [], limit: .none)
+        configuration.preferredExecutor = .nioTransportServices
+
+        var secureConnection = Internals.SecureConnection()
+        secureConnection.additionalTrustRoots = [.file("/dev/null")]
+        configuration.secureConnection = secureConnection
+
+        // When
+        let sut = configuration.resolveExecutor()
+
+        // Then
+        #if canImport(Darwin)
+        #expect(sut == .nioTransportServices)
         #else
         #expect(sut == .nio)
         #endif
@@ -344,7 +373,7 @@ struct InternalsSessionConfigurationExecutorTests {
         configuration.preferredExecutor = .nioTransportServices
 
         var secureConnection = Internals.SecureConnection()
-        secureConnection.additionalTrustRoots = [.file("/dev/null")]
+        secureConnection.certificateVerification = .noHostnameVerification
         configuration.secureConnection = secureConnection
 
         // When
@@ -442,7 +471,7 @@ struct InternalsSessionConfigurationExecutorTests {
         configuration.enableNetworkFramework = true
 
         var secureConnection = Internals.SecureConnection()
-        secureConnection.additionalTrustRoots = [.file("/dev/null")]
+        secureConnection.certificateVerification = .noHostnameVerification
         configuration.secureConnection = secureConnection
 
         // When
@@ -586,11 +615,15 @@ struct InternalsSessionConfigurationExecutorTests {
 
     @Test
     func requireExecutor_whenNIOTransportServicesPinnedAndIncompatible_throwsWithExactReasons() async throws {
-        // Given
+        // Given -- `.noHostnameVerification` stays a genuine Network.framework gap (traps via
+        // `precondition` in AsyncHTTPClient's own bridge unless a custom verification callback is
+        // installed, which nothing here does), unlike `additionalTrustRoots` -- see
+        // `requireExecutor_whenNIOTransportServicesPinnedWithAdditionalTrustRootsOnly_doesNotThrow`
+        // below for that one.
         var configuration = Internals.Session.Configuration()
 
         var secureConnection = Internals.SecureConnection()
-        secureConnection.additionalTrustRoots = [.file("/dev/null")]
+        secureConnection.certificateVerification = .noHostnameVerification
         configuration.secureConnection = secureConnection
 
         // When
@@ -600,8 +633,22 @@ struct InternalsSessionConfigurationExecutorTests {
         } catch let error as Internals.IncompatibleExecutorConfigurationError {
             // Then
             #expect(error.requiredExecutor == .nioTransportServices)
-            #expect(error.reasons == [.additionalTrustRootsUnderNetworkFramework])
+            #expect(error.reasons == [.noHostnameVerificationUnderNetworkFramework])
         }
+    }
+
+    @Test
+    func requireExecutor_whenNIOTransportServicesPinnedWithAdditionalTrustRootsOnly_doesNotThrow() async throws {
+        // Given -- regression coverage for the gap `Internals.NIOTrustEvaluator` closed:
+        // `additionalTrustRoots` alone, with no SPKI pinning, used to throw here.
+        var configuration = Internals.Session.Configuration()
+
+        var secureConnection = Internals.SecureConnection()
+        secureConnection.additionalTrustRoots = [.file("/dev/null")]
+        configuration.secureConnection = secureConnection
+
+        // When / Then
+        try configuration.requireExecutor(.nioTransportServices)
     }
 
     // MARK: - nonURLSessionExecutorIncompatibilityReasons() / early rejection

--- a/Tests/RequestDLInternalsTests/Sources/Session/Session Configuration/InternalsSessionConfigurationExecutorTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Session/Session Configuration/InternalsSessionConfigurationExecutorTests.swift
@@ -305,9 +305,8 @@ struct InternalsSessionConfigurationExecutorTests {
     func resolveExecutor_whenAdditionalTrustRootsSetAndNIOTransportServicesPreferred_resolvesToItOverURLSession()
         async throws
     {
-        // Given -- `additionalTrustRoots` alone (no SPKI pinning) used to keep NIOTransportServices
-        // off the table entirely; `Internals.NIOTrustEvaluator` closed that gap, so an explicit
-        // preference for it now actually wins instead of silently falling back to URLSession.
+        // Given -- `additionalTrustRoots` alone (no SPKI pinning) doesn't rule out NIOTransportServices,
+        // so an explicit preference for it wins instead of falling back to URLSession.
         var configuration = Internals.Session.Configuration()
         configuration.decompression = .enabled(algorithms: [], limit: .none)
         configuration.preferredExecutor = .nioTransportServices
@@ -331,9 +330,9 @@ struct InternalsSessionConfigurationExecutorTests {
     func resolveExecutor_whenNoHostnameVerificationSetAndNIOTransportServicesPreferred_resolvesToItOverURLSession()
         async throws
     {
-        // Given -- `.noHostnameVerification` alone used to keep NIOTransportServices off the
-        // table entirely (AsyncHTTPClient's own `precondition` trap); `Internals.NIOTrustEvaluator`
-        // closed that gap too, so an explicit preference for it now actually wins.
+        // Given -- `.noHostnameVerification` alone doesn't rule out NIOTransportServices either
+        // (`Internals.NIOTrustEvaluator` installs the custom verification callback AsyncHTTPClient's
+        // own `precondition` trap otherwise requires), so an explicit preference for it wins.
         var configuration = Internals.Session.Configuration()
         configuration.decompression = .enabled(algorithms: [], limit: .none)
         configuration.preferredExecutor = .nioTransportServices
@@ -675,12 +674,11 @@ struct InternalsSessionConfigurationExecutorTests {
 
     @Test
     func requireExecutor_whenNIOTransportServicesPinnedWithNoHostnameVerificationOnly_doesNotThrow() async throws {
-        // Given -- regression coverage for the gap `Internals.NIOTrustEvaluator` closed:
-        // `.noHostnameVerification` alone used to throw here, because AsyncHTTPClient's
-        // NIOTransportServices bridge traps on it via `precondition` unless a custom Network.framework
-        // verification callback is installed. `Internals.NIOTrustEvaluator` now installs exactly
-        // that callback whenever `.noHostnameVerification` is configured, and swaps in a
-        // hostname-less trust policy inside it.
+        // Given -- AsyncHTTPClient's NIOTransportServices bridge traps on `.noHostnameVerification`
+        // via `precondition` unless a custom Network.framework verification callback is installed.
+        // `Internals.NIOTrustEvaluator` installs exactly that callback whenever
+        // `.noHostnameVerification` is configured, and swaps in a hostname-less trust policy
+        // inside it, so this doesn't throw.
         var configuration = Internals.Session.Configuration()
 
         var secureConnection = Internals.SecureConnection()

--- a/Tests/RequestDLInternalsTests/Sources/Session/Session Configuration/InternalsSessionConfigurationTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Session/Session Configuration/InternalsSessionConfigurationTests.swift
@@ -24,7 +24,7 @@ import Network
 
 #if canImport(Darwin)
 // `URLSessionConfiguration` isn't part of the narrow `import struct Foundation.UUID` this file
-// otherwise gets by with -- needed only by the Darwin-gated `buildURLSessionConfiguration()`
+// otherwise gets by with; needed only by the Darwin-gated `buildURLSessionConfiguration()`
 // tests below.
 import Foundation
 #endif
@@ -376,12 +376,12 @@ struct InternalsSessionConfigurationTests {
         configuration.enableNetworkFramework = true
         configuration.secureConnection = secureConnection
 
-        // Then -- SPKI pinning is enforced under Network.framework too, via
+        // Then: SPKI pinning is enforced under Network.framework too, via
         // `Internals.NIOTrustEvaluator`/`HTTPClient.Configuration.tlsCustomVerificationNetworkFramework`
         // (AsyncHTTPClient's fork, 1.38.0+), so it no longer needs to steer a session off that
         // executor the way it did when pinning only worked through the NIOSSL backend. Network.framework
         // doesn't exist at all off Darwin, so `isCompatibleWithNetworkFramework` itself stays
-        // unconditionally `false` there regardless of reasons -- checked directly on Darwin, and via
+        // unconditionally `false` there regardless of reasons, checked directly on Darwin, and via
         // the platform-independent reasons list everywhere else.
         #if canImport(Darwin)
         #expect(configuration.isCompatibleWithNetworkFramework)
@@ -490,7 +490,7 @@ struct InternalsSessionConfigurationTests {
     func configuration_whenSecureConnectionOmitsTLSVersionRange_urlSessionConfigurationKeepsSystemDefault()
         async throws
     {
-        // Given -- absence must stay absence, not get forced to some RequestDL-chosen floor
+        // Given: absence must stay absence, not get forced to some RequestDL-chosen floor
         let configuration = Internals.Session.Configuration()
         let defaultConfiguration = URLSessionConfiguration.ephemeral
 

--- a/Tests/RequestDLInternalsTests/Sources/Session/Session Configuration/InternalsSessionConfigurationTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Session/Session Configuration/InternalsSessionConfigurationTests.swift
@@ -352,7 +352,7 @@ struct InternalsSessionConfigurationTests {
     }
 
     @Test
-    func configuration_whenNetworkFrameworkEnabledWithSPKIPinning_isCompatibleWithNetworkFrameworkIsFalse()
+    func configuration_whenNetworkFrameworkEnabledWithSPKIPinning_isCompatibleWithNetworkFrameworkIsTrue()
         async throws
     {
         // Given
@@ -364,11 +364,17 @@ struct InternalsSessionConfigurationTests {
         configuration.enableNetworkFramework = true
         configuration.secureConnection = secureConnection
 
-        // Then -- SPKI pinning silently overrides the Network framework request rather than
-        // failing outright or dropping the pins: AsyncHTTPClient's NIOTransportServices bridge
-        // never consults `SPKIPinningConfiguration`, so honoring `enableNetworkFramework` here
-        // would mean the pins stop being enforced without any signal to the caller.
-        #expect(!configuration.isCompatibleWithNetworkFramework)
+        // Then -- SPKI pinning is enforced under Network.framework too, via
+        // `Internals.NIOTrustEvaluator`/`HTTPClient.Configuration.tlsCustomVerificationNetworkFramework`
+        // (AsyncHTTPClient's fork, 1.38.0+), so it no longer needs to steer a session off that
+        // executor the way it did when pinning only worked through the NIOSSL backend. Network.framework
+        // doesn't exist at all off Darwin, so `isCompatibleWithNetworkFramework` itself stays
+        // unconditionally `false` there regardless of reasons -- checked directly on Darwin, and via
+        // the platform-independent reasons list everywhere else.
+        #if canImport(Darwin)
+        #expect(configuration.isCompatibleWithNetworkFramework)
+        #endif
+        #expect(secureConnection.networkFrameworkIncompatibilityReasons().isEmpty)
         #expect(secureConnection.tlsPins != nil)
     }
 

--- a/Tests/RequestDLInternalsTests/Sources/Session/Session Configuration/InternalsSessionConfigurationTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Session/Session Configuration/InternalsSessionConfigurationTests.swift
@@ -28,7 +28,7 @@ struct InternalsSessionConfigurationTests {
         // When
         configuration.secureConnection = secureConnection
 
-        let builtConfiguration = try configuration.build()
+        let builtConfiguration = try configuration.build().httpClientConfiguration
 
         // Then
         #expect(
@@ -47,7 +47,7 @@ struct InternalsSessionConfigurationTests {
         // When
         configuration.redirectConfiguration = redirectConfiguration
 
-        let builtConfiguration = try configuration.build()
+        let builtConfiguration = try configuration.build().httpClientConfiguration
 
         // Then
         #expect(
@@ -76,7 +76,7 @@ struct InternalsSessionConfigurationTests {
         // When
         configuration.timeout = timeout
 
-        let builtConfiguration = try configuration.build()
+        let builtConfiguration = try configuration.build().httpClientConfiguration
 
         // Then
         #expect(builtConfiguration.timeout.connect == .nanoseconds(connect))
@@ -93,7 +93,7 @@ struct InternalsSessionConfigurationTests {
         // When
         configuration.connectionPool = connectionPool
 
-        let builtConfiguration = try configuration.build()
+        let builtConfiguration = try configuration.build().httpClientConfiguration
 
         // Then
         #expect(builtConfiguration.connectionPool == connectionPool)
@@ -114,7 +114,7 @@ struct InternalsSessionConfigurationTests {
         // When
         configuration.proxy = proxy
 
-        let builtConfiguration = try configuration.build()
+        let builtConfiguration = try configuration.build().httpClientConfiguration
 
         // Then
         #expect(builtConfiguration.proxy?.host == proxy.host)
@@ -140,7 +140,7 @@ struct InternalsSessionConfigurationTests {
         // When
         configuration.proxy = proxy
 
-        let builtConfiguration = try configuration.build()
+        let builtConfiguration = try configuration.build().httpClientConfiguration
 
         // Then
         #expect(builtConfiguration.proxy?.host == proxy.host)
@@ -165,7 +165,7 @@ struct InternalsSessionConfigurationTests {
         // When
         configuration.proxy = proxy
 
-        let builtConfiguration = try configuration.build()
+        let builtConfiguration = try configuration.build().httpClientConfiguration
 
         // Then
         #expect(builtConfiguration.proxy?.host == proxy.host)
@@ -188,7 +188,7 @@ struct InternalsSessionConfigurationTests {
         // When
         configuration.proxy = proxy
 
-        let builtConfiguration = try configuration.build()
+        let builtConfiguration = try configuration.build().httpClientConfiguration
 
         // Then
         #expect(builtConfiguration.proxy?.host == proxy.host)
@@ -206,7 +206,7 @@ struct InternalsSessionConfigurationTests {
         // When
         configuration.decompression = decompression
 
-        let builtConfiguration = try configuration.build()
+        let builtConfiguration = try configuration.build().httpClientConfiguration
 
         // Then
         #expect(
@@ -229,7 +229,7 @@ struct InternalsSessionConfigurationTests {
         // When
         configuration.httpVersion = version
 
-        let builtConfiguration = try configuration.build()
+        let builtConfiguration = try configuration.build().httpClientConfiguration
 
         // Then
         #expect(builtConfiguration.httpVersion == version.build())
@@ -249,7 +249,7 @@ struct InternalsSessionConfigurationTests {
         // When
         configuration.multipathServiceType = multipathServiceType
 
-        let builtConfiguration = try configuration.build()
+        let builtConfiguration = try configuration.build().httpClientConfiguration
 
         // Then
         #expect(builtConfiguration.enableMultipath)
@@ -261,7 +261,7 @@ struct InternalsSessionConfigurationTests {
         let configuration = Internals.Session.Configuration()
 
         // When
-        let builtConfiguration = try configuration.build()
+        let builtConfiguration = try configuration.build().httpClientConfiguration
 
         // Then
         #expect(!builtConfiguration.enableMultipath)
@@ -398,7 +398,7 @@ struct InternalsSessionConfigurationTests {
         configuration.tracer = RecordingTracer()
 
         // When
-        let builtConfiguration = try configuration.build()
+        let builtConfiguration = try configuration.build().httpClientConfiguration
 
         // Then -- `async-http-client`'s own tracing is always suppressed; RequestDL owns the span
         // lifecycle itself (see the doc comment on `Configuration.tracer`).
@@ -412,14 +412,14 @@ struct InternalsSessionConfigurationTests {
 
         // Then
         #expect((configuration.tracer as? NoOpTracer) != nil)
-        #expect((try configuration.build().tracing.tracer as? NoOpTracer) != nil)
+        #expect((try configuration.build().httpClientConfiguration.tracing.tracer as? NoOpTracer) != nil)
     }
 
     @Test
     func configuration_whenInit_shouldBeDefault() async throws {
         // When
         let configuration = Internals.Session.Configuration()
-        let builtConfiguration = try configuration.build()
+        let builtConfiguration = try configuration.build().httpClientConfiguration
 
         // Then
         #expect(builtConfiguration.tlsConfiguration == nil)

--- a/Tests/RequestDLInternalsTests/Sources/Session/Session Configuration/InternalsSessionConfigurationTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Session/Session Configuration/InternalsSessionConfigurationTests.swift
@@ -465,7 +465,7 @@ struct InternalsSessionConfigurationTests {
 
     #if canImport(Darwin)
     /// Regression coverage: `minimumTLSVersion`/`maximumTLSVersion` used to be silently dropped
-    /// under `.urlSession` -- no `URLSessionConfiguration` counterpart was ever set, despite both
+    /// under `.urlSession`: no `URLSessionConfiguration` counterpart was ever set, despite both
     /// being genuinely reachable via `tlsMinimumSupportedProtocolVersion`/
     /// `tlsMaximumSupportedProtocolVersion` (public API since iOS 13/macOS 10.15, both already
     /// below this package's own deployment floor).

--- a/Tests/RequestDLInternalsTests/Sources/Session/Session Configuration/InternalsSessionConfigurationTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Session/Session Configuration/InternalsSessionConfigurationTests.swift
@@ -5,6 +5,7 @@
 import AsyncHTTPClient
 import Crypto
 import NIOCore
+import NIOSSL
 import Testing
 import Tracing
 
@@ -15,6 +16,17 @@ import Tracing
 import FoundationEssentials
 #else
 import struct Foundation.UUID
+#endif
+
+#if canImport(Network)
+import Network
+#endif
+
+#if canImport(Darwin)
+// `URLSessionConfiguration` isn't part of the narrow `import struct Foundation.UUID` this file
+// otherwise gets by with -- needed only by the Darwin-gated `buildURLSessionConfiguration()`
+// tests below.
+import Foundation
 #endif
 
 struct InternalsSessionConfigurationTests {
@@ -450,6 +462,52 @@ struct InternalsSessionConfigurationTests {
         #expect(builtConfiguration.httpVersion == .automatic)
         #expect(!builtConfiguration.enableMultipath)
     }
+
+    #if canImport(Darwin)
+    /// Regression coverage: `minimumTLSVersion`/`maximumTLSVersion` used to be silently dropped
+    /// under `.urlSession` -- no `URLSessionConfiguration` counterpart was ever set, despite both
+    /// being genuinely reachable via `tlsMinimumSupportedProtocolVersion`/
+    /// `tlsMaximumSupportedProtocolVersion` (public API since iOS 13/macOS 10.15, both already
+    /// below this package's own deployment floor).
+    @Test
+    func configuration_whenSecureConnectionSetsTLSVersionRange_urlSessionConfigurationMatches() async throws {
+        // Given
+        var configuration = Internals.Session.Configuration()
+        var secureConnection = Internals.SecureConnection()
+        secureConnection.minimumTLSVersion = .tlsv12
+        secureConnection.maximumTLSVersion = .tlsv13
+        configuration.secureConnection = secureConnection
+
+        // When
+        let urlSessionConfiguration = configuration.buildURLSessionConfiguration()
+
+        // Then
+        #expect(urlSessionConfiguration.tlsMinimumSupportedProtocolVersion == .TLSv12)
+        #expect(urlSessionConfiguration.tlsMaximumSupportedProtocolVersion == .TLSv13)
+    }
+
+    @Test
+    func configuration_whenSecureConnectionOmitsTLSVersionRange_urlSessionConfigurationKeepsSystemDefault()
+        async throws
+    {
+        // Given -- absence must stay absence, not get forced to some RequestDL-chosen floor
+        let configuration = Internals.Session.Configuration()
+        let defaultConfiguration = URLSessionConfiguration.ephemeral
+
+        // When
+        let urlSessionConfiguration = configuration.buildURLSessionConfiguration()
+
+        // Then
+        #expect(
+            urlSessionConfiguration.tlsMinimumSupportedProtocolVersion
+                == defaultConfiguration.tlsMinimumSupportedProtocolVersion
+        )
+        #expect(
+            urlSessionConfiguration.tlsMaximumSupportedProtocolVersion
+                == defaultConfiguration.tlsMaximumSupportedProtocolVersion
+        )
+    }
+    #endif
 }
 
 private struct RecordingTracer: Tracer, Sendable {

--- a/Tests/RequestDLInternalsTests/Sources/Session/Session Configuration/Models/InternalsExecutorIncompatibilityReasonTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Session/Session Configuration/Models/InternalsExecutorIncompatibilityReasonTests.swift
@@ -42,7 +42,6 @@ struct InternalsExecutorIncompatibilityReasonTests {
             .shutdownTimeout,
             .pskHint,
             .pskIdentityResolver,
-            .noHostnameVerificationUnderNetworkFramework,
             .dnsOverrideUnderURLSession,
             .http1OnlyUnderURLSession,
             .proxyConnectHeadersUnderURLSession,
@@ -51,6 +50,6 @@ struct InternalsExecutorIncompatibilityReasonTests {
         ]
 
         // Then
-        #expect(cases.count == 16)
+        #expect(cases.count == 15)
     }
 }

--- a/Tests/RequestDLInternalsTests/Sources/Session/Session Configuration/Models/InternalsExecutorIncompatibilityReasonTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Session/Session Configuration/Models/InternalsExecutorIncompatibilityReasonTests.swift
@@ -11,8 +11,8 @@ struct InternalsExecutorIncompatibilityReasonTests {
     @Test
     func reason_whenEquals() {
         // Given
-        let lhs = Internals.ExecutorIncompatibilityReason.certificateChain
-        let rhs = Internals.ExecutorIncompatibilityReason.certificateChain
+        let lhs = Internals.ExecutorIncompatibilityReason.keyLogger
+        let rhs = Internals.ExecutorIncompatibilityReason.keyLogger
 
         // Then
         #expect(lhs == rhs)
@@ -21,8 +21,8 @@ struct InternalsExecutorIncompatibilityReasonTests {
     @Test
     func reason_whenNotEquals() {
         // Given
-        let lhs = Internals.ExecutorIncompatibilityReason.certificateChain
-        let rhs = Internals.ExecutorIncompatibilityReason.privateKey
+        let lhs = Internals.ExecutorIncompatibilityReason.keyLogger
+        let rhs = Internals.ExecutorIncompatibilityReason.cipherSuites
 
         // Then
         #expect(lhs != rhs)
@@ -32,8 +32,6 @@ struct InternalsExecutorIncompatibilityReasonTests {
     func reason_whenHashable() {
         // Given
         let cases: Set<Internals.ExecutorIncompatibilityReason> = [
-            .certificateChain,
-            .privateKey,
             .keyLogger,
             .cipherSuites,
             .cipherSuiteValues,
@@ -54,6 +52,6 @@ struct InternalsExecutorIncompatibilityReasonTests {
         ]
 
         // Then
-        #expect(cases.count == 19)
+        #expect(cases.count == 17)
     }
 }

--- a/Tests/RequestDLInternalsTests/Sources/Session/Session Configuration/Models/InternalsExecutorIncompatibilityReasonTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Session/Session Configuration/Models/InternalsExecutorIncompatibilityReasonTests.swift
@@ -43,7 +43,6 @@ struct InternalsExecutorIncompatibilityReasonTests {
             .pskHint,
             .pskIdentityResolver,
             .noHostnameVerificationUnderNetworkFramework,
-            .additionalTrustRootsUnderNetworkFramework,
             .dnsOverrideUnderURLSession,
             .http1OnlyUnderURLSession,
             .proxyConnectHeadersUnderURLSession,
@@ -52,6 +51,6 @@ struct InternalsExecutorIncompatibilityReasonTests {
         ]
 
         // Then
-        #expect(cases.count == 17)
+        #expect(cases.count == 16)
     }
 }

--- a/Tests/RequestDLInternalsTests/Sources/Session/Session Configuration/Models/InternalsIncompatibleExecutorConfigurationErrorTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Session/Session Configuration/Models/InternalsIncompatibleExecutorConfigurationErrorTests.swift
@@ -13,12 +13,12 @@ struct InternalsIncompatibleExecutorConfigurationErrorTests {
         // Given
         let error = Internals.IncompatibleExecutorConfigurationError(
             requiredExecutor: .nioTransportServices,
-            reasons: [.additionalTrustRootsUnderNetworkFramework, .keyLogger]
+            reasons: [.dnsOverrideUnderURLSession, .keyLogger]
         )
 
         // Then
         #expect(error.requiredExecutor == .nioTransportServices)
-        #expect(error.reasons == [.additionalTrustRootsUnderNetworkFramework, .keyLogger])
+        #expect(error.reasons == [.dnsOverrideUnderURLSession, .keyLogger])
     }
 
     @Test

--- a/Tests/RequestDLInternalsTests/Sources/Session/Session Configuration/Models/InternalsIncompatibleExecutorConfigurationErrorTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Session/Session Configuration/Models/InternalsIncompatibleExecutorConfigurationErrorTests.swift
@@ -13,12 +13,12 @@ struct InternalsIncompatibleExecutorConfigurationErrorTests {
         // Given
         let error = Internals.IncompatibleExecutorConfigurationError(
             requiredExecutor: .nioTransportServices,
-            reasons: [.additionalTrustRootsUnderNetworkFramework, .certificateChain]
+            reasons: [.additionalTrustRootsUnderNetworkFramework, .keyLogger]
         )
 
         // Then
         #expect(error.requiredExecutor == .nioTransportServices)
-        #expect(error.reasons == [.additionalTrustRootsUnderNetworkFramework, .certificateChain])
+        #expect(error.reasons == [.additionalTrustRootsUnderNetworkFramework, .keyLogger])
     }
 
     @Test

--- a/Tests/RequestDLTests/Properties/Sources/Graph/Resolve/ResolveTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Graph/Resolve/ResolveTests.swift
@@ -255,6 +255,8 @@ extension ResolveTests {
                                     additionalTrustRoots = nil,
                                     tlsPinningPolicy = nil,
                                     tlsPins = nil,
+                                    revocationPolicy = nil,
+                                    trustDecisionObserver = nil,
                                     privateKey = nil,
                                     signingSignatureAlgorithms = nil,
                                     verifySignatureAlgorithms = nil,

--- a/Tests/RequestDLTests/Properties/Sources/Session/Session/Models/ExecutorRequirementErrorTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Session/Session/Models/ExecutorRequirementErrorTests.swift
@@ -60,6 +60,8 @@ struct ExecutorRequirementErrorTests {
             .proxyConnectHeadersUnderURLSession,
             .proxyBearerAuthorizationUnderURLSession,
             .decompressionRequiresURLSession,
+            .maximumTLSVersionUnderURLSession,
+            .applicationProtocolsUnderURLSession,
         ]
     )
     func reason_whenEveryInternalCaseMapped_hasNonEmptyDescription(

--- a/Tests/RequestDLTests/Properties/Sources/Session/Session/Models/ExecutorRequirementErrorTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Session/Session/Models/ExecutorRequirementErrorTests.swift
@@ -77,25 +77,4 @@ struct ExecutorRequirementErrorTests {
         // Then
         #expect(!reason.description.isEmpty)
     }
-
-    @Test
-    func reason_additionalTrustRootsUnderNetworkFramework_hasNonEmptyDescription() async throws {
-        // Given -- kept for source compatibility even though RequestDLInternals no longer
-        // produces this case (see its own doc comment); not reachable through
-        // `reason_whenEveryInternalCaseMapped_hasNonEmptyDescription` above since there's no
-        // longer an `Internals.ExecutorIncompatibilityReason` counterpart to map from.
-
-        // Then
-        #expect(!ExecutorRequirementError.Reason.additionalTrustRootsUnderNetworkFramework.description.isEmpty)
-    }
-
-    @Test
-    func reason_noHostnameVerificationUnderNetworkFramework_hasNonEmptyDescription() async throws {
-        // Given -- same situation as `additionalTrustRootsUnderNetworkFramework` above: kept for
-        // source compatibility, no longer produced, no longer reachable through the parameterized
-        // test above.
-
-        // Then
-        #expect(!ExecutorRequirementError.Reason.noHostnameVerificationUnderNetworkFramework.description.isEmpty)
-    }
 }

--- a/Tests/RequestDLTests/Properties/Sources/Session/Session/Models/ExecutorRequirementErrorTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Session/Session/Models/ExecutorRequirementErrorTests.swift
@@ -55,7 +55,6 @@ struct ExecutorRequirementErrorTests {
             .shutdownTimeout,
             .pskHint,
             .pskIdentityResolver,
-            .noHostnameVerificationUnderNetworkFramework,
             .dnsOverrideUnderURLSession,
             .http1OnlyUnderURLSession,
             .proxyConnectHeadersUnderURLSession,
@@ -88,5 +87,15 @@ struct ExecutorRequirementErrorTests {
 
         // Then
         #expect(!ExecutorRequirementError.Reason.additionalTrustRootsUnderNetworkFramework.description.isEmpty)
+    }
+
+    @Test
+    func reason_noHostnameVerificationUnderNetworkFramework_hasNonEmptyDescription() async throws {
+        // Given -- same situation as `additionalTrustRootsUnderNetworkFramework` above: kept for
+        // source compatibility, no longer produced, no longer reachable through the parameterized
+        // test above.
+
+        // Then
+        #expect(!ExecutorRequirementError.Reason.noHostnameVerificationUnderNetworkFramework.description.isEmpty)
     }
 }

--- a/Tests/RequestDLTests/Properties/Sources/Session/Session/Models/ExecutorRequirementErrorTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Session/Session/Models/ExecutorRequirementErrorTests.swift
@@ -14,7 +14,7 @@ struct ExecutorRequirementErrorTests {
         // Given
         let internalError = Internals.IncompatibleExecutorConfigurationError(
             requiredExecutor: .nioTransportServices,
-            reasons: [.additionalTrustRootsUnderNetworkFramework, .keyLogger]
+            reasons: [.dnsOverrideUnderURLSession, .keyLogger]
         )
 
         // When
@@ -22,7 +22,7 @@ struct ExecutorRequirementErrorTests {
 
         // Then
         #expect(error.requiredExecutor == .nioTransportServices)
-        #expect(error.reasons == [.additionalTrustRootsUnderNetworkFramework, .keyLogger])
+        #expect(error.reasons == [.dnsOverrideUnderURLSession, .keyLogger])
     }
 
     @Test
@@ -56,7 +56,6 @@ struct ExecutorRequirementErrorTests {
             .pskHint,
             .pskIdentityResolver,
             .noHostnameVerificationUnderNetworkFramework,
-            .additionalTrustRootsUnderNetworkFramework,
             .dnsOverrideUnderURLSession,
             .http1OnlyUnderURLSession,
             .proxyConnectHeadersUnderURLSession,
@@ -78,5 +77,16 @@ struct ExecutorRequirementErrorTests {
 
         // Then
         #expect(!reason.description.isEmpty)
+    }
+
+    @Test
+    func reason_additionalTrustRootsUnderNetworkFramework_hasNonEmptyDescription() async throws {
+        // Given -- kept for source compatibility even though RequestDLInternals no longer
+        // produces this case (see its own doc comment); not reachable through
+        // `reason_whenEveryInternalCaseMapped_hasNonEmptyDescription` above since there's no
+        // longer an `Internals.ExecutorIncompatibilityReason` counterpart to map from.
+
+        // Then
+        #expect(!ExecutorRequirementError.Reason.additionalTrustRootsUnderNetworkFramework.description.isEmpty)
     }
 }

--- a/Tests/RequestDLTests/Properties/Sources/Session/Session/Models/ExecutorRequirementErrorTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Session/Session/Models/ExecutorRequirementErrorTests.swift
@@ -14,7 +14,7 @@ struct ExecutorRequirementErrorTests {
         // Given
         let internalError = Internals.IncompatibleExecutorConfigurationError(
             requiredExecutor: .nioTransportServices,
-            reasons: [.additionalTrustRootsUnderNetworkFramework, .certificateChain]
+            reasons: [.additionalTrustRootsUnderNetworkFramework, .keyLogger]
         )
 
         // When
@@ -22,7 +22,7 @@ struct ExecutorRequirementErrorTests {
 
         // Then
         #expect(error.requiredExecutor == .nioTransportServices)
-        #expect(error.reasons == [.additionalTrustRootsUnderNetworkFramework, .certificateChain])
+        #expect(error.reasons == [.additionalTrustRootsUnderNetworkFramework, .keyLogger])
     }
 
     @Test
@@ -45,9 +45,7 @@ struct ExecutorRequirementErrorTests {
 
     @Test(
         arguments: [
-            Internals.ExecutorIncompatibilityReason.certificateChain,
-            .privateKey,
-            .keyLogger,
+            Internals.ExecutorIncompatibilityReason.keyLogger,
             .cipherSuites,
             .cipherSuiteValues,
             .renegotiationSupport,

--- a/Tests/RequestDLTests/Properties/Sources/Session/Session/SessionTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Session/Session/SessionTests.swift
@@ -438,7 +438,8 @@ struct SessionTests {
         // `async-http-client`'s own built-in tracing is always suppressed -- RequestDL owns the
         // span lifecycle itself, in `RawTask.result()`, using `resolved.session.configuration
         // .tracer` directly.
-        #expect(try (resolved.session.configuration.build().tracing.tracer as? NoOpTracer) != nil)
+        let builtTracer = try resolved.session.configuration.build().httpClientConfiguration.tracing.tracer
+        #expect((builtTracer as? NoOpTracer) != nil)
     }
 
     @Test

--- a/Tests/RequestDLTests/Request/InternalsClientIdentityDescriptorTests.swift
+++ b/Tests/RequestDLTests/Request/InternalsClientIdentityDescriptorTests.swift
@@ -215,7 +215,6 @@ struct InternalsClientIdentityDescriptorTests {
             "this SwiftPM test harness has no Keychain Sharing entitlement on any platform; see RequestConfigurationURLSessionClientMTLSTests's type doc comment",
             {
                 let (handle, intermediates) = try rebuiltClientIdentityDescriptor.makeIdentity()
-                defer { Internals.RawBytesIdentityBuilder.remove(handle) }
 
                 let delegate = ClientCertificateForwardingDelegate(
                     identity: handle.identity,

--- a/Tests/RequestDLTests/Request/InternalsClientIdentityDescriptorTests.swift
+++ b/Tests/RequestDLTests/Request/InternalsClientIdentityDescriptorTests.swift
@@ -212,7 +212,7 @@ struct InternalsClientIdentityDescriptorTests {
 
         // Then
         await withKnownIssue(
-            "this SwiftPM test harness has no Keychain Sharing entitlement on any platform -- see RequestConfigurationURLSessionClientMTLSTests's type doc comment",
+            "this SwiftPM test harness has no Keychain Sharing entitlement on any platform; see RequestConfigurationURLSessionClientMTLSTests's type doc comment",
             {
                 let (handle, intermediates) = try rebuiltClientIdentityDescriptor.makeIdentity()
                 defer { Internals.RawBytesIdentityBuilder.remove(handle) }

--- a/Tests/RequestDLTests/Request/InternalsServerTrustPolicyTests.swift
+++ b/Tests/RequestDLTests/Request/InternalsServerTrustPolicyTests.swift
@@ -235,7 +235,7 @@ struct InternalsServerTrustPolicyTests {
     // MARK: - Trust decision observer
 
     /// A live (never `descriptor()`-rebuilt) policy, since `Descriptor` is `Codable`-only and
-    /// can't carry an observer across a relaunch -- see ``Internals/ServerTrustPolicy/init(descriptor:)``'s
+    /// can't carry an observer across a relaunch. See ``Internals/ServerTrustPolicy/init(descriptor:)``'s
     /// own doc comment.
     @Test
     func handle_whenChainAndPinsBothMatch_notifiesObserverWithTrustedDecision() async throws {
@@ -580,7 +580,7 @@ private final class ForwardingChallengeDelegate: NSObject, URLSessionTaskDelegat
 }
 
 /// A test double recording every ``TrustDecision`` it's notified of, in order. `@unchecked
-/// Sendable` is safe here -- `URLSession`'s challenge delegate callback runs each handshake's
+/// Sendable` is safe here, since `URLSession`'s challenge delegate callback runs each handshake's
 /// decision serially, one at a time, for these single-request tests.
 private final class RecordingTrustDecisionObserver: TrustDecisionObserver, @unchecked Sendable {
     private(set) var decisions: [TrustDecision] = []

--- a/Tests/RequestDLTests/Request/InternalsServerTrustPolicyTests.swift
+++ b/Tests/RequestDLTests/Request/InternalsServerTrustPolicyTests.swift
@@ -90,6 +90,50 @@ struct InternalsServerTrustPolicyTests {
         #expect(descriptor.trustedRootCertificatesDER.count == 2)
     }
 
+    // MARK: - Revocation policy
+
+    @Test
+    func resolve_whenRevocationPolicyConfigured_capturesInDescriptor() async throws {
+        // Given
+        var secureConnection = Internals.SecureConnection()
+        secureConnection.revocationPolicy = .strict
+
+        // When
+        let descriptor = try Internals.ServerTrustPolicy.resolve(from: secureConnection).descriptor()
+
+        // Then
+        #expect(descriptor.revocationPolicy == .strict)
+    }
+
+    @Test
+    func resolve_whenNoRevocationPolicyConfigured_descriptorHasNone() async throws {
+        // Given
+        let secureConnection = Internals.SecureConnection()
+
+        // When
+        let descriptor = try Internals.ServerTrustPolicy.resolve(from: secureConnection).descriptor()
+
+        // Then
+        #expect(descriptor.revocationPolicy == nil)
+    }
+
+    @Test
+    func descriptor_roundTripsRevocationPolicyThroughInit() async throws {
+        // Given
+        var secureConnection = Internals.SecureConnection()
+        secureConnection.revocationPolicy = .disabled
+
+        let original = try Internals.ServerTrustPolicy.resolve(from: secureConnection)
+
+        // When
+        let encoded = try JSONEncoder().encode(original.descriptor())
+        let decoded = try JSONDecoder().decode(Internals.ServerTrustPolicy.Descriptor.self, from: encoded)
+        let rebuilt = Internals.ServerTrustPolicy(descriptor: decoded)
+
+        // Then
+        #expect(try rebuilt.descriptor() == original.descriptor())
+    }
+
     // MARK: - SPKI pinning
 
     @Test

--- a/Tests/RequestDLTests/Request/InternalsServerTrustPolicyTests.swift
+++ b/Tests/RequestDLTests/Request/InternalsServerTrustPolicyTests.swift
@@ -232,6 +232,83 @@ struct InternalsServerTrustPolicyTests {
         #expect(try rebuilt.descriptor() == original.descriptor())
     }
 
+    // MARK: - Trust decision observer
+
+    /// A live (never `descriptor()`-rebuilt) policy, since `Descriptor` is `Codable`-only and
+    /// can't carry an observer across a relaunch -- see ``Internals/ServerTrustPolicy/init(descriptor:)``'s
+    /// own doc comment.
+    @Test
+    func handle_whenChainAndPinsBothMatch_notifiesObserverWithTrustedDecision() async throws {
+        // Given
+        let server = Certificates().server()
+        let pin = try hashSPKI(from: server.certificateURL, algorithm: SHA256.self)
+        let localServer = try await LocalServer(.standard)
+        let uri = "/" + UUID().uuidString
+        let output = "Hello World"
+
+        let response = try LocalServer.ResponseConfiguration(jsonObject: output)
+        localServer.cleanup(at: uri)
+        localServer.insert(response, at: uri)
+        defer { localServer.cleanup(at: uri) }
+
+        var secureConnection = Internals.SecureConnection()
+        secureConnection.trustRoots = .file(server.certificateURL.absolutePath(percentEncoded: false))
+        secureConnection.tlsPins = [.init(source: .rawData(pin), algorithm: SHA256.self)]
+        secureConnection.tlsPinningPolicy = .strict
+        let observer = RecordingTrustDecisionObserver()
+        secureConnection.trustDecisionObserver = observer
+
+        let policy = try Internals.ServerTrustPolicy.resolve(from: secureConnection)
+
+        let delegate = ForwardingChallengeDelegate(policy: policy)
+        let session = URLSession(configuration: .ephemeral, delegate: delegate, delegateQueue: nil)
+
+        var request = URLRequest(url: try #require(URL(string: "https://\(localServer.baseURL)\(uri)")))
+        request.httpMethod = "GET"
+
+        // When
+        _ = try await session.data(for: request)
+
+        // Then
+        #expect(observer.decisions == [TrustDecision(isTrusted: true, pinsMatched: true)])
+    }
+
+    @Test
+    func handle_whenPinMismatch_notifiesObserverWithUntrustedDecisionAndUnmatchedPins() async throws {
+        // Given
+        let server = Certificates().server()
+        let unrelatedCertificate = Certificates().client()
+        let wrongPin = try hashSPKI(from: unrelatedCertificate.certificateURL, algorithm: SHA256.self)
+        let localServer = try await LocalServer(.standard)
+        let uri = "/" + UUID().uuidString
+
+        localServer.cleanup(at: uri)
+        defer { localServer.cleanup(at: uri) }
+
+        var secureConnection = Internals.SecureConnection()
+        secureConnection.trustRoots = .file(server.certificateURL.absolutePath(percentEncoded: false))
+        secureConnection.tlsPins = [.init(source: .rawData(wrongPin), algorithm: SHA256.self)]
+        secureConnection.tlsPinningPolicy = .strict
+        let observer = RecordingTrustDecisionObserver()
+        secureConnection.trustDecisionObserver = observer
+
+        let policy = try Internals.ServerTrustPolicy.resolve(from: secureConnection)
+
+        let delegate = ForwardingChallengeDelegate(policy: policy)
+        let session = URLSession(configuration: .ephemeral, delegate: delegate, delegateQueue: nil)
+
+        var request = URLRequest(url: try #require(URL(string: "https://\(localServer.baseURL)\(uri)")))
+        request.httpMethod = "GET"
+
+        // When
+        await #expect(throws: (any Error).self) {
+            try await session.data(for: request)
+        }
+
+        // Then
+        #expect(observer.decisions == [TrustDecision(isTrusted: false, pinsMatched: false)])
+    }
+
     // MARK: - handle(challenge:completionHandler:) -- real handshake, rebuilt policy
 
     /// The whole point of splitting this type out: a policy rebuilt from nothing but a
@@ -499,6 +576,17 @@ private final class ForwardingChallengeDelegate: NSObject, URLSessionTaskDelegat
         completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
     ) {
         policy.handle(challenge: challenge, completionHandler: completionHandler)
+    }
+}
+
+/// A test double recording every ``TrustDecision`` it's notified of, in order. `@unchecked
+/// Sendable` is safe here -- `URLSession`'s challenge delegate callback runs each handshake's
+/// decision serially, one at a time, for these single-request tests.
+private final class RecordingTrustDecisionObserver: TrustDecisionObserver, @unchecked Sendable {
+    private(set) var decisions: [TrustDecision] = []
+
+    func callAsFunction(_ decision: TrustDecision) {
+        decisions.append(decision)
     }
 }
 

--- a/Tests/RequestDLTests/Request/RequestConfigurationURLSessionClientTests.swift
+++ b/Tests/RequestDLTests/Request/RequestConfigurationURLSessionClientTests.swift
@@ -152,7 +152,7 @@ struct RequestConfigurationURLSessionClientMTLSTests {
         // every platform (confirmed on macOS and iOS Simulator directly), not a defect in the
         // mapping this test otherwise exercises, and not specific to macOS.
         await withKnownIssue(
-            "this SwiftPM test harness has no Keychain Sharing entitlement on any platform -- see the type doc comment",
+            "this SwiftPM test harness has no Keychain Sharing entitlement on any platform; see the type doc comment",
             {
                 let urlSessionClient = try Internals.URLSessionClient(
                     configuration: .ephemeral,

--- a/Tests/RequestDLTests/Tasks/Sources/Raw Task/Data/DataTaskTests.swift
+++ b/Tests/RequestDLTests/Tasks/Sources/Raw Task/Data/DataTaskTests.swift
@@ -249,7 +249,7 @@ struct DataTaskTests {
     }
 
     /// Regression coverage for the gap `Internals.NIOTrustEvaluator` closed: `additionalTrustRoots`
-    /// alone, with no SPKI pinning, used to be silently ignored under Network.framework --
+    /// alone, with no SPKI pinning, used to be silently ignored under Network.framework.
     /// `localServer`'s certificate is signed by a private test CA the system default trust store
     /// has never heard of (see `dataTask_whenCAEnabled` above), so this handshake only succeeds if
     /// `AdditionalTrustRoots` genuinely reached Network.framework's own trust evaluation, not just
@@ -486,7 +486,7 @@ extension DataTaskTests {
     /// before any client is built or network I/O starts.
     @Test
     func dataTask_whenRequiredExecutorIsIncompatible_throwsActionableErrorBeforeAnyNetworkIO() async throws {
-        // Given -- a custom cipher suite has no Network.framework equivalent at all (silently
+        // Given: a custom cipher suite has no Network.framework equivalent at all (silently
         // dropped rather than trapped, but still flagged incompatible so it isn't lost without a
         // signal), so pinning `.nioTransportServices` is guaranteed to conflict.
         let task = DataTask {

--- a/Tests/RequestDLTests/Tasks/Sources/Raw Task/Data/DataTaskTests.swift
+++ b/Tests/RequestDLTests/Tasks/Sources/Raw Task/Data/DataTaskTests.swift
@@ -234,6 +234,105 @@ struct DataTaskTests {
         // Then
         #expect(result.response == output)
     }
+
+    /// Regression coverage for the gap `Internals.NIOTrustEvaluator` closed: `.noHostnameVerification`
+    /// alone used to trap under Network.framework (AsyncHTTPClient's own `precondition`, unless a
+    /// custom verification callback is installed). Paired with
+    /// `dataTask_whenNoHostnameVerificationSetWithoutTrustRoots_stillRejectsUntrustedCertificate`
+    /// below (chain trust still enforced with no `TrustRoots`), this proves the fix skips exactly
+    /// the hostname check and nothing more -- `Internals.NIOTrustEvaluator` swaps the `SecTrust`'s
+    /// policy for a hostname-less one but still anchors it on `TrustRoots`/`additionalTrustRoots`
+    /// and still evaluates the chain.
+    @Test
+    func dataTask_whenNoHostnameVerificationSetWithTrustRoots_completesHandshakeUnderNIOTransportServices()
+        async throws
+    {
+        // Given
+        let server = Certificates().server()
+        let uri = "/" + UUID().uuidString
+
+        let localServer = try await LocalServer(
+            LocalServer.Configuration(
+                host: "localhost",
+                port: 8894,
+                option: .none
+            )
+        )
+
+        let output = "Hello World"
+
+        let response = try LocalServer.ResponseConfiguration(
+            jsonObject: output
+        )
+
+        localServer.cleanup(at: uri)
+        localServer.insert(response, at: uri)
+        defer { localServer.cleanup(at: uri) }
+
+        // When
+        let data = try await DataTask {
+            BaseURL(localServer.baseURL)
+            Path(uri)
+
+            Session.localServer
+                .requiredExecutor(.nioTransportServices)
+
+            SecureConnection {
+                TrustRoots(server.certificateURL.absolutePath(percentEncoded: false))
+            }
+            .verification(.noHostnameVerification)
+        }
+        .extractPayload()
+        .result()
+
+        let result = try HTTPResult<String>(data)
+
+        // Then
+        #expect(result.response == output)
+    }
+
+    /// The other half of the pair above: with no `TrustRoots` to vouch for this self-signed test
+    /// certificate, the handshake must still fail even though `.noHostnameVerification` turns off
+    /// hostname matching -- proving that flag alone never became "trust everything."
+    @Test
+    func dataTask_whenNoHostnameVerificationSetWithoutTrustRoots_stillRejectsUntrustedCertificate() async throws {
+        // Given
+        let uri = "/" + UUID().uuidString
+
+        let localServer = try await LocalServer(
+            LocalServer.Configuration(
+                host: "localhost",
+                port: 8895,
+                option: .none
+            )
+        )
+
+        let output = "Hello World"
+
+        let response = try LocalServer.ResponseConfiguration(
+            jsonObject: output
+        )
+
+        localServer.cleanup(at: uri)
+        localServer.insert(response, at: uri)
+        defer { localServer.cleanup(at: uri) }
+
+        // When / Then
+        await #expect(throws: (any Error).self) {
+            try await DataTask {
+                BaseURL(localServer.baseURL)
+                Path(uri)
+
+                Session.localServer
+                    .requiredExecutor(.nioTransportServices)
+
+                SecureConnection {}
+                    .verification(.noHostnameVerification)
+            }
+            .extractPayload()
+            .result()
+        }
+    }
 }
 
 extension DataTaskTests {
@@ -321,9 +420,9 @@ extension DataTaskTests {
     /// before any client is built or network I/O starts.
     @Test
     func dataTask_whenRequiredExecutorIsIncompatible_throwsActionableErrorBeforeAnyNetworkIO() async throws {
-        // Given -- disabled hostname verification traps unconditionally under Network.framework
-        // (no custom verification callback installed here to work around it), so pinning
-        // `.nioTransportServices` is guaranteed to conflict.
+        // Given -- a custom cipher suite has no Network.framework equivalent at all (silently
+        // dropped rather than trapped, but still flagged incompatible so it isn't lost without a
+        // signal), so pinning `.nioTransportServices` is guaranteed to conflict.
         let task = DataTask {
             BaseURL("localhost")
 
@@ -331,7 +430,7 @@ extension DataTaskTests {
                 .requiredExecutor(.nioTransportServices)
 
             SecureConnection {}
-                .verification(.noHostnameVerification)
+                .cipherSuites(.TLS_AES_128_GCM_SHA256)
         }
         .extractPayload()
 
@@ -347,7 +446,7 @@ extension DataTaskTests {
             // Then -- actionable, not just "it throws": names the pinned executor, the
             // conflicting field, and points at the escape hatch.
             #expect(error.requiredExecutor == .nioTransportServices)
-            #expect(error.reasons == [.noHostnameVerificationUnderNetworkFramework])
+            #expect(error.reasons == [.cipherSuiteValues])
             #expect(error.description.contains(".requiredExecutor(.nioTransportServices)"))
             #expect(error.description.contains(".preferredExecutor(_:)"))
         }

--- a/Tests/RequestDLTests/Tasks/Sources/Raw Task/Data/DataTaskTests.swift
+++ b/Tests/RequestDLTests/Tasks/Sources/Raw Task/Data/DataTaskTests.swift
@@ -182,6 +182,72 @@ struct DataTaskTests {
         #expect(result.response == output)
     }
 
+    /// Regression coverage for the crash `Internals.SecureConnection.build(isCompatibleWithNetworkFramework:)`
+    /// fixed: `certificateChain`/`privateKey` used to always land on the same `TLSConfiguration`
+    /// AsyncHTTPClient's NIOTransportServices bridge also reads, which `preconditionFailure`s the
+    /// instant either is non-empty -- regardless of the Network.framework-native identity also
+    /// being supplied correctly via `tlsLocalIdentityNetworkFramework`. Reachable in practice via
+    /// `enableNetworkFramework(true)`/`preferredExecutor(.nioTransportServices)`/this test's own
+    /// `requiredExecutor(.nioTransportServices)` any time mTLS is also configured -- nothing in
+    /// `networkFrameworkIncompatibilityReasons()` ever stood in the way, since mTLS is genuinely
+    /// supported there, just through a different channel.
+    ///
+    /// Wrapped in the same unconditional `withKnownIssue` as `dataTask_whenCAEnabled` above (no
+    /// Keychain Sharing entitlement on this SwiftPM test harness): what this specifically proves,
+    /// independent of whether the Keychain round-trip itself succeeds here, is that reaching this
+    /// codepath no longer crashes the process.
+    @Test
+    func dataTask_whenCAEnabledUnderNIOTransportServices() async throws {
+        // Given
+        let server = Certificates().server()
+        let client = Certificates().client()
+
+        let uri = "/" + UUID().uuidString
+
+        let localServer = try await LocalServer(
+            LocalServer.Configuration(
+                host: "localhost",
+                port: 8896,
+                option: .client(client)
+            )
+        )
+
+        let output = "Hello World"
+
+        let response = try LocalServer.ResponseConfiguration(
+            jsonObject: output
+        )
+
+        localServer.cleanup(at: uri)
+        localServer.insert(response, at: uri)
+        defer { localServer.cleanup(at: uri) }
+
+        // When / Then
+        await withKnownIssue(
+            "this SwiftPM test harness has no Keychain Sharing entitlement on any platform -- see RequestConfigurationURLSessionClientMTLSTests's type doc comment"
+        ) {
+            let data = try await DataTask {
+                BaseURL(localServer.baseURL)
+                Path(uri)
+
+                Session.localServer
+                    .requiredExecutor(.nioTransportServices)
+
+                SecureConnection {
+                    TrustRoots(server.certificateURL.absolutePath(percentEncoded: false))
+                    RequestDL.Certificates(client.certificateURL.absolutePath(percentEncoded: false))
+                    PrivateKey(client.privateKeyURL.absolutePath(percentEncoded: false))
+                }
+                .verification(.fullVerification)
+            }
+            .extractPayload()
+            .result()
+
+            let result = try HTTPResult<String>(data)
+            #expect(result.response == output)
+        }
+    }
+
     /// Regression coverage for the gap `Internals.NIOTrustEvaluator` closed: `additionalTrustRoots`
     /// alone, with no SPKI pinning, used to be silently ignored under Network.framework --
     /// `localServer`'s certificate is signed by a private test CA the system default trust store

--- a/Tests/RequestDLTests/Tasks/Sources/Raw Task/Data/DataTaskTests.swift
+++ b/Tests/RequestDLTests/Tasks/Sources/Raw Task/Data/DataTaskTests.swift
@@ -224,7 +224,7 @@ struct DataTaskTests {
 
         // When / Then
         await withKnownIssue(
-            "this SwiftPM test harness has no Keychain Sharing entitlement on any platform -- see RequestConfigurationURLSessionClientMTLSTests's type doc comment"
+            "this SwiftPM test harness has no Keychain Sharing entitlement on any platform; see RequestConfigurationURLSessionClientMTLSTests's type doc comment"
         ) {
             let data = try await DataTask {
                 BaseURL(localServer.baseURL)

--- a/Tests/RequestDLTests/Tasks/Sources/Raw Task/Data/DataTaskTests.swift
+++ b/Tests/RequestDLTests/Tasks/Sources/Raw Task/Data/DataTaskTests.swift
@@ -181,6 +181,59 @@ struct DataTaskTests {
         // Then
         #expect(result.response == output)
     }
+
+    /// Regression coverage for the gap `Internals.NIOTrustEvaluator` closed: `additionalTrustRoots`
+    /// alone, with no SPKI pinning, used to be silently ignored under Network.framework --
+    /// `localServer`'s certificate is signed by a private test CA the system default trust store
+    /// has never heard of (see `dataTask_whenCAEnabled` above), so this handshake only succeeds if
+    /// `AdditionalTrustRoots` genuinely reached Network.framework's own trust evaluation, not just
+    /// NIOSSL's `.nio` backend.
+    @Test
+    func dataTask_whenAdditionalTrustRootsSetAndNIOTransportServicesRequired_completesHandshakeWithoutSPKIPinning()
+        async throws
+    {
+        // Given
+        let server = Certificates().server()
+        let uri = "/" + UUID().uuidString
+
+        let localServer = try await LocalServer(
+            LocalServer.Configuration(
+                host: "localhost",
+                port: 8893,
+                option: .none
+            )
+        )
+
+        let output = "Hello World"
+
+        let response = try LocalServer.ResponseConfiguration(
+            jsonObject: output
+        )
+
+        localServer.cleanup(at: uri)
+        localServer.insert(response, at: uri)
+        defer { localServer.cleanup(at: uri) }
+
+        // When
+        let data = try await DataTask {
+            BaseURL(localServer.baseURL)
+            Path(uri)
+
+            Session.localServer
+                .requiredExecutor(.nioTransportServices)
+
+            SecureConnection {
+                AdditionalTrustRoots(server.certificateURL.absolutePath(percentEncoded: false))
+            }
+        }
+        .extractPayload()
+        .result()
+
+        let result = try HTTPResult<String>(data)
+
+        // Then
+        #expect(result.response == output)
+    }
 }
 
 extension DataTaskTests {
@@ -268,17 +321,17 @@ extension DataTaskTests {
     /// before any client is built or network I/O starts.
     @Test
     func dataTask_whenRequiredExecutorIsIncompatible_throwsActionableErrorBeforeAnyNetworkIO() async throws {
-        // Given -- `additionalTrustRoots` is reachable under `.urlSession` but not under
-        // `.nioTransportServices`, so pinning the latter here is guaranteed to conflict.
+        // Given -- disabled hostname verification traps unconditionally under Network.framework
+        // (no custom verification callback installed here to work around it), so pinning
+        // `.nioTransportServices` is guaranteed to conflict.
         let task = DataTask {
             BaseURL("localhost")
 
             Session()
                 .requiredExecutor(.nioTransportServices)
 
-            SecureConnection {
-                AdditionalTrustRoots("/dev/null")
-            }
+            SecureConnection {}
+                .verification(.noHostnameVerification)
         }
         .extractPayload()
 
@@ -294,7 +347,7 @@ extension DataTaskTests {
             // Then -- actionable, not just "it throws": names the pinned executor, the
             // conflicting field, and points at the escape hatch.
             #expect(error.requiredExecutor == .nioTransportServices)
-            #expect(error.reasons == [.additionalTrustRootsUnderNetworkFramework])
+            #expect(error.reasons == [.noHostnameVerificationUnderNetworkFramework])
             #expect(error.description.contains(".requiredExecutor(.nioTransportServices)"))
             #expect(error.description.contains(".preferredExecutor(_:)"))
         }

--- a/Tests/RequestDLTests/Tasks/Sources/Raw Task/Data/DataTaskTests.swift
+++ b/Tests/RequestDLTests/Tasks/Sources/Raw Task/Data/DataTaskTests.swift
@@ -225,9 +225,7 @@ struct DataTaskTests {
         defer { localServer.cleanup(at: uri) }
 
         // When / Then
-        await withKnownIssue(
-            "this SwiftPM test harness has no Keychain Sharing entitlement on any platform; see RequestConfigurationURLSessionClientMTLSTests's type doc comment"
-        ) {
+        func verify() async throws {
             let data = try await DataTask {
                 BaseURL(localServer.baseURL)
                 Path(uri)
@@ -248,6 +246,21 @@ struct DataTaskTests {
             let result = try HTTPResult<String>(data)
             #expect(result.response == output)
         }
+
+        // The Keychain round-trip this "known issue" is about only happens inside
+        // `#if canImport(Darwin)` code (the mTLS identity Network.framework needs); off Darwin,
+        // `.nioTransportServices` never touches the Keychain at all, so `verify()` succeeds
+        // outright there and `withKnownIssue` would fail the test for not hitting an issue that
+        // was never reachable off Darwin to begin with.
+        #if canImport(Darwin)
+        await withKnownIssue(
+            "this SwiftPM test harness has no Keychain Sharing entitlement on any platform; see RequestConfigurationURLSessionClientMTLSTests's type doc comment"
+        ) {
+            try await verify()
+        }
+        #else
+        try await verify()
+        #endif
     }
 
     /// Regression coverage for the gap `Internals.NIOTrustEvaluator` closed: `additionalTrustRoots`

--- a/Tests/RequestDLTests/Tasks/Sources/Raw Task/Data/DataTaskTests.swift
+++ b/Tests/RequestDLTests/Tasks/Sources/Raw Task/Data/DataTaskTests.swift
@@ -185,10 +185,10 @@ struct DataTaskTests {
     /// Regression coverage for the crash `Internals.SecureConnection.build(isCompatibleWithNetworkFramework:)`
     /// fixed: `certificateChain`/`privateKey` used to always land on the same `TLSConfiguration`
     /// AsyncHTTPClient's NIOTransportServices bridge also reads, which `preconditionFailure`s the
-    /// instant either is non-empty -- regardless of the Network.framework-native identity also
+    /// instant either is non-empty, regardless of the Network.framework-native identity also
     /// being supplied correctly via `tlsLocalIdentityNetworkFramework`. Reachable in practice via
     /// `enableNetworkFramework(true)`/`preferredExecutor(.nioTransportServices)`/this test's own
-    /// `requiredExecutor(.nioTransportServices)` any time mTLS is also configured -- nothing in
+    /// `requiredExecutor(.nioTransportServices)` any time mTLS is also configured; nothing in
     /// `networkFrameworkIncompatibilityReasons()` ever stood in the way, since mTLS is genuinely
     /// supported there, just through a different channel.
     ///
@@ -306,7 +306,7 @@ struct DataTaskTests {
     /// custom verification callback is installed). Paired with
     /// `dataTask_whenNoHostnameVerificationSetWithoutTrustRoots_stillRejectsUntrustedCertificate`
     /// below (chain trust still enforced with no `TrustRoots`), this proves the fix skips exactly
-    /// the hostname check and nothing more -- `Internals.NIOTrustEvaluator` swaps the `SecTrust`'s
+    /// the hostname check and nothing more. `Internals.NIOTrustEvaluator` swaps the `SecTrust`'s
     /// policy for a hostname-less one but still anchors it on `TrustRoots`/`additionalTrustRoots`
     /// and still evaluates the chain.
     @Test
@@ -359,7 +359,7 @@ struct DataTaskTests {
 
     /// The other half of the pair above: with no `TrustRoots` to vouch for this self-signed test
     /// certificate, the handshake must still fail even though `.noHostnameVerification` turns off
-    /// hostname matching -- proving that flag alone never became "trust everything."
+    /// hostname matching, proving that flag alone never became "trust everything."
     @Test
     func dataTask_whenNoHostnameVerificationSetWithoutTrustRoots_stillRejectsUntrustedCertificate() async throws {
         // Given

--- a/Tests/RequestDLTests/Tasks/Sources/Raw Task/Data/DataTaskTests.swift
+++ b/Tests/RequestDLTests/Tasks/Sources/Raw Task/Data/DataTaskTests.swift
@@ -186,8 +186,10 @@ struct DataTaskTests {
     /// fixed: `certificateChain`/`privateKey` used to always land on the same `TLSConfiguration`
     /// AsyncHTTPClient's NIOTransportServices bridge also reads, which `preconditionFailure`s the
     /// instant either is non-empty, regardless of the Network.framework-native identity also
-    /// being supplied correctly via `tlsLocalIdentityNetworkFramework`. Reachable in practice via
-    /// `enableNetworkFramework(true)`/`preferredExecutor(.nioTransportServices)`/this test's own
+    /// being supplied correctly via `tlsLocalIdentityNetworkFramework`.
+    ///
+    /// Reachable in practice via `enableNetworkFramework(true)`/
+    /// `preferredExecutor(.nioTransportServices)`/this test's own
     /// `requiredExecutor(.nioTransportServices)` any time mTLS is also configured; nothing in
     /// `networkFrameworkIncompatibilityReasons()` ever stood in the way, since mTLS is genuinely
     /// supported there, just through a different channel.
@@ -303,8 +305,9 @@ struct DataTaskTests {
 
     /// Regression coverage for the gap `Internals.NIOTrustEvaluator` closed: `.noHostnameVerification`
     /// alone used to trap under Network.framework (AsyncHTTPClient's own `precondition`, unless a
-    /// custom verification callback is installed). Paired with
-    /// `dataTask_whenNoHostnameVerificationSetWithoutTrustRoots_stillRejectsUntrustedCertificate`
+    /// custom verification callback is installed).
+    ///
+    /// Paired with `dataTask_whenNoHostnameVerificationSetWithoutTrustRoots_stillRejectsUntrustedCertificate`
     /// below (chain trust still enforced with no `TrustRoots`), this proves the fix skips exactly
     /// the hostname check and nothing more. `Internals.NIOTrustEvaluator` swaps the `SecTrust`'s
     /// policy for a hostname-less one but still anchors it on `TrustRoots`/`additionalTrustRoots`


### PR DESCRIPTION
## Summary

**Breaking:** bumps the `async-http-client` fork dependency to `1.38.1`, which removes `SPKIPinningConfiguration`/`SPKIHash`/`SPKIPinningPolicy` in favor of two thin, policy-free hooks (`tlsCustomVerification` for the NIOSSL backend, `tlsCustomVerificationNetworkFramework` + `tlsLocalIdentityNetworkFramework` for Network.framework). RequestDL now owns its trust-evaluation and SPKI pinning logic entirely, instead of borrowing it from the fork.

- `Internals.SPKIHash` no longer depends on `AsyncHTTPClient` — digest validation (base64 decode + length check) is self-contained.
- New public `RequestDL.SPKIPinningPolicy` (`.strict`/`.audit`), replacing the type this package used to borrow from AsyncHTTPClient's own (now-removed) one.
- `Internals.ServerTrustPolicy` (`.urlSession`) and the new `Internals.NIOTrustEvaluator` (`.nio`, both NIOSSL and Network.framework) check SPKI pins against **every certificate in the chain, not just the leaf** — closes the OWASP-recommended backup-pin gap on both executors.
- `Internals.NIOTrustEvaluator` installs a custom verification callback whenever SPKI pinning, `additionalTrustRoots`, or `.noHostnameVerification` is configured; the TLS backend's own native trust-root handling (NIOSSL/BoringSSL/Security.framework) stays completely untouched otherwise.
  - **Darwin**: reconstructs/receives a real `SecTrust` and calls `SecTrustEvaluateAsyncWithError`, preserving OS-level Certificate Transparency, revocation checking, and trust-store parity.
  - **Off Darwin**: replicates the same validation with `swift-certificates` (`X509.Verifier` + `RFC5280Policy`), falling back to NIOSSL's own distro CA-bundle search heuristic when no explicit trust roots are configured.
- **mTLS now works under Network.framework too** (previously impossible): `certificateChain`/`privateKey` build a `SecIdentity` via the same Keychain round-trip `RawBytesIdentityBuilder` already used for `.urlSession`, wired into the new `tlsLocalIdentityNetworkFramework` hook — including **password-protected traditional PKCS#1 RSA PEM keys**, decrypted via `_CryptoExtras`.

## New capabilities beyond the original port

- **Revocation checking (OCSP/CRL)**: `SecureConnection.revocationPolicy(_:)` (`.strict`/`.relaxed`), layered on top of `SecTrust`'s own best-effort default check, on every Apple-platform executor.
- **`TrustDecisionObserver`**: an opt-in hook notified of each TLS trust decision (accept/reject, pin-match state) actually evaluated through RequestDL's own logic — for audit logging, independent of the accept/reject outcome itself.
- **`additionalTrustRoots` and `.noHostnameVerification` now work under Network.framework** without also requiring SPKI pinning to be configured — previously silently ignored (the former) or an outright crash (the latter, an AsyncHTTPClient `precondition` trap). These were the last two fields where `.nioTransportServices` and `.urlSession` disagreed; they're now symmetric on every trust/TLS-identity field.
- **`maximumTLSVersion`/`applicationProtocols` (ALPN) now correctly flagged as `.urlSession`-incompatible**, alongside `cipherSuites`: neither has an App Transport Security (Info.plist) equivalent, so automatic executor resolution skips `.urlSession` for them and `requiredExecutor(.urlSession)` throws instead of silently dropping the setting. A new DocC article, <doc:Configuring-App-Transport-Security-for-URLSession>, walks through the ATS story for `.urlSession`'s TLS-version/ALPN modifiers as a whole.

## Keychain identity lifecycle

- `Internals.Client` (`.nio`/`.nioTransportServices`) now owns and releases the mTLS identity's Keychain items itself, mirroring `Internals.URLSessionIdentityPolicy` — closing a leak where every such client used to abandon one Keychain entry per distinct identity.
- `.nio` no longer pays for the Network.framework identity's Keychain round-trip when the resolved executor doesn't need it.
- **Reference-counted across independently-built handles**: two `Internals.Client`/`Internals.URLSessionIdentityPolicy` instances configured with the same client certificate (a routine outcome — `Internals.ClientManager` pools by full session-configuration equality, not certificate identity alone) used to share one Keychain-item label with no coordination, so the first to deallocate could delete items the other's already-resolved `SecIdentity` still depended on. `Internals.IdentityHandle` (a class; deinit-driven release) plus `Internals.IdentityManager` (a process-wide, lock-guarded registry keyed by a label that now folds in the private key too, not just the certificate) fix this: the underlying Keychain items are deleted only once every live handle for that exact certificate/key pair has gone away.

## Linux

- Fixed a Linux-only compile error (`import Security` unconditional in a Darwin-only test file) that had been silently blocking the Linux CI job from ever running its tests to completion on this branch.
- Once that let the Linux suite actually run, two tests turned out to assume a Keychain-Sharing-entitlement failure that's only reachable on Darwin (`withKnownIssue` correctly failed them for not seeing the issue they were told to expect) — now gated to `#if canImport(Darwin)`.

## Documentation

- Every `///`/`//`/string-literal instance of the `word -- clause` dash tic this PR's own commits introduced was rewritten into plain sentences, and dense doc-comment paragraphs mixing several unrelated points were split for readability.

## Test plan

- [x] `swift build` / `swift build --build-tests` clean on macOS.
- [x] Full suite green on macOS — 546 tests, 4 known issues (all the same pre-existing Keychain-Sharing-entitlement gap in this sandboxed SwiftPM harness).
- [x] Full suite green on Linux CI, including the two previously-mis-gated `withKnownIssue` tests.
- [x] `xcodebuild docbuild` clean — 0 warnings in either `RequestDL` or `RequestDLInternals`, including the new ATS article's cross-references.
- [x] The Linux-only `swift-certificates` trust-evaluation path is exercised directly against a real `openssl`-generated, `openssl verify`-checked three-level certificate chain, confirming a pin on the intermediate (not just the leaf) is honored.
- [x] End-to-end `DataTaskTests` regression coverage for the Network.framework `additionalTrustRoots`/`.noHostnameVerification` fixes, the mTLS-under-Network.framework fix, and the Keychain reference-counting fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
