### PR TITLE
test: prove PropertyReader+AsyncProperty already cover dynamic proxy routing

### DIFF
--- a/Sources/RequestDLInternals/Sources/Session/Proxy/Internals.SystemProxyResolver.swift
+++ b/Sources/RequestDLInternals/Sources/Session/Proxy/Internals.SystemProxyResolver.swift
@@ -166,6 +166,37 @@ extension Internals.SystemProxyResolver {
 
     /// The conventional environment variables, which is what "the system proxy" means outside
     /// of Apple platforms.
+    ///
+    /// - Important: Deliberately stops at env vars and never reads PAC (proxy auto-configuration)
+    /// here, even though `Internals.PACEvaluator`/`Internals.PACProxyCache` already exist and are
+    /// wired into the Darwin branch above. Two separate problems block porting that here:
+    ///
+    ///   1. **Finding whether a PAC script is even configured, and its URL, has no OS-standard
+    ///      answer outside Darwin** -- `CFNetworkCopySystemProxySettings` folds in every source
+    ///      (network profile, IT-managed config, user setting) behind one call; nothing here does.
+    ///      - Windows: the readable trace is `HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\
+    ///        Internet Settings\AutoConfigURL`, but WinInet actually resolves the *active*
+    ///        connection from a binary `DefaultConnectionSettings` blob under `...\Internet
+    ///        Settings\Connections`, so a naive registry read can disagree with what the OS would
+    ///        really use. The correct source is the Win32 `WinHttpGetIEProxyConfigForCurrentUser`
+    ///        API (plus `WinHttpGetProxyForUrl`/`WinHttpDetectAutoProxyConfigUrl` for WPAD, when
+    ///        "automatically detect settings" -- not a fixed URL -- is what's configured) --
+    ///        meaning C interop against `winhttp.h`, not a file or registry read.
+    ///      - Linux has no cross-desktop standard at all. GNOME keeps it in dconf, readable via
+    ///        `gsettings get org.gnome.system.proxy autoconfig-url` (only meaningful once `mode`
+    ///        reads `'auto'`); KDE keeps it in `~/.config/kioslaverc` under `[Proxy Settings]` as
+    ///        `Proxy Config Script`, gated on `ProxyType=2`. Neither is reachable without either
+    ///        shelling out to a desktop-specific tool or linking a desktop-specific library, and a
+    ///        headless/server or non-GNOME/non-KDE Linux box has nowhere to look at all.
+    ///
+    ///   2. **Evaluating the script once fetched needs a JavaScript engine.** CFNetwork gives
+    ///      Darwin `CFNetworkExecuteProxyAutoConfigurationURL` for free; nothing here replaces it
+    ///      except writing a PAC-specific JS-subset interpreter or embedding an engine (e.g.
+    ///      QuickJS via C interop) -- a new dependency this package's Android/musl/static-SDK CI
+    ///      targets would all need to keep compiling against.
+    ///
+    /// Both are real, separate pieces of work. `Internals.PACEvaluator`/`Internals.PACProxyCache`
+    /// only cover problem 2 -- porting either here still leaves problem 1 completely unsolved.
     private static func resolve(_ url: URL) async -> Internals.Proxy? {
         let environment = ProcessInfo.processInfo.environment
 

--- a/Tests/RequestDLTests/Properties/Sources/Reader/PropertyReaderTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Reader/PropertyReaderTests.swift
@@ -57,6 +57,122 @@ struct PropertyReaderTests {
         #expect(resolved.requestConfiguration.url.contains("counter=0"))
     }
 
+    @Test
+    func propertyReader_combinedWithAsyncProperty_resolvesProxyDynamicallyFromComposedURL() async throws {
+        // Given
+        // Demonstrates that a per-request dynamic proxy (decided from the fully composed URL,
+        // with a real `async` lookup in between) doesn't need a dedicated resolver protocol --
+        // `PropertyReader` exposes the resolved URL of its `source`, and `AsyncProperty` can
+        // `await` before picking the `Proxy` to add as a sibling.
+        @Sendable func lookUpProxy(for host: String) async -> (host: String, port: Int)? {
+            if host.contains("internal.") {
+                return ("internal-proxy.local", 3_128)
+            } else if host.contains("external.") {
+                return ("external-proxy.local", 8_080)
+            } else {
+                return nil
+            }
+        }
+
+        func dynamicProxySession(host: String) -> some Property {
+            PropertyReader(BaseURL(.https, host: host)) { context in
+                AsyncProperty {
+                    if let proxy = await lookUpProxy(for: context.requestConfiguration.url) {
+                        Proxy(host: proxy.host, port: proxy.port, connection: .http)
+                    }
+                }
+            }
+        }
+
+        // When
+        let internalResolved = try await resolve(dynamicProxySession(host: "internal.company.example.com"))
+        let externalResolved = try await resolve(dynamicProxySession(host: "external.company.example.com"))
+        let unmatchedResolved = try await resolve(dynamicProxySession(host: "other.example.com"))
+
+        // Then
+        #expect(internalResolved.requestConfiguration.url == "https://internal.company.example.com")
+        #expect(internalResolved.session.configuration.proxy?.host == "internal-proxy.local")
+        #expect(internalResolved.session.configuration.proxy?.port == 3_128)
+
+        #expect(externalResolved.session.configuration.proxy?.host == "external-proxy.local")
+        #expect(externalResolved.session.configuration.proxy?.port == 8_080)
+
+        #expect(unmatchedResolved.session.configuration.proxy == nil)
+    }
+
+    @Test
+    func propertyReader_whenCallerWrapsEntireURLTreeAsSource_proxyDecisionSeesFullyComposedURL() async throws {
+        // Given
+        // `PropertyReader`'s `content` only sees what `source` itself resolved into -- not
+        // whatever siblings surround the `PropertyReader` node in the outer tree. A reusable
+        // "pick a proxy from the request's URL" component therefore has to have its *caller*
+        // wrap the entire URL-producing tree (`BaseURL` + `Path` + `Query`, in whatever order
+        // and however many pieces they come in) as `source`, not just a fragment of it.
+        func routedRequest<URLTree: Property>(
+            @PropertyBuilder urlTree: () -> URLTree
+        ) -> some Property {
+            PropertyReader(urlTree()) { context in
+                if context.requestConfiguration.url.contains("/admin/") {
+                    Proxy(host: "admin-proxy.local", port: 3_128, connection: .http)
+                } else {
+                    Proxy(host: "default-proxy.local", port: 8_080, connection: .http)
+                }
+            }
+        }
+
+        // When
+        let adminResolved = try await resolve(
+            routedRequest {
+                BaseURL(.https, host: "api.example.com")
+                Path("admin/users")
+                Query(name: "active", value: "true")
+            }
+        )
+
+        let defaultResolved = try await resolve(
+            routedRequest {
+                BaseURL(.https, host: "api.example.com")
+                Path("public/users")
+            }
+        )
+
+        // Then
+        #expect(adminResolved.requestConfiguration.url == "https://api.example.com/admin/users?active=true")
+        #expect(adminResolved.session.configuration.proxy?.host == "admin-proxy.local")
+
+        #expect(defaultResolved.requestConfiguration.url == "https://api.example.com/public/users")
+        #expect(defaultResolved.session.configuration.proxy?.host == "default-proxy.local")
+    }
+
+    @Test
+    func propertyReader_whenURLPartsAreDeclaredOutsideSource_proxyDecisionMissesThem() async throws {
+        // Given
+        // The gotcha the previous test's contract depends on getting right: `Path` declared as
+        // a *sibling* of `PropertyReader` -- not inside its `source` -- never reaches
+        // `context.requestConfiguration.url`, even though it still lands in the final request.
+        // A caller who only wraps part of the URL tree gets a routing decision made against a
+        // stale/partial URL, silently.
+        let resolved = try await resolve(
+            TestProperty {
+                PropertyReader(BaseURL(.https, host: "api.example.com")) { context in
+                    if context.requestConfiguration.url.contains("/admin/") {
+                        Proxy(host: "admin-proxy.local", port: 3_128, connection: .http)
+                    } else {
+                        Proxy(host: "default-proxy.local", port: 8_080, connection: .http)
+                    }
+                }
+
+                Path("admin/users")
+            }
+        )
+
+        // Then
+        // The final request URL does carry `/admin/users`...
+        #expect(resolved.requestConfiguration.url == "https://api.example.com/admin/users")
+        // ...but the proxy decision, made from `source`'s isolated resolution, never saw it.
+        #expect(resolved.session.configuration.proxy?.host == "default-proxy.local")
+    }
+
     @Test func neverBody() async throws {
         // Given
         let property = PropertyReader(EmptyProperty()) { _ in EmptyProperty() }


### PR DESCRIPTION
## Summary
- Investigated generalizing `SystemProxy`/PAC into a resolver protocol (mirroring `RedirectStrategy`). Concluded it's unnecessary: existing `PropertyReader` + `AsyncProperty` already let a caller pick a `Proxy` dynamically from the fully composed request URL, including real async lookups, with no new public API.
- Adds a doc comment on `SystemProxyResolver`'s non-Darwin branch explaining why PAC support isn't ported there yet: discovering whether/where a PAC script is configured has no cross-platform standard (Windows needs WinHttp C interop, Linux is fragmented across GNOME/KDE with no headless fallback), and evaluating one needs a JS engine RequestDL doesn't carry today.

## Test plan
- [x] `swift build` succeeds
- [x] `swift test --filter PropertyReaderTests` passes (5/5 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)