### PR TITLE
Rewrite -- in doc comments for readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 RequestDL is a Swift package designed to simplify the process of performing network requests. It provides a set of tools, including the `RequestTask` protocol, which supports different types of requests, including `DataTask`, `DownloadTask`, and `UploadTask`.
 
-Requests can run over Apple's `URLSession`, or over SwiftNIO -- either plain `NIO` or `NIOTransportServices` (Network.framework) -- letting you pick the transport that best fits each platform and deployment target. See [Choosing a transport](#choosing-a-transport) below.
+Requests can run over Apple's `URLSession`, or over SwiftNIO (either plain `NIO` or `NIOTransportServices` for Network.framework), letting you pick the transport that best fits each platform and deployment target. See [Choosing a transport](#choosing-a-transport) below.
 
 One of the key features of RequestDL is its support for specifying properties of a request, such as `Query`, `Payload`, and `Headers`, among others. You can also use `RequestTaskModifier` and `RequestTaskInterceptor` to process the response after the request is complete, allowing for actions like decoding, mapping, error handling based on status codes, and logging responses in the console.
 
@@ -65,7 +65,7 @@ This is just a simple example of what RequestDL can do. Check out the documentat
 
 ## Choosing a transport
 
-By default, RequestDL picks the best available transport for the current platform and session configuration -- `URLSession` on Darwin platforms, falling back to SwiftNIO where needed. You can express a preference with `preferredExecutor(_:)`, which is honored whenever the rest of the session's configuration supports it, or pin a session to a specific transport with `requiredExecutor(_:)`, which fails the request instead of silently falling back if that transport can't satisfy the configuration:
+By default, RequestDL picks the best available transport for the current platform and session configuration: `URLSession` on Darwin platforms, falling back to SwiftNIO where needed. You can express a preference with `preferredExecutor(_:)`, which is honored whenever the rest of the session's configuration supports it, or pin a session to a specific transport with `requiredExecutor(_:)`, which fails the request instead of silently falling back if that transport can't satisfy the configuration:
 
 ```swift
 try await DataTask {

--- a/Sources/RequestDL/Properties/Sources/Compression/Compressor.swift
+++ b/Sources/RequestDL/Properties/Sources/Compression/Compressor.swift
@@ -5,7 +5,7 @@
 /// A pluggable request-compression algorithm.
 ///
 /// Conform to this to teach RequestDL a compression scheme it doesn't know natively, without
-/// writing a new Task Modifier or Property -- install it via ``Property/compression(_:onDuplicateHeader:shouldCompressBodyData:)``,
+/// writing a new Task Modifier or Property; install it via ``Property/compression(_:onDuplicateHeader:shouldCompressBodyData:)``,
 /// the same way ``gzip``/``deflate`` already work.
 ///
 /// Unlike ``Decompressor``, there's no OS-provided shortcut this package can defer to: neither
@@ -15,7 +15,7 @@
 ///
 /// `callAsFunction()` is called once per request, producing a fresh ``CompressorStream`` that
 /// owns whatever mutable encode state the format needs (a zlib window, for instance) for exactly
-/// that one request -- never shared or reused across requests, since this type itself is
+/// that one request. It's never shared or reused across requests, since this type itself is
 /// `Sendable` and may be reused freely across many concurrent ones.
 public protocol Compressor: Sendable {
 
@@ -29,11 +29,11 @@ public protocol Compressor: Sendable {
 /// The stateful, per-request half of a ``Compressor``.
 ///
 /// Fed the outgoing body as it becomes available. Returning `[]` is always valid: a codec may
-/// buffer internally and emit nothing until it has enough to produce meaningful output -- exactly
+/// buffer internally and emit nothing until it has enough to produce meaningful output, exactly
 /// how `deflate()` itself behaves, buffering several writes before flushing anything back out.
 ///
 /// ``finish()`` is called exactly once, after the last chunk, and flushes whatever the encoder is
-/// still holding (a gzip trailer/checksum, for instance) -- nothing calls this a second time to
+/// still holding (a gzip trailer/checksum, for instance). Nothing calls this a second time to
 /// give an encoder another chance.
 public protocol CompressorStream {
 

--- a/Sources/RequestDL/Properties/Sources/Compression/Models/CompressionDuplicateHeaderBehavior.swift
+++ b/Sources/RequestDL/Properties/Sources/Compression/Models/CompressionDuplicateHeaderBehavior.swift
@@ -9,7 +9,7 @@ import RequestDLInternals
 ///
 /// This is a real conflict, not a footgun to design away: the request already carrying
 /// `Content-Encoding` usually means the caller pre-compressed the body themselves (a file already
-/// gzipped on disk, say) and set the header to declare that -- a legitimate intent distinct from
+/// gzipped on disk, say) and set the header to declare that, a legitimate intent distinct from
 /// asking this package to compress the body itself.
 public enum CompressionDuplicateHeaderBehavior: Sendable, Hashable {
 

--- a/Sources/RequestDL/Properties/Sources/Compression/Models/CompressionEnvironmentKey.swift
+++ b/Sources/RequestDL/Properties/Sources/Compression/Models/CompressionEnvironmentKey.swift
@@ -39,14 +39,15 @@ extension Property {
     /// header accordingly.
     ///
     /// Unlike response decompression (``Session/decompressionAlgorithms(_:limit:)``), this is
-    /// attached near the body itself, not the session -- it's environment-driven, the same way
-    /// ``Property/payloadEncoder(_:)`` is, so it applies to every `Payload`/`Form` in scope, and
-    /// is independent of which ``Session/Executor`` the request resolves to: the body is
+    /// attached near the body itself, not the session: it's environment-driven, the same way
+    /// ``Property/payloadEncoder(_:)`` is, so it applies to every `Payload`/`Form` in scope.
+    ///
+    /// It's also independent of which ``Session/Executor`` the request resolves to. The body is
     /// compressed once, up front, so `.urlSession`/`.nioTransportServices`/`.nio` and every
     /// negotiated HTTP version all see the same already-compressed bytes.
     ///
     /// Compression is only worth its CPU cost for bodies that are both sizable and not already
-    /// compressed (a large JSON payload, say, but not an image) -- use `shouldCompressBodyData`
+    /// compressed (a large JSON payload, say, but not an image). Use `shouldCompressBodyData`
     /// to gate it on the body's byte count, the same threshold Alamofire's own
     /// `DeflateRequestCompressor.shouldCompressBodyData` recommends. Left `nil`, every request
     /// with a body is compressed whenever a `Compressor` is configured, regardless of size.

--- a/Sources/RequestDL/Properties/Sources/Compression/Models/InternalsCompressionAlgorithmAdapter.swift
+++ b/Sources/RequestDL/Properties/Sources/Compression/Models/InternalsCompressionAlgorithmAdapter.swift
@@ -6,8 +6,8 @@ import NIOCore
 import RequestDLInternals
 
 /// Adapts a `RequestDL.Compressor` to `Internals.CompressionAlgorithm`, converting between this
-/// module's public `[UInt8]`-based protocols and the `ByteBuffer`-based ones `Internals` --
-/// shared by both transports -- can reference without depending back on this module.
+/// module's public `[UInt8]`-based protocols and the `ByteBuffer`-based ones `Internals`
+/// (shared by both transports) can reference without depending back on this module.
 struct InternalsCompressionAlgorithmAdapter: Internals.CompressionAlgorithm {
 
     // MARK: - Internal properties

--- a/Sources/RequestDL/Properties/Sources/Compression/Models/NIOHTTPCompressorStreamBridge.swift
+++ b/Sources/RequestDL/Properties/Sources/Compression/Models/NIOHTTPCompressorStreamBridge.swift
@@ -6,7 +6,7 @@ import NIOCore
 import RequestDLInternals
 
 /// Bridges `Internals.NIOHTTPCompressorStream` (`ByteBuffer`-based) onto the public,
-/// `[UInt8]`-based ``CompressorStream`` -- backs ``GzipAlgorithm``/``DeflateAlgorithm``, the only
+/// `[UInt8]`-based ``CompressorStream``. It backs ``GzipAlgorithm``/``DeflateAlgorithm``, the only
 /// two built-in ``Compressor``s that do real work rather than throw
 /// ``NativeOnlyAlgorithmError``, since there is no OS-provided outgoing-compression shortcut
 /// either of them could defer to instead.

--- a/Sources/RequestDL/Properties/Sources/Extra Properties/Environment/Models/RequestEnvironment.swift
+++ b/Sources/RequestDL/Properties/Sources/Extra Properties/Environment/Models/RequestEnvironment.swift
@@ -7,7 +7,7 @@
 /// ## Overview
 ///
 /// ``RequestEnvironment`` reads a value out of the ``RequestEnvironmentValues`` in scope for
-/// whichever type declares it -- a ``Property`` (populated while the request's property graph is
+/// whichever type declares it: a ``Property`` (populated while the request's property graph is
 /// built) or a ``RequestTask`` (populated the same way, when the task actually runs). Both are
 /// driven by the same mechanism: reflection over the declaring type's stored properties, so no
 /// extra plumbing is needed on either side beyond declaring the wrapper.
@@ -55,7 +55,7 @@
 ///     .result()
 /// ```
 ///
-/// - Note: Falls back to the key's own default when read before anything ever populated it --
+/// - Note: Falls back to the key's own default when read before anything ever populated it:
 /// a property never resolved through a graph, a task run via a bare `.result()`, a preview, or a
 /// test reading the wrapper directly.
 @propertyWrapper

--- a/Sources/RequestDL/Properties/Sources/Graph/Resolve/Models/PropertyResolutionLogger.swift
+++ b/Sources/RequestDL/Properties/Sources/Graph/Resolve/Models/PropertyResolutionLogger.swift
@@ -9,9 +9,11 @@ import Logging
 /// `assertPathway()`, `Certificate.Format.resolve(for:in:)`) that have no `_PropertyInputs` in
 /// scope to read it from directly.
 ///
-/// Scoped to `Property` resolution only -- bound once per `Resolve.outputs()` call, to that
-/// resolve's own `environment.logger` -- unlike the `@TaskLocal` `RequestEnvironmentValues.current`
-/// used to be: a nested `Resolve` (a `RequestTask` built from within another task's `result()`)
+/// Scoped to `Property` resolution only: bound once per `Resolve.outputs()` call, to that
+/// resolve's own `environment.logger`, unlike the `@TaskLocal` `RequestEnvironmentValues.current`
+/// used to be.
+///
+/// A nested `Resolve` (a `RequestTask` built from within another task's `result()`)
 /// rebinds this to its own logger before building its own graph, so there's nothing here for it
 /// to inherit by accident.
 enum PropertyResolutionLogger {

--- a/Sources/RequestDL/Properties/Sources/Headers/Authorization/Digest/DigestAuthentication.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Authorization/Digest/DigestAuthentication.swift
@@ -7,8 +7,10 @@
 ///
 /// Pairs with ``RequestTask/digestAuthentication(_:maxAttempts:)``, which parses the server's
 /// `WWW-Authenticate: Digest` challenge on a `401`, stores it on a `DigestCredential`, and
-/// retries -- this property alone only ever *uses* a challenge already stored there; it never
-/// fetches one itself. The credential itself is never passed explicitly: it flows down through
+/// retries. This property alone only ever *uses* a challenge already stored there; it never
+/// fetches one itself.
+///
+/// The credential itself is never passed explicitly: it flows down through
 /// the environment the same way ``URLEncoder`` does, from whichever
 /// ``RequestTask/digestAuthentication(_:maxAttempts:)`` this request is under.
 ///
@@ -23,14 +25,16 @@
 /// ```
 ///
 /// - Important: Place this *after* every property that contributes to the URL (``BaseURL``,
-/// ``Path``, ``Query``) or the method (``RequestMethod``) -- the digest response is computed over
+/// ``Path``, ``Query``) or the method (``RequestMethod``): the digest response is computed over
 /// whatever they have already set by the time this runs, same as every other property that reads
 /// `Make` rather than only writing to it.
 ///
-/// - Note: Only `qop=auth` (or no `qop` at all, RFC 2069 style) is supported -- `qop=auth-int`,
+/// - Note: Only `qop=auth` (or no `qop` at all, RFC 2069 style) is supported. `qop=auth-int`,
 /// which additionally hashes the request body, is not. Neither are the `-sess` algorithm variants
-/// (`MD5-sess`/`SHA-256-sess`). A challenge asking for either is treated as unusable, the same as
-/// one missing `realm`/`nonce` entirely: this property contributes no header, and the request
+/// (`MD5-sess`/`SHA-256-sess`).
+///
+/// A challenge asking for either is treated as unusable, the same as one missing
+/// `realm`/`nonce` entirely: this property contributes no header, and the request
 /// goes out exactly as it would have without ``DigestAuthentication`` at all.
 public struct DigestAuthentication: Property {
 
@@ -88,7 +92,7 @@ public struct DigestAuthentication: Property {
     /// - Parameters:
     ///    - username: The username to authenticate with.
     ///    - password: The password to authenticate with.
-    ///    - method: The request's own HTTP method -- must match whatever ``RequestMethod`` (or
+    ///    - method: The request's own HTTP method: must match whatever ``RequestMethod`` (or
     ///    the default `GET`) this request actually uses, since it is hashed into the digest
     ///    response. Defaults to `.get`.
     ///
@@ -113,10 +117,11 @@ public struct DigestAuthentication: Property {
 
         // A leaf property with a hand-written `_makeProperty` doesn't go through `Property`'s
         // own default implementation, which is what runs `GraphOperation` (namespace,
-        // environment, stored object) for every composite property automatically -- without
-        // this, `@RequestEnvironment(\.digestCredential)` above would never see anything set via
-        // `.environment(\.digestCredential, ...)`/`Modifiers.DigestAuthentication` and would
-        // silently fall back to `DigestCredentialEnvironmentKey`'s own shared default.
+        // environment, stored object) for every composite property automatically.
+        //
+        // Without this, `@RequestEnvironment(\.digestCredential)` above would never see anything
+        // set via `.environment(\.digestCredential, ...)`/`Modifiers.DigestAuthentication` and
+        // would silently fall back to `DigestCredentialEnvironmentKey`'s own shared default.
         var inputs = inputs
         GraphOperation(property)(&inputs)
 

--- a/Sources/RequestDL/Properties/Sources/Headers/Authorization/Digest/DigestCredential.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Authorization/Digest/DigestCredential.swift
@@ -22,7 +22,7 @@ import SwiftAsyncStream
 /// Construct one yourself only to reuse it explicitly across separate requests, passing it to
 /// ``RequestTask/digestAuthentication(_:maxAttempts:)`` in place of its default.
 ///
-/// - Important: Reused across every request made with it -- the same instance carries the
+/// - Important: Reused across every request made with it: the same instance carries the
 /// server's nonce from one request into the next, matching how a real Digest client is expected
 /// to behave. Give unrelated requests (different hosts, different credentials) their own
 /// instance.
@@ -45,7 +45,7 @@ public final class DigestCredential: @unchecked Sendable {
 
     // MARK: - Inits
 
-    /// Initializes an empty credential -- no challenge yet, so the first request this is used
+    /// Initializes an empty credential: no challenge yet, so the first request this is used
     /// with carries no `Authorization` header until the server issues one.
     public init() {}
 }

--- a/Sources/RequestDL/Properties/Sources/Headers/Authorization/Digest/Models/DigestAlgorithm.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Authorization/Digest/Models/DigestAlgorithm.swift
@@ -20,7 +20,7 @@ enum DigestAlgorithm: Sendable, Hashable {
 
     // MARK: - Inits
 
-    /// - Parameter rawValue: The challenge's `algorithm` parameter, or `nil` when absent --
+    /// - Parameter rawValue: The challenge's `algorithm` parameter, or `nil` when absent,
     /// which RFC 7616 §3.3 says implies `MD5`, the same default RFC 2069 always assumed.
     init?(rawValue: String?) {
         switch rawValue?.uppercased() {
@@ -41,7 +41,7 @@ enum DigestAlgorithm: Sendable, Hashable {
 
     /// Whether this is a `-sess` variant, which folds a client/server nonce pair into `HA1`
     /// itself rather than recomputing it fresh for every request. Not currently supported by
-    /// ``DigestAuthentication`` -- see its own doc comment.
+    /// ``DigestAuthentication``; see its own doc comment.
     var isSession: Bool {
         switch self {
         case .md5Sess, .sha256Sess:

--- a/Sources/RequestDL/Properties/Sources/Headers/Authorization/Digest/Models/DigestChallenge.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Authorization/Digest/Models/DigestChallenge.swift
@@ -10,7 +10,7 @@ struct DigestChallenge: Sendable, Hashable {
     let realm: String
     let nonce: String
     let opaque: String?
-    /// `true` when the challenge offered `qop=auth` (or the legacy, unquoted `qop=auth`) --
+    /// `true` when the challenge offered `qop=auth` (or the legacy, unquoted `qop=auth`).
     /// `auth-int`, which additionally hashes the request body, is treated the same as no `qop`
     /// at all: neither is supported, see ``DigestAuthentication``'s own doc comment.
     let hasAuthQop: Bool
@@ -66,7 +66,7 @@ struct DigestChallenge: Sendable, Hashable {
 
     // MARK: - Private static methods
 
-    /// Splits `string` on every unquoted occurrence of `separator` -- a plain `split(separator:)`
+    /// Splits `string` on every unquoted occurrence of `separator`: a plain `split(separator:)`
     /// would also split inside a quoted value that happens to contain the same character (a
     /// `nonce`/`opaque` is server-chosen, opaque data, and RFC 7616 does not forbid a comma in
     /// one).

--- a/Sources/RequestDL/Properties/Sources/Headers/Authorization/Digest/Models/DigestResponse.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Authorization/Digest/Models/DigestResponse.swift
@@ -18,7 +18,7 @@ enum DigestResponse {
     ) -> String {
         let algorithm = challenge.algorithm
 
-        // HA1 -- the `-sess` variant, which additionally folds in a client/server nonce pair, is
+        // HA1: the `-sess` variant, which additionally folds in a client/server nonce pair, is
         // rejected by `DigestChallenge.init(headerValue:)` before this is ever reached.
         let ha1 = algorithm.hexDigest("\(username):\(challenge.realm):\(password)")
         let ha2 = algorithm.hexDigest("\(method):\(uri)")
@@ -64,7 +64,7 @@ enum DigestResponse {
 
     // MARK: - Private static methods
 
-    /// A fresh, random client nonce -- per RFC 7616 §3.4, it must be unpredictable, since it
+    /// A fresh, random client nonce. Per RFC 7616 §3.4, it must be unpredictable, since it
     /// factors into the response hash the same way the server's own nonce does.
     private static func randomHexString(byteCount: Int = 16) -> String {
         var generator = SystemRandomNumberGenerator()

--- a/Sources/RequestDL/Properties/Sources/Headers/Header Group/HeaderGroup.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Header Group/HeaderGroup.swift
@@ -73,12 +73,13 @@ extension HeaderGroup where Content == PropertyForEach<[String: String], String,
     /// Initializes a new `HeaderGroup` with a dictionary of headers.
     ///
     /// - Important: `Dictionary` iteration order is unspecified and can vary between runs of the
-    /// same process. This is invisible for keys that are actually distinct headers, but if the
-    /// dictionary happens to carry two keys that only differ by case (e.g. `"User-Agent"` and
-    /// `"user-agent"` -- distinct dictionary keys to Swift, since `String` equality is
-    /// case-sensitive, but the same header once resolved, since header names are compared
-    /// case-insensitively per RFC 9110), which one wins -- or the order they combine in under
-    /// ``HeaderStrategy/adding`` -- is not guaranteed to be the same across runs. Use
+    /// same process. This is invisible for keys that are actually distinct headers.
+    ///
+    /// But if the dictionary happens to carry two keys that only differ by case (e.g.
+    /// `"User-Agent"` and `"user-agent"`: distinct dictionary keys to Swift, since `String`
+    /// equality is case-sensitive, but the same header once resolved, since header names are
+    /// compared case-insensitively per RFC 9110), which one wins, or the order they combine in
+    /// under ``HeaderStrategy/adding``, is not guaranteed to be the same across runs. Use
     /// ``init(content:)`` with an explicit, ordered list of ``CustomHeader``s instead when that
     /// matters.
     ///

--- a/Sources/RequestDL/Properties/Sources/Headers/Headers/Accept Charset/AcceptCharsetHeader.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Headers/Accept Charset/AcceptCharsetHeader.swift
@@ -10,10 +10,13 @@
 ///
 /// - Warning: `Accept-Charset` is a legacy header the web platform has moved away from. The
 /// WHATWG Fetch Standard lists it among the forbidden request-header names a browser refuses to
-/// let a caller set at all (`fetch()`/`XMLHttpRequest.setRequestHeader` both reject it), and
-/// browsers stopped sending it on ordinary navigations years ago -- most servers, and every JSON
+/// let a caller set at all (`fetch()`/`XMLHttpRequest.setRequestHeader` both reject it).
+///
+/// Browsers stopped sending it on ordinary navigations years ago. Most servers, and every JSON
 /// endpoint (UTF-8 by definition), already ignore it. Sending it today mostly just signals a
-/// non-browser client. Prefer negotiating charset through the response's own `Content-Type`, or
+/// non-browser client.
+///
+/// Prefer negotiating charset through the response's own `Content-Type`, or
 /// an application-level convention with the server, instead.
 @available(
     *,

--- a/Sources/RequestDL/Properties/Sources/Headers/Headers/Cache/CacheHeader.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Headers/Cache/CacheHeader.swift
@@ -64,10 +64,12 @@ public struct CacheHeader: Property {
         property.assertPathway()
 
         // Cache-Control's directive list (RFC 9111 §5.2, `1#cache-directive`) is comma-delimited
-        // by definition -- hardcoded here rather than deferring to `.headerSeparator(_:)`, the
+        // by definition, hardcoded here rather than deferring to `.headerSeparator(_:)`, the
         // same way `HeaderNode`'s own `commaSeparatedNames` forces this header's *cross-instance*
-        // combining to "," regardless of what the environment configures. Anything else joined
-        // in would parse as one opaque, meaningless directive instead of a recognizable list.
+        // combining to "," regardless of what the environment configures.
+        //
+        // Anything else joined in would parse as one opaque, meaningless directive instead of a
+        // recognizable list.
         let value = property.pointer()
             .makeContents()
             .joined(separator: ",")

--- a/Sources/RequestDL/Properties/Sources/Headers/Headers/Header Node/HeaderNode.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Headers/Header Node/HeaderNode.swift
@@ -44,7 +44,7 @@ struct HeaderNode: PropertyNode {
     func make(_ make: inout Make) async throws {
         self(&make.requestConfiguration.headers)
 
-        // `.lowercased()`, not Foundation's `caseInsensitiveCompare(_:)` -- unavailable outside
+        // `.lowercased()`, not Foundation's `caseInsensitiveCompare(_:)`: unavailable outside
         // Darwin (FoundationEssentials/Linux/Android), and this path runs for every executor,
         // not just `.urlSession`.
         if key.lowercased() == "user-agent" {
@@ -54,23 +54,26 @@ struct HeaderNode: PropertyNode {
 
     // MARK: - Private properties
 
-    /// Header names whose value every governing spec defines as singular -- repeating the field
+    /// Header names whose value every governing spec defines as singular: repeating the field
     /// line, or splicing a second value into it with whatever separator happens to be in scope,
     /// either violates the field's own grammar or produces something that fails to parse as
     /// anything valid at all.
     ///
-    /// `Host`: RFC 9110 §7.2 -- a server MUST 400 a request carrying more than one. `Origin`
+    /// `Host`: per RFC 9110 §7.2, a server MUST 400 a request carrying more than one. `Origin`
     /// (RFC 6454/Fetch) and `Referer` (RFC 9110 §10.1.3) are each a single serialized value, not
     /// a list. `Authorization`, `Content-Type`, and `Content-Length` are each exactly one
-    /// credentials/media-type/byte-count value -- `Payload`/`Authorization`/`DigestAuthentication`
-    /// already write them via a direct `headers.set(...)`, bypassing `HeaderNode` entirely, but
-    /// that only stops those *specific* properties from duplicating themselves. It does nothing
-    /// to stop an unrelated `CustomHeader` that happens to case-insensitively collide with one of
-    /// these names (e.g. `CustomHeader(name: "content-type", ...)` after a `Payload`) from
-    /// appending onto it via `.adding`, or -- worse, when a separator is also in scope -- from
-    /// splicing its value directly into the existing one, silently corrupting it into a single
-    /// unparseable string. Enforcing this here, for every write regardless of which `Property`
-    /// produced it, is the one place that closes both vectors.
+    /// credentials/media-type/byte-count value.
+    ///
+    /// `Payload`/`Authorization`/`DigestAuthentication` already write them via a direct
+    /// `headers.set(...)`, bypassing `HeaderNode` entirely, but that only stops those *specific*
+    /// properties from duplicating themselves. It does nothing to stop an unrelated
+    /// `CustomHeader` that happens to case-insensitively collide with one of these names (e.g.
+    /// `CustomHeader(name: "content-type", ...)` after a `Payload`) from appending onto it via
+    /// `.adding`, or, worse, when a separator is also in scope, from splicing its value directly
+    /// into the existing one, silently corrupting it into a single unparseable string.
+    ///
+    /// Enforcing this here, for every write regardless of which `Property` produced it, is the
+    /// one place that closes both vectors.
     ///
     /// Deliberately excludes `User-Agent`: combining multiple ``UserAgentHeader`` instances is a
     /// documented, intentional feature (see its own doc comment), so it cannot be forced to
@@ -79,21 +82,23 @@ struct HeaderNode: PropertyNode {
         "host", "origin", "referer", "authorization", "content-type", "content-length",
     ]
 
-    /// Header names whose combined value RFC 9110/9111 define as a comma-separated list --
+    /// Header names whose combined value RFC 9110/9111 define as a comma-separated list:
     /// `,` (plus optional whitespace) is the *only* separator any spec sanctions for folding
     /// multiple field lines into one, regardless of what `.headerSeparator(_:)` a caller passes.
     ///
     /// This isn't a matter of taste: `;` in particular already means something inside these
     /// headers' own grammar. `Accept`/`Accept-Charset`/`Accept-Encoding`/`Accept-Language` use it
-    /// to attach a `q` parameter to the *previous* element (`text/html;q=0.9`) -- joining two
+    /// to attach a `q` parameter to the *previous* element (`text/html;q=0.9`). Joining two
     /// instances with `.headerSeparator(";")` produces `text/html;q=0.9;application/json`, which
     /// a compliant `#(media-range)` parser reads as `application/json` being an (invalid)
-    /// parameter of `text/html`, not a second accepted type. `Cache-Control`'s directive list
-    /// (`1#cache-directive`, RFC 9111 §5.2) has no comparable internal use of `;`, but still
-    /// parses as one opaque, meaningless directive if joined with anything but `,`.
+    /// parameter of `text/html`, not a second accepted type.
+    ///
+    /// `Cache-Control`'s directive list (`1#cache-directive`, RFC 9111 §5.2) has no comparable
+    /// internal use of `;`, but still parses as one opaque, meaningless directive if joined with
+    /// anything but `,`.
     ///
     /// Only for headers RequestDL itself defines the semantics of. `CustomHeader` is deliberately
-    /// left alone -- for an arbitrary, non-standard header name, whatever separator its own
+    /// left alone: for an arbitrary, non-standard header name, whatever separator its own
     /// backend expects (if any) isn't something RequestDL can know or second-guess.
     private static let commaSeparatedNames: Set<String> = [
         "accept", "accept-charset", "accept-encoding", "accept-language", "cache-control",

--- a/Sources/RequestDL/Properties/Sources/Headers/Headers/User Agent/UserAgentHeader.swift
+++ b/Sources/RequestDL/Properties/Sources/Headers/Headers/User Agent/UserAgentHeader.swift
@@ -46,7 +46,7 @@ public struct UserAgentHeader: Property {
     private let isDefault: Bool
 
     /// `ProcessInfo.processInfo.userAgent` bundle/version/OS lookups and string interpolation,
-    /// computed once per process rather than on every ``init()`` call -- none of its inputs
+    /// computed once per process rather than on every ``init()`` call: none of its inputs
     /// change while the process is running, and `init()` runs again every time a request's
     /// property tree is rebuilt (`_makeProperty` is called once per resolve), not once per app
     /// launch.

--- a/Sources/RequestDL/Properties/Sources/Payloads/Form Group/Models/FormNode.swift
+++ b/Sources/RequestDL/Properties/Sources/Payloads/Form Group/Models/FormNode.swift
@@ -16,11 +16,11 @@ struct FormNode: PropertyNode {
     let items: [FormItem]
 
     /// Captured from `inputs.environment.descriptorFormFields` at `_makeProperty` time by
-    /// whichever `Property` builds this node (`Form`, `FormGroup`) -- not read from inside
+    /// whichever `Property` builds this node (`Form`, `FormGroup`); not read from inside
     /// `make()` itself, since `PropertyNode.make(_:)` has no `environment` of its own to read.
     let descriptorFormFields: DescriptorFormFieldBox?
 
-    /// Same capture-at-`_makeProperty`-time reasoning as `descriptorFormFields` -- see
+    /// Same capture-at-`_makeProperty`-time reasoning as `descriptorFormFields`; see
     /// `PayloadNode`'s identical fields.
     let compression: (any Compressor)?
     let compressionDuplicateHeaderBehavior: CompressionDuplicateHeaderBehavior

--- a/Sources/RequestDL/Properties/Sources/Payloads/Payload/Models/PayloadNode.swift
+++ b/Sources/RequestDL/Properties/Sources/Payloads/Payload/Models/PayloadNode.swift
@@ -14,7 +14,7 @@ struct PayloadNode: PropertyNode {
     let chunkSize: Int?
     let payloadEncoder: (any PayloadEncoder)?
 
-    /// Captured from `inputs.environment` at `_makeProperty` time -- see `RequestConfiguration
+    /// Captured from `inputs.environment` at `_makeProperty` time; see `RequestConfiguration
     /// .compression`'s own doc comment for why this can't be read from inside `make(_:)` itself.
     let compression: (any Compressor)?
     let compressionDuplicateHeaderBehavior: CompressionDuplicateHeaderBehavior
@@ -82,9 +82,10 @@ struct PayloadNode: PropertyNode {
         output: PayloadOutput,
         make: inout Make
     ) {
-        // Only fills in a default, never overrides an explicit `RequestMethod` -- whichever
-        // node runs first wins, since `RequestMethod`'s own node assigns unconditionally. A
-        // body attached to whatever method ends up unset otherwise falls through to `"GET"` at
+        // Only fills in a default, never overrides an explicit `RequestMethod`: whichever
+        // node runs first wins, since `RequestMethod`'s own node assigns unconditionally.
+        //
+        // A body attached to whatever method ends up unset otherwise falls through to `"GET"` at
         // request-build time, which AsyncHTTPClient tolerates silently but URLSession/CFNetwork
         // does not: a GET carrying a body fails outright (`NSURLErrorDataLengthExceedsMaximum`,
         // confirmed against a real server, not LocalServer- or beta-OS-specific).

--- a/Sources/RequestDL/Properties/Sources/Secure Connection/SPKI Pinning/SPKIPinning.swift
+++ b/Sources/RequestDL/Properties/Sources/Secure Connection/SPKI Pinning/SPKIPinning.swift
@@ -21,8 +21,8 @@ import RequestDLInternals
 ///
 /// - Warning: Always deploy non-empty backup pins in production to avoid lockout during certificate rotation.
 ///
-/// - Note: Incompatible with ``Session/enableNetworkFramework(_:)`` -- pinning is never dropped to honor that flag; the
-/// session instead falls back to plain SwiftNIO and keeps enforcing the pins.
+/// - Note: Incompatible with ``Session/enableNetworkFramework(_:)``: pinning is never dropped to honor that flag.
+/// The session instead falls back to plain SwiftNIO and keeps enforcing the pins.
 public struct SPKIPinning<Content: Property>: Property {
 
     private struct Node: SecureConnectionPropertyNode {

--- a/Sources/RequestDL/Properties/Sources/Secure Connection/Secure Connection/Models/ClientIdentityError.swift
+++ b/Sources/RequestDL/Properties/Sources/Secure Connection/Secure Connection/Models/ClientIdentityError.swift
@@ -17,20 +17,20 @@ import protocol Foundation.LocalizedError
 /// `URLSession`-presentable identity, under the `.urlSession` executor (`Session.Executor`).
 ///
 /// Building that identity is a Keychain round-trip with no in-memory alternative on Apple
-/// platforms -- see <doc:Using-a-Client-Certificate-with-URLSession> for the full walkthrough,
+/// platforms. See <doc:Using-a-Client-Certificate-with-URLSession> for the full walkthrough,
 /// including the one-time Xcode project setting
 /// (``Reason/missingKeychainSharingEntitlement(operation:)``'s most common cause) most apps using
 /// ``Certificate``/``PrivateKey`` under this executor need.
 ///
 /// `RequestDLInternals`'s raw `Internals.RawBytesIdentityBuilder.Error`/
-/// `Internals.URLSessionIdentityPolicy.ConfigurationError` -- the internal, package-visible errors
-/// -- get caught where the session bootstraps and rewrapped into this type, following the same
+/// `Internals.URLSessionIdentityPolicy.ConfigurationError` (the internal, package-visible errors)
+/// get caught where the session bootstraps and rewrapped into this type, following the same
 /// split `SecureFileError` uses for `Internals.SecureFileLoadError`.
 public struct ClientIdentityError: Error, Sendable {
 
     /// The specific reason RequestDL could not build a `URLSession`-presentable identity.
     public enum Reason: Sendable {
-        /// `SecureConnection` configured only a `certificateChain` or only a `privateKey` -- mTLS
+        /// `SecureConnection` configured only a `certificateChain` or only a `privateKey`; mTLS
         /// under `.urlSession` needs both.
         case incompleteClientIdentity
 
@@ -41,7 +41,7 @@ public struct ClientIdentityError: Error, Sendable {
         case invalidCertificateData
 
         /// The configured private key isn't RSA (PKCS#1 or PKCS#8) or EC P-256/P-384/P-521 (SEC1
-        /// or PKCS#8) -- the shapes this executor recognizes. `header` describes what was
+        /// or PKCS#8), the shapes this executor recognizes. `header` describes what was
         /// actually supplied, to help spot the mismatch (e.g. an Ed25519 key, which has no
         /// `SecKeyCreateWithData` entry point at all).
         case unsupportedKeyFormat(header: String)
@@ -53,7 +53,7 @@ public struct ClientIdentityError: Error, Sendable {
         /// This app is missing the Keychain Sharing capability that writing a client
         /// certificate/private key into the Keychain requires. `operation` names the specific
         /// Keychain call that failed. This is almost always fixed by adding **Keychain Sharing**
-        /// under the affected target's Signing & Capabilities tab in Xcode -- see
+        /// under the affected target's Signing & Capabilities tab in Xcode. See
         /// <doc:Using-a-Client-Certificate-with-URLSession>.
         case missingKeychainSharingEntitlement(operation: String)
 
@@ -61,9 +61,9 @@ public struct ClientIdentityError: Error, Sendable {
         /// names the specific Keychain call, `status` is the underlying `OSStatus`.
         ///
         /// On a non-sandboxed macOS process (a bare command-line tool, for instance), this can
-        /// surface even with Keychain Sharing correctly configured -- see
+        /// surface even with Keychain Sharing correctly configured. See
         /// <doc:Using-a-Client-Certificate-with-URLSession>'s "Platforms" section for that
-        /// specific, still-unresolved gap -- adding Keychain Sharing again will not fix it.
+        /// specific, still-unresolved gap; adding Keychain Sharing again will not fix it.
         case keychainOperationFailed(operation: String, status: OSStatus)
 
         /// An internal Keychain query returned a value of an unexpected type. Not expected to
@@ -126,7 +126,7 @@ public struct ClientIdentityError: Error, Sendable {
 extension ClientIdentityError: LocalizedError {
 
     /// A message describing what went wrong, self-diagnosable without needing to have already
-    /// read <doc:Using-a-Client-Certificate-with-URLSession> -- this is what
+    /// read <doc:Using-a-Client-Certificate-with-URLSession>. This is what
     /// `error.localizedDescription` surfaces, the way most callers actually display a caught
     /// error.
     public var errorDescription: String? {

--- a/Sources/RequestDL/Properties/Sources/Session/Decompression/Decompressor.swift
+++ b/Sources/RequestDL/Properties/Sources/Session/Decompression/Decompressor.swift
@@ -5,13 +5,13 @@
 /// A pluggable response-decompression algorithm.
 ///
 /// Conform to this to teach RequestDL a `Content-Encoding` it doesn't know natively, without
-/// writing a new Task Modifier or Property -- install it via
+/// writing a new Task Modifier or Property; install it via
 /// ``Session/decompressionAlgorithms(_:limit:)``, the same way ``gzip``/``deflate`` already work.
 ///
 /// `callAsFunction()` is called once per response whose `Content-Encoding` matches
 /// ``contentEncodingValue``, producing a fresh ``DecompressorStream`` that owns whatever mutable
-/// decode state the format needs (a zlib window, for instance) for exactly that one response --
-/// never shared or reused across requests, since this type itself is `Sendable` and may be
+/// decode state the format needs (a zlib window, for instance) for exactly that one response.
+/// It's never shared or reused across requests, since this type itself is `Sendable` and may be
 /// reused freely across many concurrent ones.
 public protocol Decompressor: Sendable {
 
@@ -26,16 +26,18 @@ public protocol Decompressor: Sendable {
 /// The stateful, per-response half of a ``Decompressor``.
 ///
 /// Fed the response body as it arrives, in whatever chunk sizes the transport happens to
-/// deliver -- there is no guarantee a chunk lines up with any boundary the encoder produced, so
+/// deliver. There is no guarantee a chunk lines up with any boundary the encoder produced, so
 /// an implementation that needs to track state across calls (most real codecs do) must do so
-/// internally. Returning `[]` is always valid: a codec may buffer internally and emit nothing
+/// internally.
+///
+/// Returning `[]` is always valid: a codec may buffer internally and emit nothing
 /// until it has enough to decode, including a codec that can only ever decode once it has seen
-/// the entire body -- that one just returns `[]` from every ``callAsFunction(decompressing:)``
+/// the entire body. That one just returns `[]` from every ``callAsFunction(decompressing:)``
 /// call and does all its work in ``finish()``. It won't benefit from incremental delivery, but it
 /// remains a correct, conforming implementation.
 ///
 /// ``finish()`` is called exactly once, after the last chunk, and flushes whatever the decoder
-/// is still holding -- it's also where a truncated or corrupt stream should be caught and
+/// is still holding. It's also where a truncated or corrupt stream should be caught and
 /// thrown, since nothing calls this a second time to give a decoder another chance.
 public protocol DecompressorStream {
 

--- a/Sources/RequestDL/Properties/Sources/Session/Decompression/Models/BrotliURLSessionOnlyAlgorithm.swift
+++ b/Sources/RequestDL/Properties/Sources/Session/Decompression/Models/BrotliURLSessionOnlyAlgorithm.swift
@@ -2,15 +2,16 @@
 // See LICENSE for this package's licensing information.
 //
 
-/// A placeholder standing in for brotli decoding, performed natively by CFNetwork -- but, unlike
-/// ``GzipAlgorithm``/``DeflateAlgorithm``, only under `.urlSession`. `NIOHTTPCompression` has no
-/// brotli decoder at all, on either transport, so there is no manual or native fallback anywhere
-/// else: a request that resolves to `.nio`/`.nioTransportServices` while this is configured, and
-/// that actually receives a `Content-Encoding: br` response, fails with
-/// ``NativeOnlyAlgorithmError`` at that point -- the name is chosen so that reading it back at
+/// A placeholder standing in for brotli decoding, performed natively by CFNetwork. Unlike
+/// ``GzipAlgorithm``/``DeflateAlgorithm``, though, it only works under `.urlSession`.
+///
+/// `NIOHTTPCompression` has no brotli decoder at all, on either transport, so there is no manual
+/// or native fallback anywhere else: a request that resolves to `.nio`/`.nioTransportServices`
+/// while this is configured, and that actually receives a `Content-Encoding: br` response, fails
+/// with ``NativeOnlyAlgorithmError`` at that point. The name is chosen so that reading it back at
 /// the call site already says why.
 ///
-/// The name is verbose on purpose -- unlike gzip/deflate, this one only works standalone, under
+/// The name is verbose on purpose: unlike gzip/deflate, this one only works standalone, under
 /// one specific executor, so the call site should say so plainly.
 public struct BrotliURLSessionOnlyAlgorithm: Decompressor {
 
@@ -33,6 +34,6 @@ public struct BrotliURLSessionOnlyAlgorithm: Decompressor {
 
 extension Decompressor where Self == BrotliURLSessionOnlyAlgorithm {
 
-    /// Decodes brotli-encoded responses -- natively, by CFNetwork, under `.urlSession` only.
+    /// Decodes brotli-encoded responses natively, by CFNetwork, under `.urlSession` only.
     public static var brotliURLSessionOnly: Self { .init() }
 }

--- a/Sources/RequestDL/Properties/Sources/Session/Decompression/Models/DeflateAlgorithm.swift
+++ b/Sources/RequestDL/Properties/Sources/Session/Decompression/Models/DeflateAlgorithm.swift
@@ -4,8 +4,8 @@
 
 /// Deflate, both directions.
 ///
-/// As a ``Decompressor``, this is a placeholder standing in for decoding always performed
-/// natively by the OS (`.urlSession`) or `async-http-client` (`.nio`/`.nioTransportServices`) --
+/// As a ``Decompressor``, this is a placeholder standing in for decoding that's always performed
+/// natively, either by the OS (`.urlSession`) or by `async-http-client` (`.nio`/`.nioTransportServices`),
 /// never by this type. The `Decompressor` `callAsFunction()` throws ``NativeOnlyAlgorithmError``
 /// if it's ever actually invoked, which only happens when mixed into the same list as a
 /// genuinely custom algorithm. See ``Session/decompressionAlgorithms(_:limit:)``.
@@ -46,6 +46,6 @@ extension Compressor where Self == DeflateAlgorithm {
 
 extension Decompressor where Self == DeflateAlgorithm {
 
-    /// Decodes deflate-encoded responses -- natively, by whichever executor the request resolves to.
+    /// Decodes deflate-encoded responses natively, by whichever executor the request resolves to.
     public static var deflate: Self { .init() }
 }

--- a/Sources/RequestDL/Properties/Sources/Session/Decompression/Models/GzipAlgorithm.swift
+++ b/Sources/RequestDL/Properties/Sources/Session/Decompression/Models/GzipAlgorithm.swift
@@ -5,7 +5,7 @@
 /// Gzip, both directions.
 ///
 /// As a ``Decompressor``, this is a placeholder standing in for decoding always performed
-/// natively by the OS (`.urlSession`) or `async-http-client` (`.nio`/`.nioTransportServices`) --
+/// natively by the OS (`.urlSession`) or `async-http-client` (`.nio`/`.nioTransportServices`),
 /// never by this type. The `Decompressor` `callAsFunction()` throws ``NativeOnlyAlgorithmError``
 /// if it's ever actually invoked, which only happens when mixed into the same list as a
 /// genuinely custom algorithm. See ``Session/decompressionAlgorithms(_:limit:)``.
@@ -46,6 +46,6 @@ extension Compressor where Self == GzipAlgorithm {
 
 extension Decompressor where Self == GzipAlgorithm {
 
-    /// Decodes gzip-encoded responses -- natively, by whichever executor the request resolves to.
+    /// Decodes gzip-encoded responses natively, by whichever executor the request resolves to.
     public static var gzip: Self { .init() }
 }

--- a/Sources/RequestDL/Properties/Sources/Session/Decompression/Models/InternalsDecompressionAlgorithmAdapter.swift
+++ b/Sources/RequestDL/Properties/Sources/Session/Decompression/Models/InternalsDecompressionAlgorithmAdapter.swift
@@ -6,8 +6,8 @@ import NIOCore
 import RequestDLInternals
 
 /// Adapts a `RequestDL.Decompressor` to `Internals.DecompressionAlgorithm`, converting between
-/// this module's public `[UInt8]`-based protocols and the `ByteBuffer`-based ones `Internals` --
-/// shared by both transports -- can reference without depending back on this module.
+/// this module's public `[UInt8]`-based protocols and the `ByteBuffer`-based ones `Internals`
+/// (shared by both transports) can reference without depending back on this module.
 struct InternalsDecompressionAlgorithmAdapter: Internals.DecompressionAlgorithm {
 
     // MARK: - Internal properties
@@ -20,7 +20,7 @@ struct InternalsDecompressionAlgorithmAdapter: Internals.DecompressionAlgorithm 
         algorithm.contentEncodingValue
     }
 
-    /// Not a `Decompressor` protocol requirement -- there is no legitimate reason for a
+    /// Not a `Decompressor` protocol requirement: there is no legitimate reason for a
     /// third-party algorithm to declare itself URLSession-only today, so this stays a closed,
     /// structural check against the one built-in type that actually is, rather than a
     /// customization point every conformer would otherwise have to consider.
@@ -29,7 +29,7 @@ struct InternalsDecompressionAlgorithmAdapter: Internals.DecompressionAlgorithm 
     }
 
     /// A closed, structural check against the exact built-in types that are themselves nothing
-    /// but placeholders for CFNetwork's own transparent decoding -- deliberately *not* a check
+    /// but placeholders for CFNetwork's own transparent decoding, deliberately *not* a check
     /// against `contentEncodingValue`. A genuinely custom `Decompressor` that happens to declare
     /// `contentEncodingValue == "gzip"` is not `GzipAlgorithm`, so this stays `false` for it: it
     /// forces `.urlSession` into manual dispatch instead of silently letting CFNetwork decode the
@@ -38,8 +38,8 @@ struct InternalsDecompressionAlgorithmAdapter: Internals.DecompressionAlgorithm 
         algorithm is GzipAlgorithm || algorithm is DeflateAlgorithm || algorithm is BrotliURLSessionOnlyAlgorithm
     }
 
-    /// Same structural check as `isNativelyDecodedByURLSession`, minus `BrotliURLSessionOnlyAlgorithm`
-    /// -- `NIOHTTPCompression` has no brotli decoder for `.nio`/`.nioTransportServices` to defer to
+    /// Same structural check as `isNativelyDecodedByURLSession`, minus `BrotliURLSessionOnlyAlgorithm`:
+    /// `NIOHTTPCompression` has no brotli decoder for `.nio`/`.nioTransportServices` to defer to
     /// at all, native or otherwise.
     var isNativelyDecodedByNIO: Bool {
         algorithm is GzipAlgorithm || algorithm is DeflateAlgorithm

--- a/Sources/RequestDL/Properties/Sources/Session/Decompression/Models/NativeOnlyAlgorithmError.swift
+++ b/Sources/RequestDL/Properties/Sources/Session/Decompression/Models/NativeOnlyAlgorithmError.swift
@@ -7,7 +7,7 @@
 ///
 /// In the normal case it never is: URLSession or `async-http-client` decodes these natively, and
 /// RequestDL never has to. It's only reached when one of these is mixed into
-/// ``Session/decompressionAlgorithms(_:limit:)`` alongside a genuinely custom algorithm --
+/// ``Session/decompressionAlgorithms(_:limit:)`` alongside a genuinely custom algorithm:
 /// mixing forces `.urlSession` to take over `Accept-Encoding` entirely (see
 /// ``Session/decompressionAlgorithms(_:limit:)``'s documentation), which means it also has to
 /// decode everything in the list itself, including the natives this type stands in for.

--- a/Sources/RequestDL/Properties/Sources/Session/Decompression/Models/UnsupportedContentEncodingError.swift
+++ b/Sources/RequestDL/Properties/Sources/Session/Decompression/Models/UnsupportedContentEncodingError.swift
@@ -6,7 +6,7 @@
 /// ``Session/decompressionAlgorithms(_:limit:)``.
 ///
 /// Only reachable once RequestDL has already taken over `Accept-Encoding` itself (any
-/// non-native algorithm in the list, or `.disabled`'s own `identity` override) -- a server is
+/// non-native algorithm in the list, or `.disabled`'s own `identity` override). A server is
 /// free to ignore what it was asked for, and this is what surfaces that rather than silently
 /// handing back undecoded bytes as if they were plain text.
 public struct UnsupportedContentEncodingError: Error, Sendable {

--- a/Sources/RequestDL/Properties/Sources/Session/Proxy/SystemProxy.swift
+++ b/Sources/RequestDL/Properties/Sources/Session/Proxy/SystemProxy.swift
@@ -25,8 +25,8 @@
 /// > Note: An explicit ``Proxy`` takes precedence. Declaring both leaves the explicit one in
 /// effect.
 ///
-/// > Note: Proxy auto configuration (a PAC script) is evaluated -- fetched and run as JavaScript
-/// against the request's URL, exactly like a browser would -- with results cached briefly per
+/// > Note: Proxy auto configuration (a PAC script) is evaluated (fetched and run as JavaScript
+/// against the request's URL, exactly like a browser would), with results cached briefly per
 /// script/URL pair so a burst of requests to the same host doesn't re-fetch and re-evaluate the
 /// same script for each one. A PAC script that's unreachable, or fails to evaluate, resolves to a
 /// direct connection rather than failing the request.

--- a/Sources/RequestDL/Properties/Sources/Session/Redirect/Models/InternalsRedirectStrategyAdapter.swift
+++ b/Sources/RequestDL/Properties/Sources/Session/Redirect/Models/InternalsRedirectStrategyAdapter.swift
@@ -5,8 +5,8 @@
 import RequestDLInternals
 
 /// Adapts a `RequestDL.RedirectStrategy` to `Internals.RedirectStrategy`, translating between
-/// this module's public request/response types and the ones `Internals` -- shared by both
-/// transports -- can reference without depending back on this module.
+/// this module's public request/response types and the ones `Internals` (shared by both
+/// transports) can reference without depending back on this module.
 struct InternalsRedirectStrategyAdapter: Internals.RedirectStrategy {
 
     // MARK: - Internal properties

--- a/Sources/RequestDL/Properties/Sources/Session/Redirect/Models/RedirectContext.swift
+++ b/Sources/RequestDL/Properties/Sources/Session/Redirect/Models/RedirectContext.swift
@@ -2,7 +2,7 @@
 // See LICENSE for this package's licensing information.
 //
 
-/// Everything a ``RedirectStrategy`` is handed to decide whether -- and how -- to follow one
+/// Everything a ``RedirectStrategy`` is handed to decide whether and how to follow one
 /// redirect.
 public struct RedirectContext: Sendable {
 
@@ -23,7 +23,7 @@ public struct RedirectContext: Sendable {
     /// `history.count - 1`).
     ///
     /// - Important: There is no built-in redirect limit once a ``RedirectStrategy`` is
-    /// configured -- enforce your own policy against this value (or `history`) to avoid an
+    /// configured. Enforce your own policy against this value (or `history`) to avoid an
     /// infinite redirect loop.
     public var redirectCount: Int
 

--- a/Sources/RequestDL/Properties/Sources/Session/Redirect/Models/RedirectDecision.swift
+++ b/Sources/RequestDL/Properties/Sources/Session/Redirect/Models/RedirectDecision.swift
@@ -2,7 +2,7 @@
 // See LICENSE for this package's licensing information.
 //
 
-/// The result of a ``RedirectStrategy`` deciding whether -- and how -- to follow a redirect.
+/// The result of a ``RedirectStrategy`` deciding whether (and how) to follow a redirect.
 public enum RedirectDecision: Sendable {
 
     /// Follow the redirect using the given request.

--- a/Sources/RequestDL/Properties/Sources/Session/Redirect/Models/RedirectRequest.swift
+++ b/Sources/RequestDL/Properties/Sources/Session/Redirect/Models/RedirectRequest.swift
@@ -5,7 +5,7 @@
 /// The request a ``RedirectStrategy`` is asked to decide on, and the request it can return to
 /// follow the redirect with.
 ///
-/// Already carries the standard rewrite rules a redirect implies -- method downgraded to `GET`
+/// Already carries the standard rewrite rules a redirect implies: method downgraded to `GET`
 /// on a `303` (or a `301`/`302` response to a `POST`), and `Authorization`/`Cookie`/`Origin`/
 /// `Proxy-Authorization` stripped when ``url`` no longer shares the original request's origin
 /// (scheme, host, and port). A strategy only needs to make further adjustments on top of that,
@@ -27,7 +27,7 @@ public struct RedirectRequest: Sendable {
     ///
     /// Read-only: which requests carry a body, and which don't, is already decided by the
     /// redirect rewrite rules (e.g. a `303` drops it) before a ``RedirectStrategy`` ever sees
-    /// this value -- there is no supported way to attach or remove a body from here.
+    /// this value; there is no supported way to attach or remove a body from here.
     public let hasBody: Bool
 
     // MARK: - Inits

--- a/Sources/RequestDL/Properties/Sources/Session/Redirect/RedirectStrategy.swift
+++ b/Sources/RequestDL/Properties/Sources/Session/Redirect/RedirectStrategy.swift
@@ -2,7 +2,7 @@
 // See LICENSE for this package's licensing information.
 //
 
-/// A pluggable strategy for deciding whether -- and how -- to follow HTTP redirects, used via
+/// A pluggable strategy for deciding whether and how to follow HTTP redirects, used via
 /// ``Session/redirectStrategy(_:)``.
 ///
 /// Unlike ``Session/disableRedirect()``/``Session/enableRedirectFollow(max:allowCycles:)``, a
@@ -24,23 +24,23 @@
 /// ```
 ///
 /// - Important: A single strategy instance is shared across every request made under it,
-/// including concurrently -- if it holds mutable state (e.g. an audit log, a shared allow-list),
+/// including concurrently. If it holds mutable state (e.g. an audit log, a shared allow-list),
 /// synchronize it yourself (an `actor`, or a class using a lock). Per-request state doesn't need
 /// that: ``RedirectContext/history`` already carries everything tracked so far for the *current*
 /// logical request, so most policies (host allow-listing, loop bounds, auditing) can be
 /// implemented statelessly by reading it fresh on each call.
 ///
 /// - Note: Configuring a ``RedirectStrategy`` opts a ``Session`` out of connection-pool reuse
-/// across requests -- unlike every other ``Session`` property, a strategy has no meaningful
+/// across requests. Unlike every other ``Session`` property, a strategy has no meaningful
 /// notion of equality to compare against a previously pooled client, so each resolution of a
 /// ``Property`` tree that configures one gets a fresh client.
 public protocol RedirectStrategy: Sendable {
 
     ///
-    /// Decide whether -- and how -- to follow a redirect.
+    /// Decide whether and how to follow a redirect.
     ///
     /// - Parameter context: Everything known about the redirect so far. See ``RedirectContext``.
-    /// - Returns: Whether -- and with what request -- to follow the redirect.
+    /// - Returns: Whether to follow the redirect, and with what request.
     /// - Throws: To fail the whole request with a custom error instead of following the redirect
     /// or returning the response that triggered it.
     ///

--- a/Sources/RequestDL/Properties/Sources/Session/Session/Models/ExecutorRequirementError.swift
+++ b/Sources/RequestDL/Properties/Sources/Session/Session/Models/ExecutorRequirementError.swift
@@ -7,8 +7,8 @@ import RequestDLInternals
 /// An error thrown when `Session.requiredExecutor(_:)` pins a session to an ``Session/Executor``
 /// its configuration cannot actually run on.
 ///
-/// `RequestDLInternals`'s raw `Internals.IncompatibleExecutorConfigurationError` -- the internal,
-/// package-visible error -- gets caught where the session bootstraps and rewrapped into this
+/// `RequestDLInternals`'s raw `Internals.IncompatibleExecutorConfigurationError` (the internal,
+/// package-visible error) gets caught where the session bootstraps and rewrapped into this
 /// type, following the same split `SecureFileError` uses for `Internals.SecureFileLoadError`.
 public struct ExecutorRequirementError: Error, Sendable {
 

--- a/Sources/RequestDL/Properties/Sources/Session/Session/Models/Session.Executor.swift
+++ b/Sources/RequestDL/Properties/Sources/Session/Session/Models/Session.Executor.swift
@@ -12,7 +12,7 @@ extension Session {
         case urlSession
         /// SwiftNIO's Network.framework transport (`NIOTransportServices`).
         case nioTransportServices
-        /// Plain SwiftNIO -- the universal fallback available on every supported platform.
+        /// Plain SwiftNIO, the universal fallback available on every supported platform.
         case nio
 
         // MARK: - Inits

--- a/Sources/RequestDL/Properties/Sources/Session/Session/Session.swift
+++ b/Sources/RequestDL/Properties/Sources/Session/Session/Session.swift
@@ -161,12 +161,12 @@ public struct Session: Property {
     /// Enable the usage of Network framework on Apple Platforms when compatible.
     ///
     /// Currently AsyncHTTPClient doesn't provide full compatibility to Apple's Network Framework. The main issue is when using mTLS
-    /// or specific secure connection settings -- including ``SPKIPinning``, which Network framework's bridge into
+    /// or specific secure connection settings, including ``SPKIPinning``, which Network framework's bridge into
     /// `sec_protocol_options` never consults. When the session's ``SecureConnection`` carries any such setting, this flag
     /// is silently ignored and the session falls back to plain SwiftNIO instead of failing or dropping the incompatible
     /// setting: whichever secure-connection settings were configured still apply in full, just over a different transport.
     ///
-    /// - Note: Deprecated in favor of ``preferredExecutor(_:)`` -- specifically
+    /// - Note: Deprecated in favor of ``preferredExecutor(_:)``, specifically
     /// `.preferredExecutor(.nioTransportServices)`, which is wired into the same live decision
     /// this flag drives. `enableNetworkFramework(true)` keeps working exactly as before: it's
     /// treated as an *implicit* `preferredExecutor(.nioTransportServices)` whenever nothing else
@@ -300,7 +300,7 @@ public struct Session: Property {
     }
 
     ///
-    /// Hands every redirect-eligible response to `strategy`, which decides whether -- and how --
+    /// Hands every redirect-eligible response to `strategy`, which decides whether (and how)
     /// to follow it, instead of the fixed count/cycle limit ``enableRedirectFollow(max:allowCycles:)``
     /// applies. See ``RedirectStrategy``.
     ///
@@ -313,8 +313,8 @@ public struct Session: Property {
 
     ///
     /// Convenience over ``redirectStrategy(_:)`` for a policy that doesn't need its own type:
-    /// every redirect-eligible response is handed to `handler`, which decides whether -- and how
-    /// -- to follow it. See ``RedirectContext`` for what `handler` receives.
+    /// every redirect-eligible response is handed to `handler`, which decides whether (and how)
+    /// to follow it. See ``RedirectContext`` for what `handler` receives.
     ///
     /// - Parameter handler: The closure that decides each redirect.
     /// - Returns: The modified `Session` instance with the redirect strategy configured.
@@ -340,13 +340,13 @@ public struct Session: Property {
     ///
     /// ``Decompressor/gzip``/``Decompressor/deflate``/``Decompressor/brotliURLSessionOnly`` are
     /// placeholders for what the OS (`.urlSession`) or `async-http-client`
-    /// (`.nio`/`.nioTransportServices`) already decode natively -- RequestDL never reimplements
+    /// (`.nio`/`.nioTransportServices`) already decode natively; RequestDL never reimplements
     /// them, and in the common case where `algorithms` contains only those, nothing in this
     /// package ever touches the response bytes at all.
     ///
     /// A genuinely custom `Decompressor` changes that on `.urlSession`: CFNetwork's transparent
     /// decoding can only be switched off entirely, for every encoding at once, by taking over
-    /// `Accept-Encoding` ourselves -- so as soon as `algorithms` contains anything beyond the
+    /// `Accept-Encoding` ourselves, so as soon as `algorithms` contains anything beyond the
     /// three natives, this session sets `Accept-Encoding` itself (every configured algorithm,
     /// listed) and decodes all of it manually, including gzip/deflate if they're in the same
     /// list. `.nio`/`.nioTransportServices` have no such constraint: `async-http-client`'s own
@@ -354,8 +354,8 @@ public struct Session: Property {
     /// alongside manual dispatch for whatever it leaves untouched.
     ///
     /// A response whose `Content-Encoding` matches none of `algorithms` throws
-    /// ``UnsupportedContentEncodingError`` -- only reachable once this session has already taken
-    /// over decoding itself, per the paragraph above.
+    /// ``UnsupportedContentEncodingError``, which is only reachable once this session has already
+    /// taken over decoding itself, per the paragraph above.
     ///
     /// - Parameters:
     ///   - algorithms: The decompressors this session accepts. Passing `[]` is equivalent to

--- a/Sources/RequestDL/Properties/Sources/Session/Timeout/Models/ResourceTimeoutError.swift
+++ b/Sources/RequestDL/Properties/Sources/Session/Timeout/Models/ResourceTimeoutError.swift
@@ -2,14 +2,14 @@
 // See LICENSE for this package's licensing information.
 //
 
-/// An error thrown when a request exceeds ``Timeout/Source/resource``'s deadline -- the total
+/// An error thrown when a request exceeds ``Timeout/Source/resource``'s deadline: the total
 /// time budgeted for connecting, following redirects, and streaming the entire response body,
 /// all together.
 ///
 /// Unlike ``Timeout/Source/connect``/``Timeout/Source/read``, which AsyncHTTPClient enforces
 /// per phase on its own, RequestDL enforces this one itself: it races the request end to end
 /// against the configured deadline and cancels it the same way dropping the response or
-/// cancelling the enclosing `Task` already would, the moment the deadline passes -- whether
+/// cancelling the enclosing `Task` already would, the moment the deadline passes, whether
 /// that's still during connection/redirects or partway through the body.
 public struct ResourceTimeoutError: Error, Sendable {
 

--- a/Sources/RequestDL/Properties/Sources/Session/Timeout/Models/Timeout.Source.swift
+++ b/Sources/RequestDL/Properties/Sources/Session/Timeout/Models/Timeout.Source.swift
@@ -12,8 +12,8 @@ extension Timeout {
     /// 1. `connect`: The connect timeout case. The default value is 30s.
     /// 2. `read`: The read timeout case.
     /// 3. `resource`: A total end-to-end deadline, covering connection, redirects, and the entire body transfer.
-    /// 4. `all`: Defines the same timeout interval for both connect and read -- deliberately excludes `resource`,
-    ///    since it means something different (a ceiling on the *whole* request) than the other two.
+    /// 4. `all`: Defines the same timeout interval for both connect and read. It deliberately excludes `resource`,
+    ///    since that means something different (a ceiling on the *whole* request) than the other two.
     ///
     /// In the example below, a request is made to the Google's website with the timeout for all types.
     ///
@@ -38,7 +38,7 @@ extension Timeout {
         /// A total end-to-end deadline for the request, mirroring
         /// `URLSessionConfiguration.timeoutIntervalForResource`: covers connecting, following any
         /// redirects, and streaming the entire response body, all as one budget. Enforced by
-        /// RequestDL itself -- neither AsyncHTTPClient's `Timeout` nor `URLSessionConfiguration`'s
+        /// RequestDL itself, since neither AsyncHTTPClient's `Timeout` nor `URLSessionConfiguration`'s
         /// own per-phase timeouts offer a single knob for this.
         ///
         /// Not included in ``all``: unlike `connect`/`read`, this isn't a per-phase timeout, so

--- a/Sources/RequestDL/Properties/Sources/URL/Query/Models/Strategies/URLEncoder.ArrayEncodingStrategy.swift
+++ b/Sources/RequestDL/Properties/Sources/URL/Query/Models/Strategies/URLEncoder.ArrayEncodingStrategy.swift
@@ -11,7 +11,7 @@ extension URLEncoder {
         case droppingIndex
 
         /// Encodes the index as a fixed, empty pair of square brackets, e.g. `[]`, the same for
-        /// every element -- unlike ``subscripted``, the brackets never carry the actual index.
+        /// every element. Unlike ``subscripted``, the brackets never carry the actual index.
         case brackets
 
         /// Encodes the index in square brackets, e.g. `[0]`.

--- a/Sources/RequestDL/Request/RequestBody.swift
+++ b/Sources/RequestDL/Request/RequestBody.swift
@@ -29,8 +29,8 @@ public struct RequestBody: Sendable {
 
     // MARK: - Public properties
 
-    /// The size of each chunk used for streaming the body data. `.zero` for a compressing body --
-    /// chunking is the compressor's own business there, not a fixed size decided upfront.
+    /// The size of each chunk used for streaming the body data. `.zero` for a compressing body,
+    /// since chunking is the compressor's own business there, not a fixed size decided upfront.
     public var chunkSize: Int {
         switch backing {
         case .fixed(let body):
@@ -42,7 +42,7 @@ public struct RequestBody: Sendable {
 
     /// The total size of the body data in bytes.
     ///
-    /// - Important: For a compressing body, this reports the *original*, pre-compression size --
+    /// - Important: For a compressing body, this reports the *original*, pre-compression size:
     /// a best-effort upper-bound progress estimate, not the actual wire size, which isn't known
     /// until the whole body has streamed through. A progress reader dividing by this value sees
     /// its percentage approach completion a little before the upload actually finishes, rather
@@ -57,7 +57,7 @@ public struct RequestBody: Sendable {
     }
 
     /// The file this body already lives in, when nothing but reading it directly would be
-    /// needed to reproduce it exactly -- see `Internals.BodySequence.wholeFileURL`. Not public:
+    /// needed to reproduce it exactly (see `Internals.BodySequence.wholeFileURL`). Not public:
     /// this exists for `Internals.URLSessionClient+RequestExecutingClient.swift` to skip a
     /// redundant copy for a `Payload(url:)`-only body, not as API surface for callers of
     /// `RequestBody` itself.
@@ -73,7 +73,7 @@ public struct RequestBody: Sendable {
         }
     }
 
-    /// The size to declare on the wire -- `nil` switches both executors to unknown-length,
+    /// The size to declare on the wire. `nil` switches both executors to unknown-length,
     /// chunked-transfer upload. Distinct from the public ``totalSize``, which for a compressing
     /// body reports the *original* size as a progress estimate, never the (not-yet-known) wire
     /// size a `Content-Length`/declared-length upload would need to be exactly right.
@@ -110,7 +110,7 @@ public struct RequestBody: Sendable {
 
     // MARK: - Internal methods
 
-    /// Wraps this body so each chunk is compressed as it's pulled by the transport -- see
+    /// Wraps this body so each chunk is compressed as it's pulled by the transport. See
     /// `Internals.CompressingByteSequence`'s own doc comment for why that's worth doing over
     /// draining the whole body into memory before compression starts.
     func compressed(with algorithm: any Internals.CompressionAlgorithm) -> RequestBody {
@@ -119,7 +119,7 @@ public struct RequestBody: Sendable {
             return RequestBody(backing: .compressing(.init(source: body, algorithm: algorithm)))
         case .compressing:
             // `RequestConfiguration.applyCompression()` only ever calls this once, on a freshly
-            // assembled body -- reached only if some future caller compresses twice.
+            // assembled body; this case is reached only if some future caller compresses twice.
             return self
         }
     }
@@ -198,7 +198,7 @@ extension RequestBody: AsyncSequence {
         ///
         /// - Returns: The next `ByteBuffer` in the sequence, or `nil` if there are no more elements.
         /// - Throws: Whatever a configured ``Compressor``'s ``CompressorStream`` throws, for a
-        /// compressing body -- a fixed body never throws, but shares this signature so callers
+        /// compressing body. A fixed body never throws, but shares this signature so callers
         /// don't need to know which kind of `RequestBody` they were handed.
         ///
         public mutating func next() async throws -> NIOCore.ByteBuffer? {

--- a/Sources/RequestDL/Request/RequestConfiguration+Compression.swift
+++ b/Sources/RequestDL/Request/RequestConfiguration+Compression.swift
@@ -11,7 +11,7 @@ extension RequestConfiguration {
     /// `Content-Encoding`/`Content-Length` to match.
     ///
     /// Runs once, here, before this configuration ever reaches `build(eventLoop:)` (the `.nio`
-    /// path) or `buildURLRequest()`/the streamed-upload path (the `.urlSession` path) --
+    /// path) or `buildURLRequest()`/the streamed-upload path (the `.urlSession` path).
     /// `RequestBody` backs the outgoing body identically for both, so wrapping it at this layer,
     /// rather than at the wire layer, makes compression behave identically on every executor and
     /// every negotiated HTTP version. A wire-layer implementation would instead need a codec
@@ -19,14 +19,14 @@ extension RequestConfiguration {
     /// pipeline isn't something this package controls at all.
     ///
     /// A no-op when there's no body, the body is empty, no `Compressor` is configured, or
-    /// `shouldCompressBodyData` declines this body's size -- the common case, so callers that
+    /// `shouldCompressBodyData` declines this body's size. That's the common case, so callers that
     /// never touch `.compression(_:)` pay nothing here.
     ///
-    /// - Important: Genuinely streamed -- `body.compressed(with:)` wraps `RequestBody` in an
+    /// - Important: Genuinely streamed. `body.compressed(with:)` wraps `RequestBody` in an
     /// `Internals.CompressingByteSequence` that compresses each chunk as the transport pulls it,
     /// rather than draining the whole body into memory before compression starts. The final,
     /// on-the-wire size is only known once the whole body has streamed through, so
-    /// `Content-Length` is removed here rather than set -- both executors fall back to chunked
+    /// `Content-Length` is removed here rather than set: both executors fall back to chunked
     /// transfer encoding (`HTTPClient.Body.stream(length: nil, ...)` on `.nio`, URLSession's own
     /// length-less upload path) instead of declaring a byte count upfront.
     mutating func applyCompression() throws {

--- a/Sources/RequestDL/Request/RequestConfiguration.swift
+++ b/Sources/RequestDL/Request/RequestConfiguration.swift
@@ -94,7 +94,7 @@ public struct RequestConfiguration: Sendable {
     private var didWriteUserAgent = false
 
     /// Captured from `inputs.environment.compression` at `_makeProperty` time by whichever
-    /// `Property` builds the node that produces ``body`` (`Payload`, `Form`, `FormGroup`) -- not
+    /// `Property` builds the node that produces ``body`` (`Payload`, `Form`, `FormGroup`). It is not
     /// read from inside a node's own `make(_:)`, since `PropertyNode.make(_:)` has no
     /// `environment` of its own to read. `nil` when no `Property.compression(_:onDuplicateHeader
     /// :shouldCompressBodyData:)` is in scope, or when nothing in the tree ever produces a body
@@ -168,13 +168,13 @@ import Foundation
 
 extension RequestConfiguration {
 
-    /// `URLSession` counterpart to `build(eventLoop:)` -- needs no `EventLoop`, since it drains
+    /// `URLSession` counterpart to `build(eventLoop:)`. It needs no `EventLoop`, since it drains
     /// `RequestBody` through its `AsyncSequence` conformance rather than the
     /// `EventLoopFuture`-driven streaming path `build(eventLoop:)` uses.
     ///
     /// Non-streaming: the whole body is buffered into `Data` before the request is returned. See
     /// `buildURLRequestWithoutBody()` for the streamed-upload counterpart, which drains `body`
-    /// itself -- into memory too, for anything under
+    /// itself, into memory too, for anything under
     /// `Internals.URLSessionUploadFile.inMemoryThreshold`, or a temporary file for anything larger.
     func buildURLRequest() async throws -> URLRequest {
         var request = try buildURLRequestWithoutBody()
@@ -193,9 +193,9 @@ extension RequestConfiguration {
         return request
     }
 
-    /// URL/method/headers only -- deliberately never touches `body`. Pairs with
+    /// URL/method/headers only; this deliberately never touches `body`. Pairs with
     /// `Internals.URLSessionClient.execute(request:streaming:delegate:onUploadProgress:)`, which
-    /// drives `body` itself -- via `uploadTask(with:from:)` or `uploadTask(with:fromFile:)`
+    /// drives `body` itself, via `uploadTask(with:from:)` or `uploadTask(with:fromFile:)`
     /// depending on size, see `Internals.URLSessionUploadFile`; both
     /// ignore whatever `httpBody`/`httpBodyStream` the request carries, so setting either here
     /// would be dead weight the caller has to know to not rely on rather than something actually
@@ -208,8 +208,8 @@ extension RequestConfiguration {
         var request = URLRequest(url: requestURL)
         request.httpMethod = method ?? "GET"
 
-        // Overrides `URLRequest`'s own default (`.useProtocolCachePolicy`), which -- independent
-        // of RequestDL's own `Internals.CacheControl`/`DataCache` -- lets URLSession's own
+        // Overrides `URLRequest`'s own default (`.useProtocolCachePolicy`), which, independent
+        // of RequestDL's own `Internals.CacheControl`/`DataCache`, lets URLSession's own
         // `URLCache` answer from its own state before ever reaching the network. RequestDL owns
         // caching entirely itself; a second, invisible cache layer underneath URLSession does
         // nothing useful and only risks disagreeing with it.
@@ -221,16 +221,17 @@ extension RequestConfiguration {
                 continue
             }
 
-            // `only-if-cached` is stripped from the wire header -- CFNetwork itself, underneath
+            // `only-if-cached` is stripped from the wire header: CFNetwork itself, underneath
             // URLSession, honors this directive against its *own* cache before the request above
-            // ever applies: regardless of `request.cachePolicy`, a `Cache-Control:
+            // ever applies. Regardless of `request.cachePolicy`, a `Cache-Control:
             // only-if-cached` request URLSession has nothing cached for fails outright with
-            // `NSURLErrorDomain` -2000 ("can't load from network"). `Internals.CacheControl`
-            // already resolved what this directive means for RequestDL's own cache before this
-            // request is ever built (see `effectiveCacheStrategy`) -- by the time execution
-            // reaches here, forwarding it verbatim would only hand the same decision to a second,
-            // stricter cache this package doesn't control and never asked to be consulted only
-            // conditionally in the first place.
+            // `NSURLErrorDomain` -2000 ("can't load from network").
+            //
+            // `Internals.CacheControl` already resolved what this directive means for RequestDL's
+            // own cache before this request is ever built (see `effectiveCacheStrategy`). By the
+            // time execution reaches here, forwarding it verbatim would only hand the same
+            // decision to a second, stricter cache this package doesn't control and never asked
+            // to be consulted only conditionally in the first place.
             let remaining =
                 value
                 .split(separator: ",")
@@ -248,7 +249,7 @@ extension RequestConfiguration {
     }
 }
 
-/// `url` failed to parse as a `Foundation.URL` -- mirrors `build(eventLoop:)`'s own failure mode,
+/// `url` failed to parse as a `Foundation.URL`. Mirrors `build(eventLoop:)`'s own failure mode,
 /// where `HTTPClient.Request`'s URL parser rejects the same kind of malformed string.
 struct InvalidRequestURLError: Error, Sendable {
     let url: String

--- a/Sources/RequestDL/Tasks/Sources/Background Download/BackgroundDownloadTask.swift
+++ b/Sources/RequestDL/Tasks/Sources/Background Download/BackgroundDownloadTask.swift
@@ -15,9 +15,11 @@ import struct Foundation.URL
 /// Schedules a download that keeps running even if the app is suspended or terminated, via
 /// `URLSession`'s background transfer support.
 ///
-/// Unlike ``DownloadTask``, ``result()`` does not wait for the download to finish -- it can't:
+/// Unlike ``DownloadTask``, ``result()`` does not wait for the download to finish. It can't:
 /// the transfer may complete long after this call returns, in a different process launch
-/// entirely. Register ``BackgroundDownloads/onEvent`` to be told when it actually completes,
+/// entirely.
+///
+/// Register ``BackgroundDownloads/onEvent`` to be told when it actually completes,
 /// fails, or makes progress, and forward
 /// `application(_:handleEventsForBackgroundURLSession:completionHandler:)` to
 /// ``BackgroundDownloads/handleEvents(forBackgroundURLSession:completionHandler:)`` for the
@@ -35,10 +37,11 @@ import struct Foundation.URL
 /// ```
 ///
 /// `content` can configure ``TrustRoots``/``AdditionalTrustRoots``/``SecureConnection/verification(_:)``
-/// freely -- none of them need a Keychain round-trip to survive a relaunch, only the certificate
+/// freely: none of them need a Keychain round-trip to survive a relaunch, only the certificate
 /// bytes themselves, which travel alongside `id`/`destination` in the scheduled task's own state.
+///
 /// A client certificate (mTLS) works too, as long as both ``Certificate`` and ``PrivateKey`` come
-/// from a **file path**, not in-memory bytes -- see ``BackgroundDownloadUnsupportedConfigurationError``
+/// from a **file path**, not in-memory bytes. See ``BackgroundDownloadUnsupportedConfigurationError``
 /// for the specific cases that still aren't supported.
 public struct BackgroundDownloadTask<Content: Property> {
 
@@ -53,7 +56,7 @@ public struct BackgroundDownloadTask<Content: Property> {
     /// - Parameters:
     ///   - id: Identifies this download in every ``BackgroundDownloads/Event`` it produces.
     ///     Not the `URLSession` background session identifier, which RequestDL manages
-    ///     internally -- this is only ever your own correlation key.
+    ///     internally; this is only ever your own correlation key.
     ///   - destination: Where the downloaded file ends up. Overwrites anything already there
     ///     once the download completes.
     ///   - content: The request to make, exactly as with any other task.
@@ -69,13 +72,13 @@ public struct BackgroundDownloadTask<Content: Property> {
 
     // MARK: - Public methods
 
-    /// Resolves `content` and schedules the download. Returns as soon as it's scheduled --
+    /// Resolves `content` and schedules the download. Returns as soon as it's scheduled;
     /// use ``BackgroundDownloads/onEvent`` to observe how it turns out.
     ///
     /// - Throws: ``BackgroundDownloadUnsupportedConfigurationError`` if `content` configures a
     ///   client certificate or SPKI pin this executor can't rebuild after a relaunch (see its own
     ///   documentation for the specific cases), or any error `content` itself throws while being
-    ///   resolved into a request (an invalid URL, a certificate file that can't be read, etc.) --
+    ///   resolved into a request (an invalid URL, a certificate file that can't be read, etc.),
     ///   the same errors any other task can throw at this stage.
     public func result() async throws {
         let resolved = try await Resolve(

--- a/Sources/RequestDL/Tasks/Sources/Background Download/BackgroundDownloads.swift
+++ b/Sources/RequestDL/Tasks/Sources/Background Download/BackgroundDownloads.swift
@@ -14,7 +14,7 @@ import Foundation
 ///
 /// Deliberately not a member of ``BackgroundDownloadTask`` itself: a generic type's static
 /// storage is per-specialization in Swift, and every `BackgroundDownloadTask<Content>` call site
-/// has its own concrete `Content` -- a handler stored there would only ever see the downloads
+/// has its own concrete `Content`, a handler stored there would only ever see the downloads
 /// created with that exact `Content` type, not every download in the app. `BackgroundDownloads`
 /// is a plain, non-generic namespace specifically so there is exactly one of everything below,
 /// regardless of how many different `BackgroundDownloadTask<Content>` specializations exist.
@@ -24,11 +24,11 @@ public enum BackgroundDownloads {
     /// created with.
     public enum Event: Sendable {
         /// `bytesWritten`/`totalBytesExpected` are the running totals for the whole download, not
-        /// the size of this particular callback -- matching
+        /// the size of this particular callback, matching
         /// `URLSessionDownloadDelegate.urlSession(_:downloadTask:didWriteData:totalBytesWritten:totalBytesExpectedToWrite:)`.
         case progress(id: String, destination: URL, bytesWritten: Int64, totalBytesExpected: Int64)
 
-        /// The file is already at `destination` by the time this fires -- moved there from
+        /// The file is already at `destination` by the time this fires, moved there from
         /// `URLSession`'s own temporary location before this event is ever produced.
         case completed(id: String, destination: URL)
 
@@ -38,7 +38,7 @@ public enum BackgroundDownloads {
     /// Called for every event from every ``BackgroundDownloadTask`` in the process, on an
     /// unspecified queue.
     ///
-    /// Set this once, early -- ideally before any ``BackgroundDownloadTask`` is ever created,
+    /// Set this once, early, ideally before any ``BackgroundDownloadTask`` is ever created,
     /// and unconditionally on every launch, including a launch the system triggered only to
     /// deliver background events (there is no user-visible UI at that point, but the events still
     /// need somewhere to go).
@@ -52,9 +52,10 @@ public enum BackgroundDownloads {
     ///
     /// Required for background downloads to work at all: this is how the system hands back the
     /// identifier of the session it wants reconnected, and the completion handler that has to be
-    /// called once every queued event has actually been delivered to ``onEvent`` -- calling it
-    /// any earlier risks the system snapshotting the app before its state reflects what actually
-    /// finished.
+    /// called once every queued event has actually been delivered to ``onEvent``.
+    ///
+    /// Calling it any earlier risks the system snapshotting the app before its state reflects
+    /// what actually finished.
     ///
     /// ```swift
     /// func application(
@@ -78,11 +79,11 @@ public enum BackgroundDownloads {
     /// Cancels the ``BackgroundDownloadTask`` scheduled with this `id`, if it's still running.
     ///
     /// A cancelled download is reported through ``onEvent`` as an ordinary `.failed` event (the
-    /// underlying error is `NSURLErrorCancelled`), the same way any other failure is -- there is
+    /// underlying error is `NSURLErrorCancelled`), the same way any other failure is: there is
     /// no separate "was cancelled" event of its own.
     ///
     /// - Returns: `true` if a matching, still-running download was found and cancelled; `false`
-    ///   if none was -- it may have already finished, failed, or never existed.
+    ///   if none was, since it may have already finished, failed, or never existed.
     @discardableResult
     public static func cancel(id: String) async -> Bool {
         await Session.shared.cancel(id: id)

--- a/Sources/RequestDL/Tasks/Sources/Background Download/Models/BackgroundDownloadUnsupportedConfigurationError.swift
+++ b/Sources/RequestDL/Tasks/Sources/Background Download/Models/BackgroundDownloadUnsupportedConfigurationError.swift
@@ -15,14 +15,17 @@ import protocol Foundation.LocalizedError
 /// An error thrown when a ``BackgroundDownloadTask``'s content configures a client certificate
 /// (mTLS) or SPKI pinning in a shape that can't survive a relaunch.
 ///
-/// A background download can outlive the process that started it -- the delegate answering a
+/// A background download can outlive the process that started it: the delegate answering a
 /// challenge after the app relaunches has no `Property` tree left to resolve
 /// `certificateChain`/`privateKey`/``SPKIPinning`` from, only whatever was persisted alongside
-/// `id`/`destination` on the scheduled task itself. `Certificate`/`PrivateKey` backed by a
-/// **file path** work fine: the path is what's persisted, and the identity is rebuilt from that
-/// file via the same Keychain round-trip on every challenge, live or after a relaunch alike. What
-/// doesn't survive is anything that isn't a stable path on disk, or an SPKI pin hashed with
-/// something other than SHA-256/384/512 -- see ``Reason`` for the specific cases.
+/// `id`/`destination` on the scheduled task itself.
+///
+/// `Certificate`/`PrivateKey` backed by a **file path** work fine: the path is what's persisted,
+/// and the identity is rebuilt from that file via the same Keychain round-trip on every
+/// challenge, live or after a relaunch alike.
+///
+/// What doesn't survive is anything that isn't a stable path on disk, or an SPKI pin hashed with
+/// something other than SHA-256/384/512. See ``Reason`` for the specific cases.
 ///
 /// `TrustRoots`/`AdditionalTrustRoots`/``SecureConnection/verification(_:)`` are unaffected by any
 /// of this: their certificate bytes are public, so they're persisted directly rather than by
@@ -32,12 +35,12 @@ public struct BackgroundDownloadUnsupportedConfigurationError: Error, Sendable {
     /// The specific reason a client certificate or SPKI pinning configuration can't be used in a
     /// background download.
     public enum Reason: Sendable {
-        /// Only one of `certificateChain`/`privateKey` was configured -- mTLS needs both.
+        /// Only one of `certificateChain`/`privateKey` was configured; mTLS needs both.
         case incompleteClientIdentity
 
         /// `certificateChain` or `privateKey` came from in-memory bytes or a pre-built
         /// certificate, not a file path. Only a file path is guaranteed to still be there to
-        /// re-read after a relaunch -- in-memory bytes are gone with the process that held them.
+        /// re-read after a relaunch; in-memory bytes are gone with the process that held them.
         case nonFileBackedSource
 
         /// The private key is password-protected. Decrypting it once and persisting the

--- a/Sources/RequestDL/Tasks/Sources/Background Download/Models/BackgroundDownloads.Session.swift
+++ b/Sources/RequestDL/Tasks/Sources/Background Download/Models/BackgroundDownloads.Session.swift
@@ -18,23 +18,24 @@ extension BackgroundDownloads {
     /// The single `URLSession` backing every ``BackgroundDownloadTask``, plus the delegate
     /// callbacks that turn its events into ``BackgroundDownloads/Event``.
     ///
-    /// One fixed identifier for the whole process, not one per download -- a background session
+    /// One fixed identifier for the whole process, not one per download: a background session
     /// happily runs many concurrent tasks, and splitting them across sessions would only add
     /// surface to keep in sync on reconnection for no real benefit. Individual downloads are told
     /// apart by `URLSessionTask.taskDescription`, not by which session they run on.
     ///
     /// Not an `actor`: `urlSession(_:downloadTask:didFinishDownloadingTo:)` has to move the
     /// downloaded file synchronously, before returning, since the system deletes the temporary
-    /// file right after that call returns -- an `await` hop there would race the cleanup.
+    /// file right after that call returns; an `await` hop there would race the cleanup.
     final class Session: NSObject, URLSessionDownloadDelegate, @unchecked Sendable {
 
         // MARK: - Internal static properties
 
         static let shared = Session()
 
-        /// Stable across launches (same bundle, same string every time) -- required for the
-        /// system to reconnect this session to tasks that outlived a previous process. Not
-        /// `private` -- `handleEvents(forIdentifier:completionHandler:)`'s identifier-matching
+        /// Stable across launches (same bundle, same string every time): required for the
+        /// system to reconnect this session to tasks that outlived a previous process.
+        ///
+        /// Not `private`: `handleEvents(forIdentifier:completionHandler:)`'s identifier-matching
         /// guard is unit-tested directly against this exact value, rather than duplicating it.
         static let identifier = "\(Bundle.main.bundleIdentifier ?? "RequestDL").BackgroundDownloadTask"
 
@@ -88,27 +89,27 @@ extension BackgroundDownloads {
             lock.withLock { _pendingCompletionHandler = completionHandler }
 
             // Recreating the session (or confirming it already exists) with the matching
-            // identifier is what makes the system replay queued delegate callbacks -- there is no
+            // identifier is what makes the system replay queued delegate callbacks; there is no
             // separate "reconnect" call.
             _ = urlSession()
         }
 
         /// Cancels the download with this `id`, if one is currently running.
         ///
-        /// No index of `id` -> `URLSessionTask` is kept around -- there is nowhere safe to keep
+        /// No index of `id` -> `URLSessionTask` is kept around: there is nowhere safe to keep
         /// one that would still be valid after a relaunch anyway, since a fresh process starts
         /// with nothing in memory. `allTasks` is the system's own live answer instead, always
         /// asked fresh: cheap enough for something that only runs when a caller explicitly asks
         /// to cancel something, not on any hot path.
         ///
         /// Cancelling a `URLSessionTask` this way makes it fail with `NSURLErrorCancelled`
-        /// shortly after, through the ordinary `didCompleteWithError` callback below -- so a
+        /// shortly after, through the ordinary `didCompleteWithError` callback below, so a
         /// cancellation is reported through ``BackgroundDownloads/onEvent`` as an ordinary
         /// `.failed` event, not a distinct case of its own.
         ///
         /// - Returns: `true` if a matching, still-running download was found and cancelled;
         /// `false` if none was (already finished, never existed, or no download has ever been
-        /// scheduled in this process at all -- checked without creating a session just to find
+        /// scheduled in this process at all, checked without creating a session just to find
         /// out, since there would be nothing in it to cancel either way).
         @discardableResult
         func cancel(id: String) async -> Bool {
@@ -141,11 +142,13 @@ extension BackgroundDownloads {
 
         // MARK: - URLSessionTaskDelegate
 
-        /// Not part of `URLSessionDownloadDelegate` itself -- `URLSessionTaskDelegate`, which
+        /// Not part of `URLSessionDownloadDelegate` itself: it's `URLSessionTaskDelegate`, which
         /// `URLSessionDownloadDelegate` already inherits from, so no extra protocol conformance
-        /// is needed to implement it. A task with no persisted `serverTrust` (the common case:
-        /// plain HTTPS, system trust) defers to the system's own default handling, exactly the
-        /// behavior this method not existing at all already had before this existed.
+        /// is needed to implement it.
+        ///
+        /// A task with no persisted `serverTrust` (the common case: plain HTTPS, system trust)
+        /// defers to the system's own default handling, exactly the behavior this method not
+        /// existing at all already had before this existed.
         func urlSession(
             _ session: URLSession,
             task: URLSessionTask,
@@ -215,7 +218,7 @@ extension BackgroundDownloads {
             }
 
             do {
-                // Best-effort -- a destination that doesn't already exist is the common case, and
+                // Best-effort: a destination that doesn't already exist is the common case, and
                 // `moveItem` below is what actually needs to succeed.
                 try? FileManager.default.removeItem(at: destination)
                 try FileManager.default.moveItem(at: location, to: destination)
@@ -246,7 +249,7 @@ extension BackgroundDownloads {
             )
         }
 
-        /// Also fires with `error == nil` on success -- ignored here, since a successful download
+        /// Also fires with `error == nil` on success; ignored here, since a successful download
         /// is already reported from `didFinishDownloadingTo` above, once the file has actually
         /// been moved to `destination`.
         func urlSession(
@@ -274,7 +277,7 @@ extension BackgroundDownloads {
 
         /// Everything a delegate callback needs to know about one download, carried on the
         /// `URLSessionTask` itself (`taskDescription`) rather than in a store RequestDL would
-        /// otherwise have to keep in sync with the system's own task bookkeeping -- the system
+        /// otherwise have to keep in sync with the system's own task bookkeeping: the system
         /// already persists this string across a relaunch for free.
         private struct Descriptor: Codable {
             let id: String
@@ -283,7 +286,7 @@ extension BackgroundDownloads {
             let clientIdentity: Internals.ClientIdentityDescriptor?
         }
 
-        // Not `private` -- unit-tested directly (`@testable import`) independent of any real
+        // Not `private`: unit-tested directly (`@testable import`) independent of any real
         // `URLSessionTask`, the same way `InternalsURLSessionUploadFileTests` covers its bridge
         // without a network round trip.
         static func encode(
@@ -317,14 +320,14 @@ extension BackgroundDownloads {
         }
 
         /// `nil` both when `taskDescription` isn't one this type encoded at all, and when it is
-        /// but carries no `serverTrust` (the common, plain-HTTPS case) -- either way, the caller's
+        /// but carries no `serverTrust` (the common, plain-HTTPS case). Either way, the caller's
         /// only correct response is the same: defer to the system's default handling.
         static func decodeServerTrust(_ taskDescription: String?) -> Internals.ServerTrustPolicy.Descriptor? {
             Self.decodeDescriptor(taskDescription)?.serverTrust
         }
 
         /// `nil` both when `taskDescription` isn't one this type encoded at all, and when it is
-        /// but carries no `clientIdentity` (no mTLS configured) -- either way, the caller's only
+        /// but carries no `clientIdentity` (no mTLS configured). Either way, the caller's only
         /// correct response is the same: defer to the system's default handling.
         static func decodeClientIdentity(_ taskDescription: String?) -> Internals.ClientIdentityDescriptor? {
             Self.decodeDescriptor(taskDescription)?.clientIdentity
@@ -344,7 +347,7 @@ extension BackgroundDownloads {
 
         // MARK: - Task matching
 
-        /// The pure part of ``cancel(id:)`` -- picking the right task out of a list -- pulled out
+        /// The pure part of ``cancel(id:)`` (picking the right task out of a list), pulled out
         /// on its own specifically so it's testable without a real background `URLSession` to ask
         /// `allTasks` of. A task with no `taskDescription`, or one this type didn't encode, simply
         /// never matches, the same way `decode(_:)`'s callers already treat it elsewhere.

--- a/Sources/RequestDL/Tasks/Sources/Modifiers/Accept Only Content Type/Modifiers.AcceptOnlyContentType.swift
+++ b/Sources/RequestDL/Tasks/Sources/Modifiers/Accept Only Content Type/Modifiers.AcceptOnlyContentType.swift
@@ -8,7 +8,7 @@ extension Modifiers {
     /// specific set of ``ContentType``s.
     ///
     /// Unlike ``AcceptOnlyStatusCode``, this inspects the response body's declared type rather
-    /// than the status line, catching cases a 2xx status code alone would miss -- for example, a
+    /// than the status line, catching cases a 2xx status code alone would miss: for example, a
     /// proxy or CDN returning an HTML error page with a `200 OK` status.
     ///
     /// Matching ignores parameters (`charset`, etc.) on both sides and honors the `*/*` and

--- a/Sources/RequestDL/Tasks/Sources/Modifiers/Decode/Modifiers.DecodeIfPresent.swift
+++ b/Sources/RequestDL/Tasks/Sources/Modifiers/Decode/Modifiers.DecodeIfPresent.swift
@@ -16,10 +16,10 @@ extension Modifiers {
     /// optional instance of a specified type, treating an empty body as `nil` instead of
     /// attempting to run it through `JSONDecoder`.
     ///
-    /// Unlike ``Decode``, which always hands the raw bytes to `JSONDecoder` -- and therefore
-    /// fails with an opaque "the given data was not valid JSON" on an empty body -- this is meant
-    /// for endpoints that may legitimately answer with no body at all, such as a `204 No Content`
-    /// or `205 Reset Content` response to a `DELETE`/`PUT`.
+    /// Unlike ``Decode``, which always hands the raw bytes to `JSONDecoder` (and therefore fails
+    /// with an opaque "the given data was not valid JSON" on an empty body), this is meant for
+    /// endpoints that may legitimately answer with no body at all, such as a `204 No Content` or
+    /// `205 Reset Content` response to a `DELETE`/`PUT`.
     ///
     public struct DecodeIfPresent<Input: Sendable, Element: Decodable & Sendable, Output: Sendable>: RequestTaskModifier
     {

--- a/Sources/RequestDL/Tasks/Sources/Modifiers/Description/DescribingRequestTask.swift
+++ b/Sources/RequestDL/Tasks/Sources/Modifiers/Description/DescribingRequestTask.swift
@@ -3,7 +3,7 @@
 //
 
 /// Backs `description(_:enabled:onDescribe:)`. Queues a hook on the environment instead of
-/// producing a ``TaskDescriptorContext`` itself -- there's no generic way to do that from an
+/// producing a ``TaskDescriptorContext`` itself: there's no generic way to do that from an
 /// arbitrary `RequestTask` (only `RawTask`, sitting under whatever chain of modifiers wraps it,
 /// actually resolves a `Property` tree). `RawTask._result(environment:)` is what runs the queued
 /// hooks, with the exact configuration it's about to send for real.
@@ -26,7 +26,7 @@ struct DescribingRequestTask<Task: RequestTask, Descriptor: TaskDescriptor>: Req
         var environment = environment
 
         // Only fills in a box no outer `.description(_:enabled:onDescribe:)` already queued one
-        // for -- `FormNode` deposits into whichever box was current when it ran, so a shared box
+        // for: `FormNode` deposits into whichever box was current when it ran, so a shared box
         // is what lets nested calls each still see every form field, not just the ones declared
         // after the innermost one set up its own.
         if environment.descriptorFormFields == nil {
@@ -47,12 +47,14 @@ extension RequestTask {
 
     ///
     /// Returns a task that, once performed, resolves this request through `descriptor`, hands
-    /// the output to `onDescribe`, then performs the request for real -- both from the one
-    /// resolve pass the request already needs, not two separate ones. Nothing runs until the
-    /// returned task is: it composes lazily, the same way ``modifier(_:)`` does.
+    /// the output to `onDescribe`, then performs the request for real, both from the one resolve
+    /// pass the request already needs, not two separate ones.
     ///
-    /// Works anywhere in a task chain -- directly on ``DataTask``/``DownloadTask``/``UploadTask``,
-    /// or after any modifier (`.extractPayload()`, `.map(_:)`, ...) -- since it queues its hook on
+    /// Nothing runs until the returned task is: it composes lazily, the same way
+    /// ``modifier(_:)`` does.
+    ///
+    /// Works anywhere in a task chain, directly on ``DataTask``/``DownloadTask``/``UploadTask``,
+    /// or after any modifier (`.extractPayload()`, `.map(_:)`, ...), since it queues its hook on
     /// the environment rather than depending on the task in front of it exposing anything special.
     /// A task with no `Property` tree to resolve (a mock, for instance) simply never triggers the
     /// hook; `onDescribe` is skipped rather than the call failing to compile or throwing.
@@ -60,7 +62,7 @@ extension RequestTask {
     /// - Parameters:
     ///   - descriptor: The ``TaskDescriptor`` that produces the description.
     ///   - enabled: When `false`, skips queuing the hook entirely (`onDescribe` is not called)
-    ///   and performs the request exactly as ``result()`` would -- useful to disable the pass in
+    ///   and performs the request exactly as ``result()`` would, useful to disable the pass in
     ///   production without removing the call site.
     ///   - onDescribe: Called with the descriptor's output once it's ready.
     /// - Returns: A task that produces this task's actual result, exactly as ``result()`` would.

--- a/Sources/RequestDL/Tasks/Sources/Modifiers/Description/Models/TaskDescriptorContextHooksEnvironmentKey.swift
+++ b/Sources/RequestDL/Tasks/Sources/Modifiers/Description/Models/TaskDescriptorContextHooksEnvironmentKey.swift
@@ -11,15 +11,17 @@ private struct TaskDescriptorContextHooksRequestEnvironmentKey: RequestEnvironme
 
 extension RequestEnvironmentValues {
 
-    /// Queued by ``RequestTask/description(_:enabled:onDescribe:)`` -- never touched directly.
+    /// Queued by ``RequestTask/description(_:enabled:onDescribe:)``; never touched directly.
     ///
     /// `RawTask` is the only thing that ever reads this: right after resolving
     /// `requestConfiguration` for real (the same resolve pass a real request already needs, not
     /// an extra one), it runs every hook here with the resulting ``TaskDescriptorContext``, then
-    /// carries on to actually perform the request. Reusing the one resolve pass this way is what
-    /// lets `description(_:enabled:onDescribe:)` work on *any* `RequestTask` -- including one
-    /// buried under `.extractPayload()`, `.map(_:)`, or any other modifier -- without every task
-    /// type needing its own way to produce a ``TaskDescriptorContext``.
+    /// carries on to actually perform the request.
+    ///
+    /// Reusing the one resolve pass this way is what lets `description(_:enabled:onDescribe:)`
+    /// work on *any* `RequestTask`, including one buried under `.extractPayload()`, `.map(_:)`,
+    /// or any other modifier, without every task type needing its own way to produce a
+    /// ``TaskDescriptorContext``.
     var taskDescriptorContextHooks: [@Sendable (TaskDescriptorContext) async throws -> Void] {
         get { self[TaskDescriptorContextHooksRequestEnvironmentKey.self] }
         set { self[TaskDescriptorContextHooksRequestEnvironmentKey.self] = newValue }

--- a/Sources/RequestDL/Tasks/Sources/Modifiers/Description/cURL/CURLTaskDescriptor.swift
+++ b/Sources/RequestDL/Tasks/Sources/Modifiers/Description/cURL/CURLTaskDescriptor.swift
@@ -23,7 +23,7 @@ import struct Foundation.Data
 /// ```
 ///
 /// To log the command line right alongside the request that actually runs it, use the
-/// `onDescribe`-taking overload instead -- it returns a task that, once performed, produces the
+/// `onDescribe`-taking overload instead. It returns a task that, once performed, produces the
 /// description, hands it to the closure, then performs the request for real:
 ///
 /// ```swift

--- a/Sources/RequestDL/Tasks/Sources/Modifiers/Digest Authentication/Modifiers.DigestAuthentication.swift
+++ b/Sources/RequestDL/Tasks/Sources/Modifiers/Digest Authentication/Modifiers.DigestAuthentication.swift
@@ -8,11 +8,14 @@ extension Modifiers {
     /// A `RequestTaskModifier` that answers an HTTP Digest (RFC 7616) challenge.
     ///
     /// Sets `credential` into the environment for the wrapped task, so a paired
-    /// ``DigestAuthentication`` property anywhere in it reads this same instance -- see
-    /// ``DigestCredential``'s own doc comment. On a `401` carrying a parseable
-    /// `WWW-Authenticate: Digest` challenge, stores it on `credential` and retries, which
-    /// re-resolves the whole request under that same environment, so `DigestAuthentication` now
-    /// has a challenge to answer and contributes the computed `Authorization` header this time.
+    /// ``DigestAuthentication`` property anywhere in it reads this same instance; see
+    /// ``DigestCredential``'s own doc comment.
+    ///
+    /// On a `401` carrying a parseable `WWW-Authenticate: Digest` challenge, stores it on
+    /// `credential` and retries, which re-resolves the whole request under that same
+    /// environment, so `DigestAuthentication` now has a challenge to answer and contributes the
+    /// computed `Authorization` header this time.
+    ///
     /// Retries at most `maxAttempts - 1` times: if the server still answers `401` after that
     /// (wrong credentials, a challenge this package doesn't support, ...), that last response is
     /// returned as-is rather than looping.
@@ -57,9 +60,9 @@ extension RequestTask where Element: TaskResultPrimitive {
     /// computed `Authorization` header after a `401`.
     ///
     /// Pairs with the ``DigestAuthentication`` property, which must also be present earlier in
-    /// the same request -- this modifier hands it the challenge it saw through the environment;
-    /// the property is what turns it into a header on the retry. See ``DigestCredential``'s own
-    /// doc comment for the shared-state contract between the two.
+    /// the same request: this modifier hands it the challenge it saw through the environment,
+    /// and the property is what turns it into a header on the retry. See ``DigestCredential``'s
+    /// own doc comment for the shared-state contract between the two.
     ///
     /// ```swift
     /// try await DataTask {
@@ -72,9 +75,9 @@ extension RequestTask where Element: TaskResultPrimitive {
     /// ```
     ///
     /// - Parameters:
-    ///    - credential: Defaults to a fresh, empty ``DigestCredential`` -- pass one explicitly
+    ///    - credential: Defaults to a fresh, empty ``DigestCredential``; pass one explicitly
     ///    only to reuse a known nonce across separate requests (see its own doc comment).
-    ///    - maxAttempts: How many times to send the request in total -- one initial, unauthenticated
+    ///    - maxAttempts: How many times to send the request in total: one initial, unauthenticated
     ///    probe plus up to `maxAttempts - 1` authenticated retries. Defaults to `2` (one probe, one
     ///    retry), which is all RFC 7616's challenge/response flow ever calls for; a higher value
     ///    only matters if the server is expected to rotate its nonce mid-flow.

--- a/Sources/RequestDL/Tasks/Sources/Modifiers/Retry/Models/RetryPolicy.swift
+++ b/Sources/RequestDL/Tasks/Sources/Modifiers/Retry/Models/RetryPolicy.swift
@@ -7,16 +7,16 @@
 ///
 /// Retrying re-executes the whole request from scratch: the ``Property`` content behind the task
 /// is resolved and sent again as if it were a brand-new call, not a resumption of the failed one.
-/// That is safe for requests that are safe to repeat -- `GET`/`HEAD`, or any request whose body is
-/// described declaratively (``Payload``'s `data`/`url`/`json` initializers, for instance) rather
-/// than consumed from a caller-owned, single-use stream that can't be read a second time.
+/// That is safe for requests that are safe to repeat, such as `GET`/`HEAD`, or any request whose
+/// body is described declaratively (``Payload``'s `data`/`url`/`json` initializers, for instance)
+/// rather than consumed from a caller-owned, single-use stream that can't be read a second time.
 ///
 /// It is **not** safe by default for requests with side effects that aren't idempotent (a `POST`
 /// that creates a resource, for example): if the original request actually reached the server but
-/// its response was lost -- a timeout, a dropped connection -- retrying it can duplicate that side
-/// effect. `RetryPolicy` has no visibility into the request it is applied to, so it cannot enforce
-/// this on its own; scope `shouldRetry` and where `.retry(_:)` is applied in the call graph
-/// accordingly.
+/// its response was lost, say to a timeout or a dropped connection, retrying it can duplicate
+/// that side effect. `RetryPolicy` has no visibility into the request it is applied to, so it
+/// cannot enforce this on its own; scope `shouldRetry` and where `.retry(_:)` is applied in the
+/// call graph accordingly.
 ///
 /// ```swift
 /// try await DataTask {
@@ -44,8 +44,8 @@ public struct RetryPolicy: Sendable {
     ///   - shouldRetry: Called with each thrown error to decide whether it is worth retrying.
     ///     Returning `false` stops retrying and rethrows that error immediately. Defaults to
     ///     retrying every error except cancellation, which is never retried.
-    ///   - delay: Called with the retry attempt number -- `1` for the delay before the second
-    ///     overall attempt, `2` before the third, and so on -- to compute how long to wait
+    ///   - delay: Called with the retry attempt number (`1` for the delay before the second
+    ///     overall attempt, `2` before the third, and so on) to compute how long to wait
     ///     before it.
     ///
     public init(

--- a/Sources/RequestDL/Tasks/Sources/Modifiers/Retry/Modifiers.Retry.swift
+++ b/Sources/RequestDL/Tasks/Sources/Modifiers/Retry/Modifiers.Retry.swift
@@ -9,7 +9,7 @@ extension Modifiers {
     /// ``RetryPolicy`` while it keeps throwing.
     ///
     /// Each retry calls the original task's `result()` again, which re-resolves and re-sends the
-    /// whole request from scratch -- see ``RetryPolicy`` for when that is, and isn't, safe to do.
+    /// whole request from scratch. See ``RetryPolicy`` for when that is, and isn't, safe to do.
     /// A `CancellationError` is never retried, regardless of `policy`.
     ///
     public struct Retry<Input: Sendable>: RequestTaskModifier {
@@ -63,11 +63,13 @@ extension RequestTask {
     ///
     /// Retries the task according to `policy` when it throws.
     ///
-    /// Use this to smooth over transient failures -- a dropped connection, a momentary `5xx`
-    /// surfaced by a modifier like ``RequestTask/acceptOnlyStatusCode(_:)`` further down the
-    /// chain -- without hand-rolling a retry loop around `result()`. Because each retry re-runs
-    /// the request from scratch, only apply it where that is safe: see ``RetryPolicy`` for the
-    /// idempotency caveat before using it on requests with side effects.
+    /// Use this to smooth over transient failures, such as a dropped connection or a momentary
+    /// `5xx` surfaced by a modifier like ``RequestTask/acceptOnlyStatusCode(_:)`` further down
+    /// the chain, without hand-rolling a retry loop around `result()`.
+    ///
+    /// Because each retry re-runs the request from scratch, only apply it where that is safe:
+    /// see ``RetryPolicy`` for the idempotency caveat before using it on requests with side
+    /// effects.
     ///
     /// ```swift
     /// try await DataTask {

--- a/Sources/RequestDL/Tasks/Sources/Raw Task/Download/Models/AsyncBytes.swift
+++ b/Sources/RequestDL/Tasks/Sources/Raw Task/Download/Models/AsyncBytes.swift
@@ -103,7 +103,7 @@ public struct AsyncBytes: Sendable, AsyncSequence, Hashable {
 
 extension AsyncBytes {
 
-    // `deadline` deliberately left out -- it's incidental race metadata, not part of what
+    // `deadline` deliberately left out: it's incidental race metadata, not part of what
     // identifies one `AsyncBytes` stream, the same way it was identified by `seed`/`bytes` alone
     // before `.resource` timeouts existed.
     public static func == (lhs: Self, rhs: Self) -> Bool {

--- a/Sources/RequestDL/Tasks/Sources/Raw Task/Download/Server-Sent Events/Models/ServerSentEvent.swift
+++ b/Sources/RequestDL/Tasks/Sources/Raw Task/Download/Server-Sent Events/Models/ServerSentEvent.swift
@@ -9,7 +9,7 @@
 /// (starting with `:`) are dropped, and a frame with no `data:` line at all produces no event.
 ///
 /// - Note: Unlike the browser `EventSource` API, `retry` is exposed directly on the event instead of
-/// silently updating a reconnection timer -- this type performs no reconnection of its own, so the value
+/// silently updating a reconnection timer. This type performs no reconnection of its own, so the value
 /// is surfaced for the caller to act on if desired.
 public struct ServerSentEvent: Sendable, Hashable {
 

--- a/Sources/RequestDL/Tasks/Sources/Raw Task/Download/Server-Sent Events/Models/ServerSentEventParser.swift
+++ b/Sources/RequestDL/Tasks/Sources/Raw Task/Download/Server-Sent Events/Models/ServerSentEventParser.swift
@@ -10,7 +10,7 @@ import struct Foundation.Data
 
 /// Incrementally decodes `text/event-stream` bytes into ``ServerSentEvent`` values.
 ///
-/// Bytes are fed in arbitrary chunks via ``feed(_:)`` -- a chunk may end mid-line, and a line may even
+/// Bytes are fed in arbitrary chunks via ``feed(_:)``: a chunk may end mid-line, and a line may even
 /// be split across a `CR`/`LF` boundary between two chunks. State is kept internally so a caller never
 /// has to reassemble lines itself.
 struct ServerSentEventParser {
@@ -39,7 +39,7 @@ struct ServerSentEventParser {
         return events
     }
 
-    /// Flushes whatever the stream left buffered when it ended -- a trailing line with no `CR`/`LF`
+    /// Flushes whatever the stream left buffered when it ended: a trailing line with no `CR`/`LF`
     /// terminator, and/or a frame that was never closed off by a final blank line. Real servers
     /// routinely close the connection right after the last event without emitting that blank line,
     /// so treating end-of-stream as an implicit frame boundary avoids silently dropping it.

--- a/Sources/RequestDL/Tasks/Sources/Raw Task/Download/Server-Sent Events/Models/ServerSentEvents.swift
+++ b/Sources/RequestDL/Tasks/Sources/Raw Task/Download/Server-Sent Events/Models/ServerSentEvents.swift
@@ -11,7 +11,7 @@ import struct Foundation.Data
 /// An `AsyncSequence` that parses `text/event-stream` framing out of ``AsyncBytes``.
 ///
 /// Bytes are consumed incrementally as they arrive over the network, so the response body is never
-/// buffered in full -- only the currently in-flight event frame is kept in memory.
+/// buffered in full: only the currently in-flight event frame is kept in memory.
 public struct ServerSentEvents: Sendable, AsyncSequence {
 
     public typealias Element = ServerSentEvent

--- a/Sources/RequestDL/Tasks/Sources/Raw Task/Raw/Models/Internals.Client+RequestExecutingClient.swift
+++ b/Sources/RequestDL/Tasks/Sources/Raw Task/Raw/Models/Internals.Client+RequestExecutingClient.swift
@@ -31,7 +31,7 @@ extension Internals.Client: RequestExecutingClient {
 
     /// - Note: `isKeepAlive` has no equivalent on `HTTPClient.Response` and this method's own
     /// caller (`Internals.CacheControl`'s conditional-revalidation check) never reads it either
-    /// way -- `true` is an inert default, matching the same call `Internals.ResponseHead.init(_
+    /// way: `true` is an inert default, matching the same call `Internals.ResponseHead.init(_
     /// response: HTTPURLResponse)` makes for the same reason on the URLSession side.
     package func revalidationHead(
         configuration: RequestConfiguration,

--- a/Sources/RequestDL/Tasks/Sources/Raw Task/Raw/Models/Internals.URLSessionClient+RequestExecutingClient.swift
+++ b/Sources/RequestDL/Tasks/Sources/Raw Task/Raw/Models/Internals.URLSessionClient+RequestExecutingClient.swift
@@ -7,16 +7,17 @@
 import RequestDLInternals
 
 /// Adapts `Internals.URLSessionClient`'s `SessionTask`-producing `execute` overloads onto
-/// `RequestExecutingClient` -- the `.urlSession` counterpart to
+/// `RequestExecutingClient`: the `.urlSession` counterpart to
 /// `Internals.Client+RequestExecutingClient.swift`.
 ///
 /// A request with a body always goes through `execute(request:streaming:...)`, matching the NIO
 /// backend's own uniform behavior (`RequestBody`'s streaming `AsyncSequence` conformance is used
-/// unconditionally there too, with no buffered-vs-streamed distinction at this layer). What that
-/// call actually uploads *from* is `Internals.URLSessionClient`'s own decision (memory, a fresh
-/// temp file, or -- via `existingUploadFile: body.wholeFileURL` below -- a `Payload(url:)` body's
-/// own file directly, skipping a redundant copy) -- see `Internals.URLSessionUploadFile` for that
-/// logic; this conformance only forwards the hint.
+/// unconditionally there too, with no buffered-vs-streamed distinction at this layer).
+///
+/// What that call actually uploads *from* is `Internals.URLSessionClient`'s own decision: memory,
+/// a fresh temp file, or, via `existingUploadFile: body.wholeFileURL` below, a `Payload(url:)`
+/// body's own file directly, skipping a redundant copy. See `Internals.URLSessionUploadFile` for
+/// that logic; this conformance only forwards the hint.
 extension Internals.URLSessionClient: RequestExecutingClient {
 
     package func execute(
@@ -48,7 +49,7 @@ extension Internals.URLSessionClient: RequestExecutingClient {
         )
     }
 
-    /// - Note: `logger` is unused -- `Internals.URLSessionClient` has no logging plumbed in
+    /// - Note: `logger` is unused: `Internals.URLSessionClient` has no logging plumbed in
     /// anywhere yet, matching every other `execute` overload on it today, none of which take one
     /// either.
     package func revalidationHead(

--- a/Sources/RequestDL/Tasks/Sources/Raw Task/Raw/Models/RequestExecutingClient.swift
+++ b/Sources/RequestDL/Tasks/Sources/Raw Task/Raw/Models/RequestExecutingClient.swift
@@ -10,22 +10,22 @@ import RequestDLInternals
 /// Declared here, in `RequestDL`, rather than under `Internals` in `RequestDLInternals`: both
 /// methods take a `RequestConfiguration`, a `RequestDL`-only type, and `RequestDLInternals` can't
 /// depend back on the module that depends on it. `Internals.Client` conforms in this same module
-/// (see `Internals.Client+RequestExecutingClient.swift`) for exactly that reason -- Swift allows a
+/// (see `Internals.Client+RequestExecutingClient.swift`) for exactly that reason: Swift allows a
 /// type from one module to conform to a protocol declared in another as long as one of the two is
 /// local to the conforming extension's module, which is the case here.
 ///
 /// Deliberately minimal: only what `RawTask.result()` and `Internals.CacheControl` actually call
-/// today. Lifecycle concerns (`isRunning`/`shutdown()`) stay on the concrete client types --
+/// today. Lifecycle concerns (`isRunning`/`shutdown()`) stay on the concrete client types;
 /// `Internals.ClientManager` manages those directly, this protocol's callers never do.
 package protocol RequestExecutingClient: Sendable {
 
     /// Runs `configuration`, returning a `SessionTask` whose response streams upload progress,
-    /// the response head, and the body -- `cache`, when non-`nil`, is teed a copy of every
+    /// the response head, and the body. `cache`, when non-`nil`, is teed a copy of every
     /// downloaded chunk as it arrives, the same way the NIO backend's own cache write-through
     /// already works (see `Internals.DownloadBuffer.cacheStream(_:)`).
     ///
-    /// - Parameter decompression: Not read from `configuration` -- it lives on `Session`, not
-    /// per-request -- so it travels separately. Each conformance is responsible for whatever its
+    /// - Parameter decompression: Not read from `configuration`, since it lives on `Session`, not
+    /// per-request, so it travels separately. Each conformance is responsible for whatever its
     /// own transport needs done with it: the `.urlSession` one derives `Accept-Encoding` from it
     /// and mutates the built request before sending, the `.nio` one only forwards it onward,
     /// since native gzip/deflate handling there is already configured once, at pooled-client
@@ -39,7 +39,7 @@ package protocol RequestExecutingClient: Sendable {
         logger: Internals.TaskLogger?
     ) async throws -> SessionTask
 
-    /// Runs `configuration` and returns just the response head -- what
+    /// Runs `configuration` and returns just the response head: what
     /// `Internals.CacheControl`'s conditional-revalidation request (`If-None-Match`/
     /// `If-Modified-Since`) needs to decide whether a cached entry is still fresh, without paying
     /// for a full `SessionTask`/streaming response it would otherwise throw away.

--- a/Sources/RequestDL/Tasks/Sources/Raw Task/Raw/RawTask.swift
+++ b/Sources/RequestDL/Tasks/Sources/Raw Task/Raw/RawTask.swift
@@ -28,7 +28,7 @@ struct RawTask<Content: Property>: RequestTask {
 
         try await notifyDescriptorHooks(resolved: resolved, environment: environment)
 
-        // Checked before anything else touches `resolved` -- a hard-pinned executor this
+        // Checked before anything else touches `resolved`: a hard-pinned executor this
         // configuration can't actually run on must fail loudly, not after paying for a
         // logger/client/cache setup nobody will get to use.
         try validateRequiredExecutor(resolved: resolved)
@@ -71,7 +71,7 @@ struct RawTask<Content: Property>: RequestTask {
     // MARK: - Private methods, setup
 
     /// Hands the exact configuration this request is about to send to every
-    /// `description(_:enabled:onDescribe:)` hook queued on `environment` -- before anything
+    /// `description(_:enabled:onDescribe:)` hook queued on `environment`, before anything
     /// downstream gets a chance to fail, so a hook still sees the resolved request even if the
     /// executor check or the request itself doesn't go through.
     private func notifyDescriptorHooks(
@@ -112,20 +112,24 @@ struct RawTask<Content: Property>: RequestTask {
         }
     }
 
-    /// `resolvedClient()` -- not `client()` -- is what makes `preferredExecutor`/
+    /// `resolvedClient()`, not `client()`, is what makes `preferredExecutor`/
     /// `requiredExecutor` (validated by `validateRequiredExecutor(resolved:)`, for the hard-pin
     /// case) actually decide which backend this request runs over, instead of always the NIO
-    /// one. `resolvedClient()` returns `Internals.ClientManager.Client` (an enum), not
-    /// `any RequestExecutingClient` directly -- see that method's own doc comment for why -- so
+    /// one.
+    ///
+    /// `resolvedClient()` returns `Internals.ClientManager.Client` (an enum), not
+    /// `any RequestExecutingClient` directly (see that method's own doc comment for why), so
     /// this is the one place that unwraps it into the existential everything below expects.
     ///
-    /// Also the one place that knows, concretely, which case was picked -- surfaced as
+    /// Also the one place that knows, concretely, which case was picked, surfaced as
     /// `isURLSessionExecutor` so `executeTraced` can decide whether to drop RequestDL's default
     /// `User-Agent` in favor of URLSession's own native one (see
-    /// `RequestConfiguration.dropDefaultUserAgentForNativeReporting()`). `.nioTransportServices`
-    /// never reaches its own case here -- `Internals.ClientManager.Client` only distinguishes
-    /// `.nio`/`.urlSession`, folding NIOTransportServices into `.nio` since both share the same
-    /// `RequestExecutingClient` conformance and differ only in which `EventLoopGroup` backs them.
+    /// `RequestConfiguration.dropDefaultUserAgentForNativeReporting()`).
+    ///
+    /// `.nioTransportServices` never reaches its own case here: `Internals.ClientManager.Client`
+    /// only distinguishes `.nio`/`.urlSession`, folding NIOTransportServices into `.nio` since
+    /// both share the same `RequestExecutingClient` conformance and differ only in which
+    /// `EventLoopGroup` backs them.
     private func resolveClient(
         resolved: Resolved
     ) async throws -> (client: any RequestExecutingClient, isURLSessionExecutor: Bool) {
@@ -157,15 +161,15 @@ struct RawTask<Content: Property>: RequestTask {
 
     private typealias OnResponseHead = @Sendable (Result<Internals.ResponseHead, Error>) -> Void
 
-    /// Runs the resolved request to completion, racing it against `deadline` and -- only when
-    /// `RequestServiceContext` was actually declared -- binding `ServiceContext.current` for its
+    /// Runs the resolved request to completion, racing it against `deadline` and, only when
+    /// `RequestServiceContext` was actually declared, binding `ServiceContext.current` for its
     /// duration.
     ///
-    /// Only rebinds the task-local when `RequestServiceContext` was actually declared -- leaving
+    /// Only rebinds the task-local when `RequestServiceContext` was actually declared; leaving
     /// it untouched otherwise preserves whatever `ServiceContext.current` the caller's own task
     /// already carries. `executeTraced(resolved:client:isURLSessionExecutor:cache:logger:)` starts
     /// its span reading this same task-local, so both the explicit and the ambient case are picked
-    /// up correctly here -- there's no `EventLoop` hop between the bind and the read.
+    /// up correctly here: there's no `EventLoop` hop between the bind and the read.
     private func runSession(
         resolved: Resolved,
         client: any RequestExecutingClient,
@@ -178,7 +182,7 @@ struct RawTask<Content: Property>: RequestTask {
         //
         // `@Sendable` because `Internals.ResourceDeadline.race(seed:_:)` below runs it as a real
         // task-group child task when `Timeout(.resource)` is configured, not just called inline
-        // in this task -- otherwise the race is a plain `await` with no isolation change at all.
+        // in this task; otherwise the race is a plain `await` with no isolation change at all.
         @Sendable
         func executeSessionTask() async throws -> (task: SessionTask, onResponseHead: OnResponseHead?) {
             switch await cacheControl(client) {
@@ -210,14 +214,14 @@ struct RawTask<Content: Property>: RequestTask {
         }
     }
 
-    /// Owns the whole span lifecycle itself -- start, header injection, attributes, and end --
+    /// Owns the whole span lifecycle itself (start, header injection, attributes, and end)
     /// rather than handing `tracer` to `async-http-client`'s own `tracing.tracer`. That built-in
     /// instrumentation only starts its span after hopping onto a SwiftNIO `EventLoop`, which loses
     /// Swift's task-locals and makes it structurally impossible for it to see whatever
     /// `ServiceContext` the caller bound. Running the whole thing here, one layer up and entirely
     /// within the caller's own task, sidesteps that.
     ///
-    /// A `RequestConfiguration` copy, not a NIO-specific `HTTPClient.Request` -- the span context
+    /// A `RequestConfiguration` copy, not a NIO-specific `HTTPClient.Request`: the span context
     /// has to reach the wire for both `.nio` and `.urlSession`, and
     /// `client.execute(configuration:cache:logger:)` (`RequestExecutingClient`, not
     /// `Internals.Session.execute`) is what stays transport-agnostic. Every conformance builds its
@@ -232,7 +236,7 @@ struct RawTask<Content: Property>: RequestTask {
     ) async throws -> (task: SessionTask, onResponseHead: OnResponseHead?) {
         var configuration = resolved.requestConfiguration
 
-        // Only `.urlSession` gets its default `User-Agent` dropped -- see
+        // Only `.urlSession` gets its default `User-Agent` dropped; see
         // `dropDefaultUserAgentForNativeReporting()`'s own doc comment for why NIO and
         // NIOTransportServices keep RequestDL's neutral default instead.
         if isURLSessionExecutor {
@@ -264,7 +268,7 @@ struct RawTask<Content: Property>: RequestTask {
     // MARK: - Private static methods, tracing
 
     /// Starts the request span, sets its request-side attributes, and injects it into
-    /// `configuration.headers` as W3C trace headers -- everything the span needs before the
+    /// `configuration.headers` as W3C trace headers: everything the span needs before the
     /// request actually goes out on the wire.
     private static func startRequestSpan(
         tracer: any Tracer,
@@ -286,7 +290,7 @@ struct RawTask<Content: Property>: RequestTask {
     }
 
     /// Mirrors what async-http-client's own built-in tracing sets on the request span as of
-    /// https://github.com/swift-server/async-http-client/pull/906 -- `url.query` is deliberately
+    /// https://github.com/swift-server/async-http-client/pull/906. `url.query` is deliberately
     /// left out, since query strings can carry tokens/PII that shouldn't end up on a span by
     /// default.
     private static func setURLAttributes(on span: any Span, url: String) {
@@ -311,7 +315,7 @@ struct RawTask<Content: Property>: RequestTask {
         }
     }
 
-    /// The port implied by `scheme` when the URL itself doesn't specify one -- mirrors
+    /// The port implied by `scheme` when the URL itself doesn't specify one; mirrors
     /// `async-http-client`'s own `DeconstructedURL`/`Scheme.defaultPort`, so `server.port` on the
     /// span still gets a value for the common `http://example.com` (no explicit port) case.
     private static func defaultPort(forScheme scheme: String) -> Int? {
@@ -350,15 +354,19 @@ extension RawTask {
     ///
     /// Not part of the `_result(environment:)` chain — like `RequestTask.result()`'s own default
     /// (`_result(environment: RequestEnvironmentValues())`), this is an entry point, not
-    /// something nested inside another task's `.environment()`. `descriptorFormFields` is set on
-    /// that fresh environment and threaded through `Resolve.init(root:environment:)` into
-    /// `_PropertyInputs.environment`, which is how `FormNode` — the only node that needs to know
-    /// a description pass is running, since it's the only place per-field structure would
-    /// otherwise be lost to multipart flattening — receives it: captured by `Form`/`FormGroup`'s
-    /// own `_makeProperty` at construction time, not read from inside `make()` itself (nodes have
-    /// no `environment` of their own to read there). `partiallyBuild()`, unlike `build()`, never
-    /// constructs an `Internals.Session` or resolves a client, which is exactly right here:
-    /// nothing about producing a description touches the network.
+    /// something nested inside another task's `.environment()`.
+    ///
+    /// `descriptorFormFields` is set on that fresh environment and threaded through
+    /// `Resolve.init(root:environment:)` into `_PropertyInputs.environment`, which is how
+    /// `FormNode` — the only node that needs to know a description pass is running, since it's
+    /// the only place per-field structure would otherwise be lost to multipart flattening —
+    /// receives it: captured by `Form`/`FormGroup`'s own `_makeProperty` at construction time,
+    /// not read from inside `make()` itself (nodes have no `environment` of their own to read
+    /// there).
+    ///
+    /// `partiallyBuild()`, unlike `build()`, never constructs an `Internals.Session` or resolves
+    /// a client, which is exactly right here: nothing about producing a description touches the
+    /// network.
     func description<Descriptor: TaskDescriptor>(_ descriptor: Descriptor) async throws -> Descriptor.Output {
         let formFieldBox = DescriptorFormFieldBox()
 

--- a/Sources/RequestDL/Tasks/Sources/Raw Task/cURL/Models/CURLCommandParser.swift
+++ b/Sources/RequestDL/Tasks/Sources/Raw Task/cURL/Models/CURLCommandParser.swift
@@ -92,8 +92,8 @@ enum CURLCommandParser {
                 let (name, headerValue) = try splitOnce(try value(for: token), separator: ":")
                 configuration.headers.add(name: name, value: headerValue)
 
-                // `.lowercased()`, not Foundation's `caseInsensitiveCompare(_:)` -- unavailable
-                // under `FoundationEssentials`/Linux.
+                // `.lowercased()`, not Foundation's `caseInsensitiveCompare(_:)`, which is
+                // unavailable under `FoundationEssentials`/Linux.
                 if name.lowercased() == "content-type" {
                     hasExplicitContentType = true
                 }
@@ -273,7 +273,7 @@ enum CURLCommandParser {
 
                 if isInsecure {
                     // `certificateVerification` is `NIOSSL.CertificateVerification?`, and
-                    // `CertificateVerification` itself has a case named `none` -- plain `.none`
+                    // `CertificateVerification` itself has a case named `none`: plain `.none`
                     // here resolves to `Optional<CertificateVerification>.none` (nil), not
                     // `CertificateVerification.none`, which leaves verification at its default
                     // (`.fullVerification`) instead of disabling it. `.some(.none)`
@@ -316,11 +316,11 @@ enum CURLCommandParser {
         var connectionProtocol: Internals.Proxy.ConnectionProtocol = .http
 
         // Neither `range(of:)` (Foundation, unavailable under `FoundationEssentials`/Linux) nor
-        // `firstRange(of:)` (stdlib, but gated to macOS 13/iOS 16 -- newer than this package's
+        // `firstRange(of:)` (stdlib, but gated to macOS 13/iOS 16, newer than this package's
         // macOS 12/iOS 15 minimum; see `URLOverrideEndpoint.init?(baseURL:)` for the same
-        // constraint). A scheme, when present, is always at the very start, so the first `:`
-        // followed by `//` is unambiguous -- an earlier `:` inside `user:pass@host:port` (no
-        // scheme) is never followed by `//`, so `hasPrefix("//")` alone tells the two apart.
+        // constraint) is used here. A scheme, when present, is always at the very start, so the
+        // first `:` followed by `//` is unambiguous: an earlier `:` inside `user:pass@host:port`
+        // (no scheme) is never followed by `//`, so `hasPrefix("//")` alone tells the two apart.
         if let colonIndex = remainder.firstIndex(of: ":"),
             remainder[remainder.index(after: colonIndex)...].hasPrefix("//")
         {

--- a/Sources/RequestDL/Tasks/Sources/Request Task/Request Task/RequestTask.swift
+++ b/Sources/RequestDL/Tasks/Sources/Request Task/Request Task/RequestTask.swift
@@ -35,15 +35,17 @@ public protocol RequestTask<Element>: Sendable {
 
 extension RequestTask {
 
-    /// Runs the task with a fresh, empty environment -- the entry point for a task that isn't
+    /// Runs the task with a fresh, empty environment: the entry point for a task that isn't
     /// nested inside another task's `.environment()`/`_result(environment:)` call.
     ///
     /// Conformers that only need `result()` to do real work off of `environment` (`RawTask`,
     /// `MockedTask`, wrapper types forwarding to an inner task, ...) implement `_result(environment:)`
     /// instead and get this for free. Conformers with no use for `environment` at all (a plain
     /// custom `RequestTask`) implement `result()` directly instead and get `_result(environment:)`
-    /// for free -- see its own default below. Implementing neither recurses forever; every
-    /// conformer needs at least one real implementation.
+    /// for free; see its own default below.
+    ///
+    /// Implementing neither recurses forever: every conformer needs at least one real
+    /// implementation.
     public func result() async throws -> Element {
         try await _result(environment: RequestEnvironmentValues())
     }
@@ -51,8 +53,8 @@ extension RequestTask {
     /// This method is used internally and should not be called directly.
     ///
     /// The default implementation threads `environment` into any `@RequestEnvironment`-marked
-    /// stored property found via reflection -- the same mechanism `@RequestEnvironment` already
-    /// uses -- and then calls the ordinary `result()`. Conformers that need `environment` to do
+    /// stored property found via reflection (the same mechanism `@RequestEnvironment` already
+    /// uses) and then calls the ordinary `result()`. Conformers that need `environment` to do
     /// real work (building a request, mocking a response, ...) override this instead of relying
     /// on the default.
     @_spi(Private)

--- a/Sources/RequestDL/Tasks/Sources/Request Task/Task Modifier/Models/_RequestTaskModifier_Content.swift
+++ b/Sources/RequestDL/Tasks/Sources/Request Task/Task Modifier/Models/_RequestTaskModifier_Content.swift
@@ -23,12 +23,13 @@ public struct _RequestTaskModifier_Content<Modifier: RequestTaskModifier>: Reque
 
     // MARK: - Public methods
 
-    // `result()` uses the environment fixed in at construction (by `ModifiedRequestTask` --
+    // `result()` uses the environment fixed in at construction (by `ModifiedRequestTask`:
     // either empty, for a plain top-of-chain `.result()`, or scoped by
     // `ModifiedRequestTask._result(environment:)` to whatever an outer modifier passed down).
+    //
     // `_result(environment:)` must NOT delegate to `result()` (the protocol's default does that,
     // ignoring its own argument): `Modifiers.Environment.body` calls this directly with a
-    // *mutated* environment that deliberately differs from `self.environment` -- that mutation is
+    // *mutated* environment that deliberately differs from `self.environment`; that mutation is
     // the entire mechanism by which `.environment()` takes effect.
     public func result() async throws -> Modifier.Input {
         try await task._result(environment: environment)

--- a/Sources/RequestDLInternals/Sources/Body/Internals.BodySequence.swift
+++ b/Sources/RequestDLInternals/Sources/Body/Internals.BodySequence.swift
@@ -131,10 +131,10 @@ extension Internals {
         }
 
         /// The file this whole body already lives in, when it's backed by exactly one buffer
-        /// that is itself an unread, non-temporary `Internals.FileBuffer` -- i.e. uploading
+        /// that is itself an unread, non-temporary `Internals.FileBuffer`: uploading
         /// straight from that file would produce exactly these bytes, with nothing to drain or
         /// copy first. `nil` for anything else: no buffers, more than one (multipart included),
-        /// a `DataBuffer`, or a `FileBuffer` that doesn't qualify -- see
+        /// a `DataBuffer`, or a `FileBuffer` that doesn't qualify. See
         /// `Internals.Buffer.wholeFileURL` for what "qualify" means.
         package var wholeFileURL: URL? {
             guard buffers.count == 1, let fileBuffer = buffers[0] as? Internals.FileBuffer else {

--- a/Sources/RequestDLInternals/Sources/Body/Internals.CompressingByteSequence.swift
+++ b/Sources/RequestDLInternals/Sources/Body/Internals.CompressingByteSequence.swift
@@ -7,13 +7,13 @@ import NIOCore
 extension Internals {
 
     /// Wraps `source` so each chunk is compressed as it's pulled, instead of draining the whole
-    /// source into memory before compression starts -- the actual upload begins as soon as the
+    /// source into memory before compression starts: the actual upload begins as soon as the
     /// first compressed bytes exist, and only ever holds one chunk's worth of the original body
     /// in memory at a time.
     ///
     /// Generic over its source (rather than hardwired to `Internals.BodySequence`) because
-    /// `RequestDLInternals` cannot depend back on `RequestDL`, where `RequestBody` -- the actual
-    /// source this wraps in practice -- is defined.
+    /// `RequestDLInternals` cannot depend back on `RequestDL`, where `RequestBody`, the actual
+    /// source this wraps in practice, is defined.
     package struct CompressingByteSequence<Source: AsyncSequence & Sendable>: Sendable, AsyncSequence
     where Source.Element == ByteBuffer {
 
@@ -35,7 +35,7 @@ extension Internals {
 
             // MARK: - Internal methods
 
-            /// Created lazily here, on the first call, rather than in `makeAsyncIterator()` --
+            /// Created lazily here, on the first call, rather than in `makeAsyncIterator()`:
             /// `AsyncIteratorProtocol.makeAsyncIterator()` isn't `throws`, and creating a
             /// `Compressor`'s stream (`Decompressor`'s own `callAsFunction()` counterpart) is
             /// allowed to fail.
@@ -45,7 +45,7 @@ extension Internals {
                 }
 
                 // Pulled into a local, non-`Optional` binding for the rest of this call, and
-                // written back below -- `CompressorStream`'s `callAsFunction`/`finish` are
+                // written back below, since `CompressorStream`'s `callAsFunction`/`finish` are
                 // `mutating`, so calling them through `self.stream` directly would need force
                 // unwrapping it on every use instead of just once, here, right after creating it.
                 var stream = try self.stream ?? algorithm()
@@ -70,7 +70,7 @@ extension Internals {
         // MARK: - Internal properties
 
         /// Exposed so `RequestBody.totalSize`/`.chunkSize` can report the *original*,
-        /// pre-compression body's own values as best-effort estimates -- see that type's own
+        /// pre-compression body's own values as best-effort estimates. See that type's own
         /// doc comments for why those, not the (not-yet-known) compressed size, are what a
         /// compressing body reports there.
         package let source: Source

--- a/Sources/RequestDLInternals/Sources/Body/Internals.StreamWriterSequence.swift
+++ b/Sources/RequestDLInternals/Sources/Body/Internals.StreamWriterSequence.swift
@@ -7,7 +7,7 @@ import NIOCore
 
 extension Internals {
 
-    /// Generic over `Body` -- rather than hardwired to `Internals.BodySequence` -- so it can
+    /// Generic over `Body`, rather than hardwired to `Internals.BodySequence`, so it can
     /// drive either a fixed, known-length body or a `Internals.CompressingByteSequence` (whose
     /// final size, and whose ability to fail mid-stream if a custom `Compressor` throws, are both
     /// only known once the whole thing has been pulled through).

--- a/Sources/RequestDLInternals/Sources/Buffers/Buffer/Internals.Buffer.swift
+++ b/Sources/RequestDLInternals/Sources/Buffers/Buffer/Internals.Buffer.swift
@@ -85,7 +85,7 @@ extension Internals {
             // MARK: - Private properties
 
             private let lock = AsyncLock(watchdog: watchdog)
-            /// `fileprivate`, not `private` -- `Internals.Buffer.wholeFileURL` (below, `Stream ==
+            /// `fileprivate`, not `private`: `Internals.Buffer.wholeFileURL` (below, `Stream ==
             /// Internals.FileStreamBuffer` only) reads this directly rather than adding an async
             /// round trip through this actor-less class for a value that never changes after init.
             fileprivate let url: Stream.URL
@@ -536,18 +536,18 @@ extension Internals.Buffer where Stream == Internals.ByteStreamBuffer {
 extension Internals.Buffer where Stream == Internals.FileStreamBuffer {
 
     /// The file this buffer addresses, when uploading straight from it would read exactly the
-    /// bytes this buffer would -- i.e. this cursor hasn't read anything yet, and the file isn't
+    /// bytes this buffer would: this cursor hasn't read anything yet, and the file isn't
     /// one this package created for its own scratch use (a caller that later removes it, or that
     /// the deallocating `Storage` above would itself clean up, could otherwise disappear out from
     /// under whoever took this URL and held onto it past this buffer's own lifetime).
     ///
     /// `nil` for anything that fails either check: something has already read from this cursor
-    /// (a stale answer here would upload less than the file actually has, or -- if this cursor
-    /// were later rewound -- silently more), or the file is temporary (this package's own, not
+    /// (a stale answer here would upload less than the file actually has, or, if this cursor
+    /// were later rewound, silently more), or the file is temporary (this package's own, not
     /// guaranteed to outlive whatever asked for its `URL`).
     ///
     /// - Important: Trusts `readableBytes` as already accurate for the file's current on-disk
-    /// size, the same trust `Internals.BodySequence.totalSize` already places in it elsewhere --
+    /// size, the same trust `Internals.BodySequence.totalSize` already places in it elsewhere;
     /// this does not re-stat the file to confirm nothing has grown or shrunk it since this buffer
     /// was built.
     package var wholeFileURL: URL? {

--- a/Sources/RequestDLInternals/Sources/Buffers/Buffer/Models/Internals.FileBufferURL.swift
+++ b/Sources/RequestDLInternals/Sources/Buffers/Buffer/Models/Internals.FileBufferURL.swift
@@ -68,7 +68,7 @@ extension Internals {
 
         private let url: URL
         /// Whether this location is one this package created for its own scratch use (and will
-        /// remove once nothing needs it any more), as opposed to a caller-supplied path -- see
+        /// remove once nothing needs it any more), as opposed to a caller-supplied path. See
         /// `Internals.Buffer.wholeFileURL`, the one external reader of this flag, for why the
         /// distinction matters outside this type.
         package let isTemporary: Bool

--- a/Sources/RequestDLInternals/Sources/Client/Client Manager/Internals.ClientManager.swift
+++ b/Sources/RequestDLInternals/Sources/Client/Client Manager/Internals.ClientManager.swift
@@ -70,19 +70,21 @@ extension Internals {
             )
         }
 
-        /// Executor-aware counterpart to `client(provider:sessionConfiguration:)` -- resolves
+        /// Executor-aware counterpart to `client(provider:sessionConfiguration:)`: resolves
         /// `sessionConfiguration.resolveExecutor()` and actually builds/caches the client that
         /// decision points to, rather than only deciding in the abstract. Covers both axes:
-        /// `.urlSession` vs. not, and -- within the `.nio` branch -- plain NIO vs.
+        /// `.urlSession` vs. not, and, within the `.nio` branch, plain NIO vs.
         /// NIOTransportServices, so `preferredExecutor(.nioTransportServices)`/
         /// `requiredExecutor(.nioTransportServices)` actually decide which event loop group a real
         /// request gets, not just `enableNetworkFramework`.
         ///
         /// Shares this manager's own `_table` with the NIO-only `client(provider:sessionConfiguration:)`
-        /// above -- a `.urlSession` entry is keyed apart from a `.nio`/NIOTransportServices one for
+        /// above: a `.urlSession` entry is keyed apart from a `.nio`/NIOTransportServices one for
         /// the same provider (see `_createNewURLSessionClient`'s `id`), so the two can never
-        /// collide or be handed back for each other. Likewise, `_nioClient`'s own `isCompatibleWithNetworkFramework`
-        /// parameter -- not `sessionConfiguration.isCompatibleWithNetworkFramework` -- is what
+        /// collide or be handed back for each other.
+        ///
+        /// Likewise, `_nioClient`'s own `isCompatibleWithNetworkFramework`
+        /// parameter, not `sessionConfiguration.isCompatibleWithNetworkFramework`, is what
         /// keys a NIOTransportServices entry apart from a plain-NIO one here
         /// (`SessionProvider.uniqueIdentifier(with:)`'s `"NTW."` prefix reads that parameter, not
         /// `enableNetworkFramework` directly), so an executor-resolved and a flag-resolved client
@@ -137,7 +139,7 @@ extension Internals {
         // MARK: - Private methods
 
         /// Shared body for `client(provider:sessionConfiguration:)` and `resolvedClient(provider:sessionConfiguration:)`'s
-        /// `.nio`/`.nioTransportServices` branch -- the two differ only in *how* they decide
+        /// `.nio`/`.nioTransportServices` branch: the two differ only in *how* they decide
         /// `isCompatibleWithNetworkFramework` (the `enableNetworkFramework` flag directly, vs.
         /// `resolveExecutor()`'s own answer), never in what happens once that's decided.
         private func _nioClient(
@@ -253,7 +255,7 @@ extension Internals {
         /// - Warning: Lockless. The caller must be holding ``tableLock``.
         ///
         /// Returns the cached `Internals.ClientManager.Client` regardless of which backend it
-        /// wraps -- shared by both `client(provider:sessionConfiguration:)` (NIO-only, unwraps
+        /// wraps: shared by both `client(provider:sessionConfiguration:)` (NIO-only, unwraps
         /// `.nio`) and `resolvedClient(provider:sessionConfiguration:)` (unwraps `.urlSession`),
         /// so the age/reuse logic below is written once rather than duplicated per backend.
         private func _reusableItem(

--- a/Sources/RequestDLInternals/Sources/Client/Client Manager/Models/Internals.ClientManager.Client.swift
+++ b/Sources/RequestDLInternals/Sources/Client/Client Manager/Models/Internals.ClientManager.Client.swift
@@ -6,7 +6,7 @@ extension Internals.ClientManager {
 
     /// The concrete client cached behind one `Internals.ClientManager` table entry.
     ///
-    /// `.nio` backs both plain NIO and NIOTransportServices -- `Internals.Client` is the same
+    /// `.nio` backs both plain NIO and NIOTransportServices: `Internals.Client` is the same
     /// type either way, differentiated only by which `EventLoopGroup` `SessionProvider.group(with:)`
     /// handed it, so there is nothing for this enum to distinguish between those two. `.urlSession`
     /// is the one genuinely different transport.

--- a/Sources/RequestDLInternals/Sources/Client/Client/Internals.Client.swift
+++ b/Sources/RequestDLInternals/Sources/Client/Client/Internals.Client.swift
@@ -177,10 +177,10 @@ extension Internals {
             }
         }
 
-        /// Executes `request`, streaming the response through a `SessionTask` -- upload
+        /// Executes `request`, streaming the response through a `SessionTask`: upload
         /// progress, head, and body, optionally teed to `cache` as it downloads.
         ///
-        /// Moved here from `Internals.Session.execute(client:request:...)` -- that method's body
+        /// Moved here from `Internals.Session.execute(client:request:...)`: that method's body
         /// never actually touched `Internals.Session` itself (`provider`/`configuration`/
         /// `manager`), just the `client` it took as a parameter, so it belongs on the client that
         /// does the executing. `Internals.Session.execute` now forwards here rather than
@@ -203,16 +203,17 @@ extension Internals {
             // No all-or-nothing constraint on this executor, unlike `.urlSession`: manual
             // dispatch only has to activate for algorithms `NIOHTTPResponseDecompressor` (added
             // separately, once, via `Internals.Session.Configuration.build()`) doesn't already
-            // handle -- gzip/deflate can stay skipped alongside it, rather than every configured
+            // handle: gzip/deflate can stay skipped alongside it, rather than every configured
             // algorithm always going through manual dispatch regardless.
             //
             // - Important: `NIOHTTPResponseDecompressor` decodes the body but does *not* strip
             // `Content-Encoding` from the response head (confirmed against the vendored
-            // `swift-nio-extras` source this package actually ships) -- the same caveat already
-            // documented for CFNetwork's own transparent decoding under `.urlSession`. Dispatch
-            // must therefore bypass by *type* (`isNativelyDecodedByNIO`), the same structural
-            // check `Internals.URLSessionClient` uses, not by checking whether the header is
-            // still present -- it always is, natively decoded or not.
+            // `swift-nio-extras` source this package actually ships), the same caveat already
+            // documented for CFNetwork's own transparent decoding under `.urlSession`.
+            //
+            // Dispatch must therefore bypass by *type* (`isNativelyDecodedByNIO`), the same
+            // structural check `Internals.URLSessionClient` uses, not by checking whether the
+            // header is still present: it always is, natively decoded or not.
             let decompressionDispatch: Internals.ManualDecompressionDispatch = {
                 switch decompression {
                 case .disabled:
@@ -291,7 +292,7 @@ extension Internals.Client {
     /// The semaphore backing `maximumConcurrentConnections`, `nil` when the client was not
     /// configured with a limit.
     ///
-    /// Forwards to `throttledExecutor`'s own testing accessor -- the semaphore itself moved
+    /// Forwards to `throttledExecutor`'s own testing accessor: the semaphore itself moved
     /// there so `maximumConcurrentConnections` behaves identically across executors, but this
     /// accessor's name and gating stay put so the tests reaching for it don't have to change.
     /// Gated behind `@_spi(Testing)` on top of `package` so this reads as a deliberate escape

--- a/Sources/RequestDLInternals/Sources/Client/Throttled Executor/Internals.ThrottledExecutor.swift
+++ b/Sources/RequestDLInternals/Sources/Client/Throttled Executor/Internals.ThrottledExecutor.swift
@@ -30,7 +30,7 @@ extension Internals {
         /// Waits for a free slot, then hands back a closure that releases it.
         ///
         /// There is no `withPermit`-style scoped variant here because the operations this guards
-        /// -- an in-flight `HTTPClient.Task`, a future URLSession task -- outlive the call that
+        /// (an in-flight `HTTPClient.Task`, a future URLSession task) outlive the call that
         /// starts them. The caller owns calling the returned closure exactly once, whenever it
         /// considers the throttled operation complete.
         package func acquire() async -> @Sendable () -> Void {

--- a/Sources/RequestDLInternals/Sources/Client/URLSession Client/Identity/Internals.ClientIdentityDescriptor.swift
+++ b/Sources/RequestDLInternals/Sources/Client/URLSession Client/Identity/Internals.ClientIdentityDescriptor.swift
@@ -3,14 +3,17 @@
 //
 
 // What a `BackgroundDownloadTask` persists on `URLSessionTask.taskDescription` for a client
-// certificate (mTLS) -- deliberately never the private key's own bytes, only the file path it
-// lives at. Unlike `Internals.ServerTrustPolicy.Descriptor` (public certificate bytes, fine to
+// certificate (mTLS): deliberately never the private key's own bytes, only the file path it
+// lives at.
+//
+// Unlike `Internals.ServerTrustPolicy.Descriptor` (public certificate bytes, fine to
 // carry verbatim), embedding key material in a task's plain-text description would be a real
-// regression from the Keychain-only handling this package otherwise holds itself to. This is why
-// a client identity sourced from `.bytes` (in-memory only, no path to persist) can't be supported
-// here at all, and why an identity is rebuilt fresh from disk on every challenge rather than
-// cached: the file, not any in-memory state, is the only thing guaranteed to still exist after a
-// relaunch.
+// regression from the Keychain-only handling this package otherwise holds itself to.
+//
+// This is why a client identity sourced from `.bytes` (in-memory only, no path to persist) can't
+// be supported here at all, and why an identity is rebuilt fresh from disk on every challenge
+// rather than cached: the file, not any in-memory state, is the only thing guaranteed to still
+// exist after a relaunch.
 
 #if canImport(Darwin)
 
@@ -64,7 +67,7 @@ extension Internals {
 
         // MARK: - Internal methods
 
-        /// `nil` when `secureConnection` configures no client identity at all -- the common case,
+        /// `nil` when `secureConnection` configures no client identity at all, the common case,
         /// and not an error.
         package static func resolve(from secureConnection: Internals.SecureConnection) throws -> Self? {
             switch (secureConnection.certificateChain, secureConnection.privateKey) {

--- a/Sources/RequestDLInternals/Sources/Client/URLSession Client/Identity/Internals.RawBytesIdentityBuilder.swift
+++ b/Sources/RequestDLInternals/Sources/Client/URLSession Client/Identity/Internals.RawBytesIdentityBuilder.swift
@@ -240,8 +240,8 @@ extension Internals {
                 ) {
                     return key
                 }
-                // CryptoKit already parsed and validated this as a well-formed EC private key --
-                // a rejection of its own X9.63 output is a genuine Security-framework failure,
+                // CryptoKit already parsed and validated this as a well-formed EC private key,
+                // so a rejection of its own X9.63 output is a genuine Security-framework failure,
                 // not a format-recognition miss.
                 let message = creationError.map { String(describing: $0.takeRetainedValue()) } ?? "unknown"
                 throw Error.secKeyCreationFailed(message)
@@ -445,13 +445,15 @@ extension Internals {
             let status = SecItemAdd(query as CFDictionary, &result)
 
             guard status == errSecSuccess else {
-                // The label-based delete right above this call is best-effort, not a guarantee --
-                // e.g. a previous process that never reached its own `remove(_:)` (killed rather
-                // than cleanly terminated). An item already present with this exact label means
-                // this exact certificate/key is already stored (Keychain's own duplicate-item
-                // constraint for these classes is content-derived: issuer+serial for
-                // certificates, key material for keys), which is exactly the state this call was
-                // trying to reach -- so this is success, not failure.
+                // The label-based delete right above this call is best-effort, not a guarantee
+                // (e.g. a previous process that never reached its own `remove(_:)`, killed rather
+                // than cleanly terminated).
+                //
+                // An item already present with this exact label means this exact certificate/key
+                // is already stored (Keychain's own duplicate-item constraint for these classes is
+                // content-derived: issuer+serial for certificates, key material for keys), which
+                // is exactly the state this call was trying to reach, so this is success, not
+                // failure.
                 if status == errSecDuplicateItem {
                     return
                 }

--- a/Sources/RequestDLInternals/Sources/Client/URLSession Client/Identity/Internals.ServerTrustPolicy.swift
+++ b/Sources/RequestDLInternals/Sources/Client/URLSession Client/Identity/Internals.ServerTrustPolicy.swift
@@ -4,7 +4,7 @@
 
 // The server-trust half of `Internals.URLSessionIdentityPolicy`, pulled out on its own: unlike
 // the client-identity half, it needs no Keychain round-trip, so it can be rebuilt from nothing
-// but raw certificate bytes -- which is exactly what a `BackgroundDownloadTask` needs to do after
+// but raw certificate bytes. That's exactly what a `BackgroundDownloadTask` needs to do after
 // a relaunch, with no `Internals.SecureConnection` left in memory to resolve from.
 
 #if canImport(Darwin)
@@ -215,7 +215,7 @@ extension Internals {
         package func descriptor() throws -> Descriptor {
             if spkiPinningDescriptor == nil, !evaluation.pins.isEmpty {
                 // Only reachable via `resolve(from:)`, whose SPKI pins never populated
-                // `spkiPinningDescriptor` because at least one used an unnameable algorithm --
+                // `spkiPinningDescriptor` because at least one used an unnameable algorithm.
                 // `init(descriptor:)` always sets `spkiPinningDescriptor` when `spkiPins` is
                 // non-empty, so this branch can't fire for an already-rebuilt policy.
                 throw DescriptorError.unpersistableAlgorithm
@@ -256,7 +256,7 @@ extension Internals {
 
             let isStrict = (secureConnection.tlsPinningPolicy ?? .strict) == .strict
 
-            // Each pin's digest is resolved exactly once here (base64 decoded, length-checked) --
+            // Each pin's digest is resolved exactly once here (base64 decoded, length-checked):
             // both `spkiPins` below (the live matcher, re-fetching this same digest per challenge
             // via `matchesSPKI`) and `spkiPinningDescriptor` reuse it, and a malformed pin throws
             // right here rather than lazily on first challenge or first background schedule.
@@ -271,8 +271,8 @@ extension Internals {
             }
 
             // `nil` whenever there are no pins at all, or whenever any pin's algorithm isn't one
-            // of the three `Internals.SPKIHash.KnownAlgorithm` cases -- deliberately *not* thrown
-            // here: an unnameable algorithm still pins correctly for live, in-process use
+            // of the three `Internals.SPKIHash.KnownAlgorithm` cases. This is deliberately *not*
+            // thrown here: an unnameable algorithm still pins correctly for live, in-process use
             // (`URLSessionClient`), it just can't be captured for a `BackgroundDownloadTask` to
             // rebuild after a relaunch. `descriptor()` is what throws, and only if it's actually
             // called with pins present but nothing capturable.
@@ -314,7 +314,7 @@ extension Internals {
             }
 
             if case .none = certificateVerification {
-                // Mirrors NIOSSL's `CertificateVerification.none` -- deliberately unsafe,
+                // Mirrors NIOSSL's `CertificateVerification.none`: deliberately unsafe,
                 // opt-in only. SPKI pins, like every other check below, don't apply here either:
                 // `.none` means trust evaluation itself was opted out of.
                 completionHandler(.useCredential, URLCredential(trust: serverTrust))

--- a/Sources/RequestDLInternals/Sources/Client/URLSession Client/Identity/Internals.URLSessionClient.TLSDelegate.swift
+++ b/Sources/RequestDLInternals/Sources/Client/URLSession Client/Identity/Internals.URLSessionClient.TLSDelegate.swift
@@ -13,15 +13,15 @@ import Foundation
 extension Internals.URLSessionClient {
 
     /// Routes a TLS challenge (server-trust, client-certificate) to `policy` only when it's for
-    /// `host` -- promoted from the URLSession Executor Spike's `RoutingMTLSURLSessionDelegate`,
+    /// `host`. This is promoted from the URLSession Executor Spike's `RoutingMTLSURLSessionDelegate`,
     /// not the single-identity `MTLSURLSessionDelegate` the spike test itself used. One
-    /// `URLSession` -- and so one `URLSessionClient`, pooled by `Internals.ClientManager` --
+    /// `URLSession`, and so one `URLSessionClient` pooled by `Internals.ClientManager`,
     /// genuinely does end up serving requests to many hosts; the host check is what keeps a
     /// challenge for one host from being answered with a policy meant for another.
     ///
     /// `Internals.URLSessionClient` only ever resolves one `Internals.SecureConnection` (the one
     /// it was configured with, same as `redirectConfiguration`/`proxy`), so there is only ever one
-    /// `Internals.URLSessionIdentityPolicy` to route to -- not a per-host map of them. What varies
+    /// `Internals.URLSessionIdentityPolicy` to route to, not a per-host map of them. What varies
     /// per request is `host`: `execute(...)` builds a fresh `TLSDelegate` for each request, pairing
     /// that one policy with the request's own destination host, since the client itself isn't tied
     /// to a single URL. A challenge for any other host (mid-redirect to a different host, for

--- a/Sources/RequestDLInternals/Sources/Client/URLSession Client/Identity/Internals.URLSessionIdentityPolicy.swift
+++ b/Sources/RequestDLInternals/Sources/Client/URLSession Client/Identity/Internals.URLSessionIdentityPolicy.swift
@@ -21,9 +21,9 @@ extension Internals {
 
     /// The resolved, `URLSession`-ready form of one `Internals.SecureConnection`: a client
     /// identity (if `certificateChain`/`privateKey` were configured), composed with an
-    /// `Internals.ServerTrustPolicy` for the trust roots/verification mode/SPKI pinning half -- the one part
-    /// of this that needs no Keychain round-trip, and so is reusable on its own wherever only
-    /// that half is needed.
+    /// `Internals.ServerTrustPolicy` for the trust roots/verification mode/SPKI pinning half, the
+    /// one part of this that needs no Keychain round-trip, and so is reusable on its own wherever
+    /// only that half is needed.
     ///
     /// Built once per `SecureConnection` and held for as long as the owning
     /// `Internals.URLSessionClient` is alive, mirroring NIOSSL's own per-connection

--- a/Sources/RequestDLInternals/Sources/Client/URLSession Client/Internals.URLSessionClient.Redirect.swift
+++ b/Sources/RequestDLInternals/Sources/Client/URLSession Client/Internals.URLSessionClient.Redirect.swift
@@ -27,7 +27,7 @@ extension Internals.RedirectRequest {
 
 extension URLRequest {
 
-    /// Applies a ``Internals/RedirectStrategy``'s decision on top of `self` -- everything besides
+    /// Applies a ``Internals/RedirectStrategy``'s decision on top of `self`: everything besides
     /// `url`/`httpMethod`/headers (in particular, whatever body-related fields URLSession itself
     /// already set on the candidate request this is called on) is left untouched, mirroring how
     /// `Internals.NIORedirectStrategyAdapter` only overwrites those same three on the NIO side.
@@ -51,7 +51,7 @@ extension URLRequest {
 
 extension URL {
 
-    /// Whether `self` and `other` share an origin (scheme, host, and port), per RFC 6454 --
+    /// Whether `self` and `other` share an origin (scheme, host, and port), per RFC 6454. This
     /// mirrors `AsyncHTTPClient`'s own (internal, so not reachable from here) `URL
     /// .hasTheSameOrigin(as:)`, which the NIO executor's `followingRedirect` uses for the same
     /// cross-origin header stripping this type's own caller implements for the `URLSession`

--- a/Sources/RequestDLInternals/Sources/Client/URLSession Client/Internals.URLSessionClient.swift
+++ b/Sources/RequestDLInternals/Sources/Client/URLSession Client/Internals.URLSessionClient.swift
@@ -25,7 +25,7 @@ extension Internals {
 
         // MARK: - Internal properties
 
-        /// Whether this client currently has any request in flight -- mirrors
+        /// Whether this client currently has any request in flight. Mirrors
         /// `Internals.Client.isRunning`, read by `Internals.ClientManager`'s idle-cleanup sweep so
         /// a busy client is never recycled out from under an in-flight request.
         package var isRunning: Bool {
@@ -36,7 +36,7 @@ extension Internals {
 
         private let session: URLSession
         private let throttledExecutor: Internals.ThrottledExecutor
-        /// Transport-agnostic in-flight counter also used by `Internals.Client` -- backs
+        /// Transport-agnostic in-flight counter also used by `Internals.Client`. Backs
         /// `isRunning` the same way there, just for `URLSession` tasks instead of
         /// `HTTPClient.Task`s.
         private let operationQueue = Internals.ClientOperationQueue()
@@ -52,8 +52,8 @@ extension Internals {
         // MARK: - Inits
 
         /// - Parameter secureConnection: Resolved once, here, into an
-        /// `Internals.URLSessionIdentityPolicy` -- including the Keychain round-trip a client
-        /// identity needs -- and cached for the lifetime of this client, mirroring
+        /// `Internals.URLSessionIdentityPolicy`, including the Keychain round-trip a client
+        /// identity needs, and cached for the lifetime of this client, mirroring
         /// NIOSSL's own per-connection `TLSConfiguration` caching in `Internals.ClientManager`.
         /// `nil` when the resolved request carries no TLS customization at all.
         /// - Parameter redirectConfiguration: Defaults to AsyncHTTPClient's own default
@@ -61,10 +61,10 @@ extension Internals {
         /// so a caller that does not set `Internals.Session.Configuration.redirectConfiguration`
         /// gets identical behavior regardless of which executor the session resolves to.
         /// - Parameter proxy: Both `.http` (`.server`) and `.socks` are mapped onto
-        /// `configuration` -- `.bearer` proxy authorization is the one thing that stays excluded
+        /// `configuration`. `.bearer` proxy authorization is the one thing that stays excluded
         /// from `.urlSession` upstream (`Internals.ExecutorIncompatibilityReason
         /// .proxyBearerAuthorizationUnderURLSession`), so a well-formed caller never passes that
-        /// here -- see `Internals.Proxy.buildConnectionProxyDictionary()`'s doc comment for the
+        /// here. See `Internals.Proxy.buildConnectionProxyDictionary()`'s doc comment for the
         /// per-platform status of this mapping.
         package init(
             configuration: URLSessionConfiguration,
@@ -74,19 +74,21 @@ extension Internals {
             maximumConcurrentConnections: Int? = nil
         ) throws {
             let configuration = configuration
-            // Explicitly `[:]`, not left untouched, when `proxy` is `nil` -- `URLSession` treats an
+            // Explicitly `[:]`, not left untouched, when `proxy` is `nil`. `URLSession` treats an
             // unset `connectionProxyDictionary` as "inherit whatever macOS's Network preferences
             // (or a device's Wi-Fi proxy config) currently say," unlike AsyncHTTPClient, which has
-            // no such discovery at all. Without this, a caller who declares neither `Proxy` nor
-            // `SystemProxy` -- the documented "system proxy is ignored unless opted into" contract
-            // `SystemProxy`'s own doc comment makes -- would silently pick up an ambient proxy
-            // anyway on `.urlSession`, but not on the NIO executor: the exact kind of
-            // executor-dependent behavior change this package works hard to avoid elsewhere (see
-            // `httpShouldSetCookies`/`httpCookieStorage` below, same rationale).
+            // no such discovery at all.
+            //
+            // Without this, a caller who declares neither `Proxy` nor `SystemProxy` (the
+            // documented "system proxy is ignored unless opted into" contract `SystemProxy`'s own
+            // doc comment makes) would silently pick up an ambient proxy anyway on `.urlSession`,
+            // but not on the NIO executor: the exact kind of executor-dependent behavior change
+            // this package works hard to avoid elsewhere (see `httpShouldSetCookies`/
+            // `httpCookieStorage` below, same rationale).
             configuration.connectionProxyDictionary = proxy?.buildConnectionProxyDictionary() ?? [:]
 
             // Required normalization, not optional: URLSession persists cookies in a jar by
-            // default, the NIO executor has none at all -- without
+            // default, the NIO executor has none at all. Without
             // this, which executor a session happens to resolve to would silently change
             // behavior across requests that share a session.
             configuration.httpShouldSetCookies = false
@@ -107,39 +109,41 @@ extension Internals {
         ///
         /// - Parameter delegate: Per-task delegate for concerns this method does not itself
         /// handle. `nil` falls back to the session's own default handling. Redirect enforcement,
-        /// proxy authentication, and -- when this client was built with a `secureConnection` --
+        /// proxy authentication, and, when this client was built with a `secureConnection`,
         /// the server-trust/client-certificate challenge (see `TaskDelegate` below) all run
         /// regardless of `delegate`; `delegate` is only consulted for a TLS challenge this client
         /// has no `identityPolicy` to answer.
         ///
-        /// Deliberately not `session.data(for:request:delegate:)` -- a captured crash report
+        /// Deliberately not `session.data(for:request:delegate:)`. A captured crash report
         /// (`EXC_BREAKPOINT`/`SIGTRAP`, entirely inside Foundation's own
         /// `NSURLSession.data(for:delegate:)` closures on the `com.apple.NSURLSession-work`
         /// queue, no frame of this package's own code anywhere in the crashing thread) confirms a
-        /// real, if rare, bug in that bridge -- reproducible on an iOS Simulator under heavy
+        /// real, if rare, bug in that bridge, reproducible on an iOS Simulator under heavy
         /// concurrent test load, not this package's own delegate (`TaskDelegate`'s shared state
-        /// is already lock-protected). Bridged by hand instead, the same way the streamed-upload
+        /// is already lock-protected).
+        ///
+        /// Bridged by hand instead, the same way the streamed-upload
         /// overload below already does: build a plain `dataTask(with:)` with no completion
         /// handler of its own, so `TaskDelegate` (already `URLSessionDataDelegate`-conforming) is
         /// the *only* thing consuming the response/data, and let its own
-        /// `didCompleteWithError:` -- which already knows how to turn `redirectError`/the
-        /// accumulated response into exactly this method's return shape -- resolve `completion`
+        /// `didCompleteWithError:`, which already knows how to turn `redirectError`/the
+        /// accumulated response into exactly this method's return shape, resolve `completion`
         /// once the task finishes. (An earlier version of this fix instead read `data`/`response`
         /// off a `dataTask(with:completionHandler:)` completion handler directly, alongside the
-        /// same delegate -- reachable together, but not guaranteed to agree with each other:
-        /// caught by `execute_whenRedirectChainExceedsMax_throwsRedirectLimitReachedError`, which
+        /// same delegate: reachable together, but not guaranteed to agree with each other.
+        /// Caught by `execute_whenRedirectChainExceedsMax_throwsRedirectLimitReachedError`, which
         /// started failing with `MissingURLResponseError` instead of the expected
         /// `RedirectLimitReachedError` once a redirect was actually refused.)
         ///
         /// `session.data(for:delegate:)` also cancelled its underlying `URLSessionTask`
-        /// automatically when the awaiting Swift `Task` was cancelled -- a guarantee this hand
+        /// automatically when the awaiting Swift `Task` was cancelled: a guarantee this hand
         /// bridge has to restore explicitly, via `CancellableTaskBox`, since nothing does that for
         /// a bare `withCheckedThrowingContinuation` on its own.
         package func execute(
             request: URLRequest,
             delegate: URLSessionTaskDelegate? = nil
         ) async throws -> (head: Internals.ResponseHead, body: Data) {
-            // Waited on before anything else, mirroring `Internals.Client.execute` -- a session
+            // Waited on before anything else, mirroring `Internals.Client.execute`: a session
             // configured with a limit must never let more requests than that reach the network,
             // whether the cap is enforced by the NIO or the URLSession executor.
             let release = await throttledExecutor.acquire()
@@ -180,7 +184,7 @@ extension Internals {
         /// front. Materializes `body` (any `AsyncSequence` of `ByteBuffer`; in practice
         /// `Internals.BodySequence`, or `RequestBody` itself from the `RequestDL` module, both of
         /// which conform) via `Internals.URLSessionUploadFile`, then uploads from whichever shape
-        /// that produced -- `uploadTask(with:from:)` for a body small enough to just hold in
+        /// that produced: `uploadTask(with:from:)` for a body small enough to just hold in
         /// memory, `uploadTask(with:fromFile:)` for one that spilled to disk.
         ///
         /// Deliberately does not drive `uploadTask(withStreamedRequest:)` + `needNewBodyStream`
@@ -188,18 +192,18 @@ extension Internals {
         /// `InputStream` (Swift subclass or a genuine `CFReadStream`) is ever recognized as
         /// reaching end-of-body. Neither of the two shapes used here goes through `InputStream` at
         /// all, so neither is affected; the file-backed one also re-reads the file itself for any
-        /// retry/redirect that resends the body -- nothing here needs to hand back a fresh body
+        /// retry/redirect that resends the body, so nothing here needs to hand back a fresh body
         /// more than once.
         ///
         /// - Parameter existingUploadFile: Set when the caller already knows `body`'s entire
         /// content is sitting untouched in this file (`RequestBody.wholeFileURL`, a
-        /// `Payload(url:)`-only body) -- skips `Internals.URLSessionUploadFile.write(body:)`
+        /// `Payload(url:)`-only body). Skips `Internals.URLSessionUploadFile.write(body:)`
         /// entirely rather than draining `body` only to recreate a copy of a file that already
         /// exists. `body` is still required in that case (for the generic `Body` type/call-site
         /// symmetry with the other overload below) but is never iterated.
         /// - Parameter onUploadProgress: Called once per `didSendBodyData` callback, in delivery
         /// order, with `(bytesSentThisCall, totalBytesExpectedToSend)`. Order and eventual
-        /// completion are what's guaranteed -- individual chunk sizes are URLSession's own to
+        /// completion are what's guaranteed; individual chunk sizes are URLSession's own to
         /// pick, not RequestDL's.
         package func execute<Body: AsyncSequence & Sendable>(
             request: URLRequest,
@@ -268,13 +272,13 @@ extension Internals {
         /// waiting for the whole body. Mirrors the NIO backend's own
         /// `Internals.AsyncResponse` shape: `Internals.DownloadStep.bytes` is a live
         /// `Internals.AsyncBytes` a caller iterates separately, re-chunked to `readingMode` by
-        /// `Internals.DownloadBuffer` -- the same type `Internals.Session.execute(...)` builds for
+        /// `Internals.DownloadBuffer`, the same type `Internals.Session.execute(...)` builds for
         /// the NIO path, reused verbatim here rather than reimplemented, since it already has no
         /// NIO dependency of its own (it consumes `Internals.AnyBuffer`, not `ByteBuffer`
         /// directly).
         ///
         /// Unlike the other two `execute` overloads, the throttle slot acquired at the top is
-        /// *not* released when this method returns -- it has to stay held until the download
+        /// *not* released when this method returns: it has to stay held until the download
         /// itself finishes, which happens well after this `async` call returns its
         /// `Internals.DownloadStep`. `TaskDelegate` releases it from
         /// `urlSession(_:task:didCompleteWithError:)` instead.
@@ -291,7 +295,7 @@ extension Internals {
             }
 
             // Built here, in an `async` context that can freely `await`, rather than inside a
-            // synchronous delegate callback -- `Internals.DownloadBuffer.init(readingMode:)` is
+            // synchronous delegate callback: `Internals.DownloadBuffer.init(readingMode:)` is
             // itself `async`, and `didReceive response:completionHandler:` below has no way to
             // await it without risking `didReceive data:` firing (URLSession serializes delegate
             // callbacks for one task, but only across calls that have themselves returned) before
@@ -321,7 +325,7 @@ extension Internals {
         }
 
         /// Executes `request`, returning a `SessionTask` whose response streams upload progress
-        /// (when `request` carries a body), the response head, and the body -- optionally teed
+        /// (when `request` carries a body), the response head, and the body, optionally teed
         /// to `cache` as it downloads.
         ///
         /// Mirrors `Internals.Client.execute(request:url:readingMode:uploadingBytes:cache:logger:)`:
@@ -330,11 +334,11 @@ extension Internals {
         /// `Internals.AsyncResponse` from that the NIO backend already produces, just fed by this
         /// client's own callbacks instead of `Internals.ClientResponseReceiver`'s.
         ///
-        /// No new delegate machinery -- reuses the exact `headCompletion`/`downloadBuffer`
+        /// No new delegate machinery: reuses the exact `headCompletion`/`downloadBuffer`
         /// mechanism `execute(request:readingMode:delegate:)` already has below, just resolving
         /// into these three streams instead of a continuation. The cache tee
         /// (`Internals.DownloadBuffer.cacheStream(_:)`) attaches from right here, at the same
-        /// point `Internals.ClientResponseReceiver.didReceiveHead` attaches it on the NIO side --
+        /// point `Internals.ClientResponseReceiver.didReceiveHead` attaches it on the NIO side,
         /// before any body chunk can arrive, since `didReceive response:completionHandler:`
         /// always precedes `didReceive data:`.
         package func execute(
@@ -359,16 +363,16 @@ extension Internals {
         }
 
         /// Combines what `execute(request:streaming:delegate:onUploadProgress:)` and
-        /// `execute(request:readingMode:delegate:)` each build separately -- a genuinely streamed
+        /// `execute(request:readingMode:delegate:)` each build separately: a genuinely streamed
         /// request body *and* a genuinely streamed response, at once.
         ///
         /// `TaskDelegate` already implements both `needNewBodyStream`/`didSendBodyData` and
-        /// `didReceive response:`/`didReceive data:` unconditionally -- this is the first call
+        /// `didReceive response:`/`didReceive data:` unconditionally. This is the first call
         /// site that activates both sets of optional fields on the same task, not new delegate
         /// logic. See `execute(request:readingMode:uploadingBytes:cache:logger:)` just above for
         /// everything else (the three-stream `SessionTask` shape, the cache tee).
         /// - Parameter existingUploadFile: See the standalone streaming `execute`'s doc comment
-        /// for this same parameter -- identical meaning here, `body` still required but unread
+        /// for this same parameter. Identical meaning here, `body` still required but unread
         /// when set.
         package func execute<Body: AsyncSequence & Sendable>(
             request: URLRequest,
@@ -398,7 +402,7 @@ extension Internals {
             )
         }
 
-        /// Shared body for the two `SessionTask`-producing `execute` overloads above -- they
+        /// Shared body for the two `SessionTask`-producing `execute` overloads above. They
         /// differ only in whether a body needs materializing first (`makeUploadBody`, `nil` for
         /// the no-body/non-streaming case), which in turn decides whether this builds a
         /// `dataTask(with:)`, an `uploadTask(with:from:)`, or an `uploadTask(with:fromFile:)`. See
@@ -418,12 +422,12 @@ extension Internals {
             let operation = operationQueue.operation()
 
             // CFNetwork's transparent `Content-Encoding` decoding can only be switched off by
-            // taking over `Accept-Encoding` ourselves -- and doing so suppresses it entirely, for
+            // taking over `Accept-Encoding` ourselves, and doing so suppresses it entirely, for
             // every encoding, not just the one added. So this is all-or-nothing: either every
             // configured algorithm is one CFNetwork already decodes natively and this stays
             // quiet, or `Accept-Encoding` is set here and this package decodes everything in the
             // list itself, manually, including the natives. `.disabled` reaches the same
-            // `identity` override -- see `Internals.Decompression.requiresManualURLSessionHandling`.
+            // `identity` override; see `Internals.Decompression.requiresManualURLSessionHandling`.
             let decompressionDispatch: Internals.ManualDecompressionDispatch
             var request = request
 
@@ -483,18 +487,18 @@ extension Internals {
             // Set before `task.resume()`, same ordering `execute(request:readingMode:delegate:)`
             // already relies on, so no callback can fire before this closure is in place.
             taskDelegate.headCompletion = { result in
-                // A response head -- success or failure -- can only exist once the request body
+                // A response head, success or failure, can only exist once the request body
                 // finished sending, so this is also where `upload` closes: mirrors
                 // `Internals.ClientResponseReceiver.didReceiveHead`, which closes `upload` again
                 // here too even though `didSendRequest` already closed it once, redundantly and
-                // harmlessly (`Internals.AsyncStream.close()` is idempotent) -- `onDownloadComplete`
+                // harmlessly (`Internals.AsyncStream.close()` is idempotent). `onDownloadComplete`
                 // below closes it a third time for the same reason: any path that reaches the end
                 // must leave `upload` closed, not just the common one.
                 upload.close()
 
                 switch result {
                 case .success(let step):
-                    // Attached before `head` is ever read from -- ordered against every future
+                    // Attached before `head` is ever read from: ordered against every future
                     // `downloadBuffer.append(_:)` by `Internals.DownloadBuffer`'s own queue, the
                     // same guarantee `Internals.ClientResponseReceiver.didReceiveHead` relies on.
                     if let cacheStream = cache?(step.head) {
@@ -536,7 +540,7 @@ extension Internals {
             )
         }
 
-        /// Invalidates the underlying `URLSession` -- mirrors `Internals.Client.shutdown()`, read
+        /// Invalidates the underlying `URLSession`. Mirrors `Internals.Client.shutdown()`, read
         /// by `Internals.ClientManager`'s idle-cleanup sweep. Idempotent and a no-op while a
         /// request is still in flight, same guard as the NIO counterpart.
         ///
@@ -560,8 +564,8 @@ extension Internals {
                 return false
             }
 
-            // No outstanding tasks per the `isRunning` guard above, so there is nothing to drain
-            // -- unlike `HTTPClient.shutdown()`, invalidation here is immediate, not awaited.
+            // No outstanding tasks per the `isRunning` guard above, so there is nothing to drain.
+            // Unlike `HTTPClient.shutdown()`, invalidation here is immediate, not awaited.
             session.invalidateAndCancel()
             return true
         }
@@ -571,14 +575,14 @@ extension Internals {
 extension Internals.URLSessionClient {
 
     /// `URLSession` only ever hands back a non-`HTTPURLResponse` for a non-HTTP(S) scheme, which
-    /// RequestDL never builds a request for -- this should be unreachable in practice.
+    /// RequestDL never builds a request for; this should be unreachable in practice.
     package struct UnexpectedURLResponseError: Error, Sendable {
         package let response: URLResponse
     }
 
     /// A streamed-upload task (`execute(request:streaming:delegate:onUploadProgress:)`) completed
-    /// with no error and yet never called `urlSession(_:dataTask:didReceive:completionHandler:)`
-    /// -- should be unreachable given `URLSession`'s own contract (every task either fails or
+    /// with no error and yet never called `urlSession(_:dataTask:didReceive:completionHandler:)`.
+    /// Should be unreachable given `URLSession`'s own contract (every task either fails or
     /// eventually receives a response), kept as a named error rather than force-unwrapping.
     package struct MissingURLResponseError: Error, Sendable {}
 
@@ -594,8 +598,8 @@ extension Internals.URLSessionClient {
     /// Lets a `withTaskCancellationHandler`'s `onCancel` closure reach a `URLSessionTask` that a
     /// concurrently-running `operation` closure is still in the middle of creating.
     ///
-    /// `onCancel` can fire the instant cancellation is requested -- including strictly before
-    /// `operation` ever assigns `task` -- so a plain `URLSessionTask?` written to after the fact
+    /// `onCancel` can fire the instant cancellation is requested, including strictly before
+    /// `operation` ever assigns `task`, so a plain `URLSessionTask?` written to after the fact
     /// could miss a cancellation that arrived in that gap. `task`'s setter checks for exactly that
     /// ordering and cancels immediately instead of losing it.
     fileprivate final class CancellableTaskBox: @unchecked Sendable {
@@ -628,7 +632,7 @@ extension Internals.URLSessionClient {
 }
 
 /// `Internals.URLSessionClient`'s own per-request delegate: redirect enforcement, proxy
-/// authentication, and -- when this client was built with a `secureConnection` -- TLS challenge
+/// authentication, and, when this client was built with a `secureConnection`, TLS challenge
 /// handling, none of which URLSession has a configuration-level API for; all must instead be
 /// answered through delegate callbacks. A TLS challenge this delegate's
 /// own `tlsDelegate` can't answer (no `identityPolicy`, or a different host) falls through to
@@ -645,12 +649,12 @@ extension Internals.URLSessionClient {
         private let tlsDelegate: TLSDelegate?
         private let forwardingDelegate: URLSessionTaskDelegate?
         private let onUploadProgress: (@Sendable (Int, Int) -> Void)?
-        /// Set for the streamed-download `execute(request:readingMode:delegate:)` path only --
+        /// Set for the streamed-download `execute(request:readingMode:delegate:)` path only.
         /// `nil` for the other two, which is exactly the switch `didReceive
         /// response:completionHandler:`/`didReceive data:`/`didCompleteWithError:` use below to
         /// tell which of the three modes this instance is answering for.
         private let downloadBuffer: Internals.DownloadBuffer?
-        /// Releases the throttle slot `execute(request:readingMode:delegate:)` acquired -- see
+        /// Releases the throttle slot `execute(request:readingMode:delegate:)` acquired. See
         /// that method's own doc comment for why it can't just `defer { release() }` the way the
         /// other two `execute` overloads do.
         private let onDownloadComplete: (@Sendable () -> Void)?
@@ -658,7 +662,7 @@ extension Internals.URLSessionClient {
 
         // MARK: - Unsafe properties
 
-        /// All visited URLs, starting with the request's own -- mirrors `RedirectState.visited`.
+        /// All visited URLs, starting with the request's own. Mirrors `RedirectState.visited`.
         private var _visited: [String]
         private var _redirectError: Error?
         /// The most recently sent request, updated on every followed redirect. Together with
@@ -666,11 +670,11 @@ extension Internals.URLSessionClient {
         /// executor builds from its own `HTTPClientRequestResponse` history.
         private var _lastRequest: URLRequest
         private var _history: [Internals.RedirectHistoryEntry] = []
-        /// Redirects followed under `.strategy` mode specifically -- independent of `_history`,
+        /// Redirects followed under `.strategy` mode specifically, independent of `_history`,
         /// which accumulates regardless of mode, mirroring the NIO adapter's own
         /// `customRedirectCount` (incremented only when `.strategy` chooses `.follow`).
         private var _strategyRedirectCount = 0
-        /// Response accumulation for the streamed-upload path only -- the buffered path never
+        /// Response accumulation for the streamed-upload path only. The buffered path never
         /// touches these, since `session.data(for:delegate:)` does its own accumulation
         /// regardless of what extra `URLSessionDataDelegate` methods this class implements.
         private var _response: URLResponse?
@@ -681,7 +685,7 @@ extension Internals.URLSessionClient {
         private var _completion: ((Result<(head: Internals.ResponseHead, body: Data), Error>) -> Void)?
         /// Set by `execute(request:readingMode:delegate:)` right after construction, resolved from
         /// `didReceive response:completionHandler:` (the common case) or, if the task fails before
-        /// a response ever arrives, from `didCompleteWithError:` instead -- guarded by `_headResolved`
+        /// a response ever arrives, from `didCompleteWithError:` instead. Guarded by `_headResolved`
         /// so whichever fires first wins and the other is a no-op.
         private var _headCompletion: ((Result<Internals.DownloadStep, Error>) -> Void)?
         private var _headResolved = false
@@ -733,7 +737,7 @@ extension Internals.URLSessionClient {
 
         /// Enforces `Internals.RedirectConfiguration` for this task.
         ///
-        /// URLSession has no native "max redirects" / "allow cycles" concept --
+        /// URLSession has no native "max redirects" / "allow cycles" concept:
         /// `willPerformHTTPRedirection` only ever offers "follow this exact request" or "don't,
         /// and treat the redirect response as final." Both the counting and the cycle detection
         /// below are a direct port of what AsyncHTTPClient's own `RedirectState`
@@ -742,12 +746,12 @@ extension Internals.URLSessionClient {
         ///
         /// `.disallow` needs no tracking at all: every redirect is refused via
         /// `completionHandler(nil)`, same as AsyncHTTPClient handing back the 3xx response
-        /// untouched when `redirectHandler` is `nil` -- not a `redirectError`, since declining to
+        /// untouched when `redirectHandler` is `nil`. This is not a `redirectError`, since declining to
         /// follow is not itself a failure.
         ///
         /// Both `.follow` and `.strategy` strip `Authorization`/`Cookie`/`Origin`/
         /// `Proxy-Authorization` from `request` when it no longer shares the previously sent
-        /// request's origin (scheme, host, and port) -- `URLSession` does not do this on its own,
+        /// request's origin (scheme, host, and port). `URLSession` does not do this on its own,
         /// unlike the NIO executor's `followingRedirect`/`transformRequestForRedirect`, which this
         /// mirrors so a redirect leaking credentials to a different host fails the same way under
         /// either transport.
@@ -781,7 +785,7 @@ extension Internals.URLSessionClient {
                 switch outcome {
                 case .success:
                     let sanitizedRequest = sanitizedForRedirect(request)
-                    // `historyEntry(for:)` takes `lock` itself to read `_lastRequest` -- must
+                    // `historyEntry(for:)` takes `lock` itself to read `_lastRequest`, so it must
                     // resolve it before entering this block, not inside it, or it deadlocks
                     // `Lock`, which is not reentrant.
                     let entry = historyEntry(for: response)
@@ -834,7 +838,7 @@ extension Internals.URLSessionClient {
 
         // MARK: - Private methods
 
-        /// The request that produced `response`, per `_lastRequest` -- i.e. the request one hop
+        /// The request that produced `response`, per `_lastRequest`: the request one hop
         /// before `request` in `urlSession(_:task:willPerformHTTPRedirection:newRequest:completionHandler:)`.
         private func historyEntry(for response: HTTPURLResponse) -> Internals.RedirectHistoryEntry {
             lock.withLock {
@@ -905,7 +909,7 @@ extension Internals.URLSessionClient {
             onUploadProgress?(Int(bytesSent), Int(totalBytesExpectedToSend))
         }
 
-        /// Response-side counterpart to `needNewBodyStream` above -- exercised by the
+        /// Response-side counterpart to `needNewBodyStream` above. Exercised by the
         /// streamed-upload path (which, unlike the buffered path's `session.data(for:delegate:)`,
         /// has no built-in response accumulation of its own to fall back on) and, differently, by
         /// the streamed-download path, which resolves `headCompletion` right here instead of
@@ -931,11 +935,11 @@ extension Internals.URLSessionClient {
                 return
             }
 
-            // Sync, deliberately -- `Internals.DownloadBuffer.append(_:)` enqueues onto an
+            // Sync, deliberately: `Internals.DownloadBuffer.append(_:)` enqueues onto an
             // ordered queue, and submission order has to match arrival order. Building the
             // `Internals.DataBuffer` on a detached `Task` (its usual, `async`, in-memory-or-file
             // generic initializer) would let two chunks race to enqueue and reassemble the body
-            // out of order -- `Internals.Buffer`'s own "Synchronous construction, in memory only"
+            // out of order. `Internals.Buffer`'s own "Synchronous construction, in memory only"
             // extension exists for precisely this reason (see its doc comment, which calls out a
             // NIO delegate callback as the original motivating case; this is the same shape of
             // problem one layer up, for `URLSessionDataDelegate` instead of
@@ -944,7 +948,7 @@ extension Internals.URLSessionClient {
             downloadBuffer.append(Internals.DataBuffer(byteURL))
         }
 
-        /// Resolves `completion`/`headCompletion` -- the streamed-upload and streamed-download
+        /// Resolves `completion`/`headCompletion`: the streamed-upload and streamed-download
         /// paths' only way to learn a task is done, since neither goes through
         /// `session.data(for:delegate:)`'s own `async` completion. A no-op for the buffered path,
         /// where `completion` is never set.
@@ -953,8 +957,8 @@ extension Internals.URLSessionClient {
                 defer { onDownloadComplete?() }
 
                 // A failure before any response ever arrived (e.g. connection refused) means
-                // `didReceive response:` never ran and `headCompletion` is still unresolved --
-                // resolve it now rather than leaving `execute(request:readingMode:delegate:)`
+                // `didReceive response:` never ran and `headCompletion` is still unresolved.
+                // Resolve it now rather than leaving `execute(request:readingMode:delegate:)`
                 // suspended forever. `resolveHead(with:downloadBuffer:)` is a no-op if a response
                 // already resolved it, so this is safe to call unconditionally.
                 if let error {
@@ -998,10 +1002,10 @@ extension Internals.URLSessionClient {
 
         // MARK: - Private methods
 
-        /// Resolves `headCompletion` from the response URLSession actually delivered --
+        /// Resolves `headCompletion` from the response URLSession actually delivered:
         /// `didReceive response:completionHandler:`'s normal path. A no-op if `headCompletion`
         /// already resolved (guarded by `_headResolved`), which only happens if
-        /// `didCompleteWithError:` beat it to a failure -- shouldn't happen given `URLSession`'s
+        /// `didCompleteWithError:` beat it to a failure. Shouldn't happen given `URLSession`'s
         /// own callback ordering, kept anyway since resolving a completion handler twice is a
         /// trap, not a silent bug.
         private func resolveHead(with response: URLResponse, downloadBuffer: Internals.DownloadBuffer) {
@@ -1049,7 +1053,7 @@ extension Internals.URLSessionClient {
             )
         }
 
-        /// Resolves `headCompletion` with `error` -- only actually resolves anything if no
+        /// Resolves `headCompletion` with `error`. Only actually resolves anything if no
         /// response ever arrived to resolve it first (guarded by the same `_headResolved` flag
         /// `resolveHead(with:downloadBuffer:)` uses); called unconditionally from
         /// `didCompleteWithError:` so a connection-level failure before any response (refused,
@@ -1065,7 +1069,7 @@ extension Internals.URLSessionClient {
             completion?(.failure(error))
         }
 
-        /// `.basic`/`.basicRawCredentials` only -- `URLCredential` has exactly two shapes
+        /// `.basic`/`.basicRawCredentials` only. `URLCredential` has exactly two shapes
         /// (user/password, identity/certificates), neither of which can carry an arbitrary
         /// bearer token, which is why `.bearer` proxy authorization is excluded from
         /// `.urlSession` entirely (`Internals.ExecutorIncompatibilityReason
@@ -1111,7 +1115,7 @@ extension Internals.ResponseHead {
                 code: UInt(response.statusCode),
                 reason: HTTPURLResponse.localizedString(forStatusCode: response.statusCode)
             ),
-            // `HTTPURLResponse` does not expose the negotiated HTTP version -- only
+            // `HTTPURLResponse` does not expose the negotiated HTTP version, only
             // `URLSessionTaskMetrics`, via a delegate callback this non-streaming round trip has
             // no reason to collect. `LocalServer`, and every executor-neutral caller today,
             // speaks HTTP/1.1 only, so that is the safe assumption here.
@@ -1122,7 +1126,7 @@ extension Internals.ResponseHead {
                 }
                 return HeaderField(name: name, value: value)
             },
-            // Not observable per response over URLSession -- connection reuse is entirely
+            // Not observable per response over URLSession: connection reuse is entirely
             // internal to the session. `true` matches HTTP/1.1's own default.
             isKeepAlive: true
         )

--- a/Sources/RequestDLInternals/Sources/Client/URLSession Client/Upload/Internals.URLSessionUploadFile.swift
+++ b/Sources/RequestDLInternals/Sources/Client/URLSession Client/Upload/Internals.URLSessionUploadFile.swift
@@ -3,15 +3,18 @@
 //
 
 // Workaround for a confirmed CFNetwork bug (root-caused, but not fixed upstream or yet reported):
-// `uploadTask(withStreamedRequest:)` never recognizes end-of-body for a custom `InputStream` --
-// confirmed across four servers and three independently-written subclasses, plus a genuine
+// `uploadTask(withStreamedRequest:)` never recognizes end-of-body for a custom `InputStream`.
+//
+// Confirmed across four servers and three independently-written subclasses, plus a genuine
 // `CFReadStream` built from raw callbacks, that every callback plausibly involved
-// (`copyProperty`/`setProperty`/`getBuffer`/object-identity) was ruled out as the cause -- only
-// Foundation's own concrete, singular `InputStream(data:)` class ever completes. The earlier
-// `Internals.URLSessionUploadStream` (an `InputStream` subclass) hit exactly that bug and is gone;
-// this replaces it with two different `URLSession` code paths -- `uploadTask(with:from:)` for a
-// body small enough to just hold in memory, `uploadTask(with:fromFile:)` for everything else --
-// neither of which touches `InputStream`/`needNewBodyStream` at all, so neither is affected.
+// (`copyProperty`/`setProperty`/`getBuffer`/object-identity) was ruled out as the cause: only
+// Foundation's own concrete, singular `InputStream(data:)` class ever completes.
+//
+// The earlier `Internals.URLSessionUploadStream` (an `InputStream` subclass) hit exactly that
+// bug and is gone; this replaces it with two different `URLSession` code paths:
+// `uploadTask(with:from:)` for a body small enough to just hold in memory, and
+// `uploadTask(with:fromFile:)` for everything else. Neither touches
+// `InputStream`/`needNewBodyStream` at all, so neither is affected.
 
 #if canImport(Darwin)
 
@@ -27,20 +30,20 @@ import struct Foundation.URL
 extension Internals {
 
     /// Materializes an upload body (`Internals.BodySequence`, or `RequestBody` itself from the
-    /// `RequestDL` module -- both conform to `AsyncSequence<ByteBuffer>`) into whichever of
+    /// `RequestDL` module, both conform to `AsyncSequence<ByteBuffer>`) into whichever of
     /// `URLSession`'s two non-`InputStream` upload shapes fits, so `Internals.URLSessionClient`
     /// never has to stream through a custom `InputStream`. See this file's header comment for why
     /// that matters.
     ///
     /// Most request bodies (a JSON payload, a small form, ordinary `Payload(data:)` uploads) are
-    /// already comfortably small -- writing every one of those to a temporary file before every
+    /// already comfortably small, so writing every one of those to a temporary file before every
     /// request would be needless disk I/O for something that already fits in memory. Only a body
     /// that turns out to be genuinely large spills to disk, and only past the point where it
     /// stopped being cheap to just hold onto.
     enum URLSessionUploadFile {
 
         /// Below this many bytes, `write(body:)` keeps the whole body in memory (`.data`) rather
-        /// than spilling to a temporary file. Deliberately generous -- most everyday bodies
+        /// than spilling to a temporary file. Deliberately generous: most everyday bodies
         /// (JSON, form fields, small-to-medium payloads) land well under it, and 8 MiB held
         /// briefly in memory for one in-flight upload is not a meaningful cost on any platform
         /// this executor targets.
@@ -49,18 +52,19 @@ extension Internals {
         /// Where an upload body ended up, whether by draining it (`write(body:)`) or by the
         /// caller already knowing it's sitting on disk untouched (`RequestBody.wholeFileURL`).
         enum Materialized {
-            /// The whole body, still in memory -- upload via `uploadTask(with:from:)`.
+            /// The whole body, still in memory: upload via `uploadTask(with:from:)`.
             case data(Data)
             /// The body spilled past `inMemoryThreshold` while draining it, now sitting in a
-            /// temporary file this package created -- upload via `uploadTask(with:fromFile:)`.
-            /// The caller owns the file from here -- remove it
+            /// temporary file this package created: upload via `uploadTask(with:fromFile:)`.
+            ///
+            /// The caller owns the file from here, and should remove it
             /// (`Internals.FileBufferURL.removeIfTemporary()`) once the upload task, success or
             /// failure, is done with it.
             case file(Internals.FileBufferURL)
-            /// The body was never drained at all -- it was already sitting in a file somebody
+            /// The body was never drained at all: it was already sitting in a file somebody
             /// else owns (`RequestBody.wholeFileURL`'s `Payload(url:)` case). Upload via
             /// `uploadTask(with:fromFile:)`, same as `.file`, but this URL is never removed
-            /// afterward -- it isn't this package's file to delete.
+            /// afterward, since it isn't this package's file to delete.
             case existingFile(URL)
         }
 

--- a/Sources/RequestDLInternals/Sources/Secure Connection/SPKI Pinning/Internals.SPKIHash.swift
+++ b/Sources/RequestDLInternals/Sources/Secure Connection/SPKI Pinning/Internals.SPKIHash.swift
@@ -25,7 +25,7 @@ extension Internals {
     package struct SPKIHash: Sendable, Hashable {
 
         /// Named algorithms `URLSessionClient`'s `SecTrust`-based trust evaluation can recompute
-        /// on its own -- `Data`/`Codable`, unlike `Algorithm.Type`, so a `ServerTrustPolicy` built
+        /// on its own. `Data`/`Codable`, unlike `Algorithm.Type`, so a `ServerTrustPolicy` built
         /// from one of these can also survive a `BackgroundDownloadTask` relaunch as a
         /// `ServerTrustPolicy.Descriptor`. Every hash algorithm actually documented for
         /// `RequestDL.SPKIHash` (SHA-256/384/512); anything else still pins correctly for the
@@ -86,7 +86,7 @@ extension Internals {
                 && lhs.algorithmID == rhs.algorithmID
         }
 
-        /// The digest this pin expects the peer's SPKI to hash to -- what `ServerTrustPolicy`
+        /// The digest this pin expects the peer's SPKI to hash to: what `ServerTrustPolicy`
         /// compares against, and what a `Descriptor` persists for `knownAlgorithm != nil` pins.
         package func resolvedDigest() throws -> Data {
             try producer(source)

--- a/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Models/Internals.SecureFileLoadError.swift
+++ b/Sources/RequestDLInternals/Sources/Secure Connection/Secure Connection/Models/Internals.SecureFileLoadError.swift
@@ -6,7 +6,7 @@ extension Internals {
 
     /// Carries the raw context of a certificate/private key file load failure up to `RequestDL`.
     ///
-    /// `RequestDL`'s public `SecureFileError` -- the documented, user-facing error -- lives in the
+    /// `RequestDL`'s public `SecureFileError` (the documented, user-facing error) lives in the
     /// `RequestDL` module and cannot be referenced from here, since `RequestDL` depends on this
     /// module rather than the other way around. `Internals.Certificate`/`Internals.PrivateKey`
     /// throw this instead; `RequestDL` catches it where the client bootstraps and rewraps it into

--- a/Sources/RequestDLInternals/Sources/Session/Async Response/Internals.ManualDecompressionDispatch.swift
+++ b/Sources/RequestDLInternals/Sources/Session/Async Response/Internals.ManualDecompressionDispatch.swift
@@ -13,24 +13,25 @@ import struct Foundation.Data
 extension Internals {
 
     /// Whether `Internals.AsyncResponse` needs to decode the response body itself, resolved once
-    /// per request by whichever `RequestExecutingClient` conformance built it -- each transport
+    /// per request by whichever `RequestExecutingClient` conformance built it: each transport
     /// has its own reason to land on `.skip` or `.dispatch`, but what happens with the answer
     /// (matching `Content-Encoding`, wrapping the byte stream) is the same either way, so it
     /// lives here, once, rather than duplicated per executor.
     ///
     /// - Important: `.skip` covers two different reasons that both resolve to "leave the bytes
     /// alone": decompression is `.disabled`, or every configured algorithm is one the transport
-    /// already decoded natively. The second case matters specifically for `.urlSession` --
-    /// CFNetwork decodes gzip/deflate/br transparently but does *not* strip `Content-Encoding`
-    /// from the headers it hands back (confirmed empirically), so this can never be reduced to
-    /// "dispatch whenever the header is present" without risking a second, corrupting decode
-    /// pass over already-decoded bytes.
+    /// already decoded natively.
+    ///
+    /// The second case matters specifically for `.urlSession`: CFNetwork decodes gzip/deflate/br
+    /// transparently but does *not* strip `Content-Encoding` from the headers it hands back
+    /// (confirmed empirically), so this can never be reduced to "dispatch whenever the header is
+    /// present" without risking a second, corrupting decode pass over already-decoded bytes.
     package enum ManualDecompressionDispatch: Sendable {
         case skip
         case dispatch(algorithms: [any Internals.DecompressionAlgorithm])
     }
 
-    /// Internals-layer counterpart to `RequestDL.UnsupportedContentEncodingError` -- caught where
+    /// Internals-layer counterpart to `RequestDL.UnsupportedContentEncodingError`, caught where
     /// the public `AsyncResponse` wrapper turns an `Internals.AsyncResponse` into its own public
     /// types, and rewrapped there, following the same split `ExecutorRequirementError` uses for
     /// `Internals.IncompatibleExecutorConfigurationError`.
@@ -45,12 +46,12 @@ extension Internals {
 
 extension Internals.ManualDecompressionDispatch {
 
-    /// The stream to actually read the response body from -- `source` itself for `.skip`, or
+    /// The stream to actually read the response body from: `source` itself for `.skip`, or
     /// whenever `Content-Encoding` is absent or `identity`; otherwise a stream that decodes
     /// through whichever configured algorithm matches it.
     ///
     /// - Throws: `Internals.UnsupportedContentEncodingError` when `Content-Encoding` matches none
-    /// of the dispatch algorithms -- only reachable in `.dispatch`, meaning this package has
+    /// of the dispatch algorithms. This is only reachable in `.dispatch`, meaning this package has
     /// already taken over decoding for this request, so a server sending something it wasn't
     /// asked for is a real, reportable mismatch rather than something to silently pass through.
     package func resolvedStream(
@@ -83,10 +84,12 @@ extension Internals.ManualDecompressionDispatch {
 extension Internals.AsyncStream where Element == Internals.DataBuffer {
 
     /// Feeds every chunk `source` produces through a fresh decoder, one per response, forwarding
-    /// whatever comes back -- `[UInt8]` decoding chunks may be empty, and empty chunks are simply
+    /// whatever comes back. `[UInt8]` decoding chunks may be empty, and empty chunks are simply
     /// not forwarded, since a `DecompressorStream` is explicitly allowed to buffer internally and
-    /// emit nothing for a given call. `finish()` runs once `source` ends, flushing whatever the
-    /// decoder is still holding before this stream itself closes.
+    /// emit nothing for a given call.
+    ///
+    /// `finish()` runs once `source` ends, flushing whatever the decoder is still holding before
+    /// this stream itself closes.
     fileprivate static func decompressing(
         _ source: Internals.AsyncStream<Internals.DataBuffer>,
         using algorithm: any Internals.DecompressionAlgorithm

--- a/Sources/RequestDLInternals/Sources/Session/Network Path Monitor/Internals.NetworkPathMonitor.swift
+++ b/Sources/RequestDLInternals/Sources/Session/Network Path Monitor/Internals.NetworkPathMonitor.swift
@@ -11,13 +11,15 @@ extension Internals {
     /// A shared, process-lifetime wrapper around a single `NWPathMonitor`, fanning its updates
     /// out to any number of concurrent ``updates()`` subscribers.
     ///
-    /// One `NWPathMonitor` for the whole process, not one per request/gate call -- starting a
-    /// fresh monitor has real overhead. Lazily created via `.shared`'s own thread-safe lazy
-    /// static initialization, so a process that never sets `allowsCellularAccess`/
-    /// `allowsExpensiveNetworkAccess`/`allowsConstrainedNetworkAccess`/`waitsForConnectivity`
-    /// never starts an `NWPathMonitor` at all -- `Internals.NetworkPathGate.wait(for:)` is only
-    /// ever called when at least one of those four is set, and `.shared` is only referenced from
-    /// inside that call's default `observer` argument.
+    /// One `NWPathMonitor` for the whole process, not one per request/gate call: starting a
+    /// fresh monitor has real overhead.
+    ///
+    /// Lazily created via `.shared`'s own thread-safe lazy static initialization, so a process
+    /// that never sets `allowsCellularAccess`/`allowsExpensiveNetworkAccess`/
+    /// `allowsConstrainedNetworkAccess`/`waitsForConnectivity` never starts an `NWPathMonitor`
+    /// at all: `Internals.NetworkPathGate.wait(for:)` is only ever called when at least one of
+    /// those four is set, and `.shared` is only referenced from inside that call's default
+    /// `observer` argument.
     package final class NetworkPathMonitor: NetworkPathObserving, @unchecked Sendable {
 
         package static let shared = NetworkPathMonitor()
@@ -87,7 +89,7 @@ extension Internals {
             }
         }
 
-        /// Identity anchor for a single `updates()` subscription -- kept alive by its own
+        /// Identity anchor for a single `updates()` subscription, kept alive by its own
         /// `onTermination` closure until termination fires, then released.
         private final class SubscriberToken: Sendable {}
     }

--- a/Sources/RequestDLInternals/Sources/Session/Proxy/Internals.PACEvaluator.swift
+++ b/Sources/RequestDLInternals/Sources/Session/Proxy/Internals.PACEvaluator.swift
@@ -16,19 +16,21 @@ import struct Foundation.URL
 
 extension Internals {
 
-    /// Bridges `CFNetworkExecuteProxyAutoConfigurationURL` -- a callback/`CFRunLoopSource` API,
-    /// not `async`-native -- into `async throws`.
+    /// Bridges `CFNetworkExecuteProxyAutoConfigurationURL` (a callback/`CFRunLoopSource` API,
+    /// not `async`-native) into `async throws`.
     ///
     /// The Swift Concurrency cooperative thread pool never runs a `CFRunLoop` on any of its
     /// threads (nothing calls `CFRunLoopRun()`/`CFRunLoopRunInMode()` there), so simply adding
     /// the source CFNetwork hands back to "the current run loop" from a `Task` would leave it
-    /// registered but never pumped -- the callback would never fire, and the awaiting
-    /// continuation would hang forever. This spins one dedicated, short-lived `Thread` per
-    /// evaluation instead, whose only job is to add the source to its own run loop and pump that
-    /// loop (`CFRunLoopRunInMode`) until either the callback fires or `timeout` elapses.
+    /// registered but never pumped: the callback would never fire, and the awaiting
+    /// continuation would hang forever.
+    ///
+    /// This spins one dedicated, short-lived `Thread` per evaluation instead, whose only job is
+    /// to add the source to its own run loop and pump that loop (`CFRunLoopRunInMode`) until
+    /// either the callback fires or `timeout` elapses.
     ///
     /// One thread per call, not a shared long-lived one: PAC evaluation is a rare, slow
-    /// (network-fetch-bound), cached operation (see `Internals.PACProxyCache`) -- the cost of
+    /// (network-fetch-bound), cached operation (see `Internals.PACProxyCache`), so the cost of
     /// spinning a thread per *uncached* call is negligible next to the fetch itself, and it
     /// avoids the lifecycle/reentrancy bookkeeping a shared pumped run loop would need for
     /// concurrent callers.
@@ -49,14 +51,15 @@ extension Internals {
         /// returns the first directly-usable proxy the script resolves to (`nil` for an explicit
         /// direct connection, or for a script that resolves to nothing this package recognizes).
         ///
-        /// Parsed via `Internals.SystemProxyResolver.firstUsableProxy(in:)` -- the exact same
+        /// Parsed via `Internals.SystemProxyResolver.firstUsableProxy(in:)`, the exact same
         /// dictionary-shape parsing the non-PAC path already does, since
         /// `CFNetworkExecuteProxyAutoConfigurationURL`'s result uses the identical shape
-        /// `CFNetworkCopyProxiesForURL` does (minus any `kCFProxyTypeAutoConfigurationURL` entry --
-        /// CFNetwork's own guarantee that a script cannot chain to another PAC file). Parsed
-        /// inside `pacEvaluationCallback`, before the result ever crosses back into `async`
-        /// context: the raw `CFArray` of `[String: Any]` dictionaries isn't `Sendable`, but the
-        /// parsed `Internals.Proxy?` is.
+        /// `CFNetworkCopyProxiesForURL` does (minus any `kCFProxyTypeAutoConfigurationURL` entry,
+        /// CFNetwork's own guarantee that a script cannot chain to another PAC file).
+        ///
+        /// This parsing happens inside `pacEvaluationCallback`, before the result ever crosses
+        /// back into `async` context: the raw `CFArray` of `[String: Any]` dictionaries isn't
+        /// `Sendable`, but the parsed `Internals.Proxy?` is.
         package static func evaluate(
             scriptURL: URL,
             targetURL: URL,
@@ -77,7 +80,7 @@ extension Internals {
 }
 
 /// Owns exactly one `evaluate(...)` call's continuation, the run loop that pumps it, and the
-/// `CFRunLoopSource` CFNetwork hands back -- one instance per call, never shared, never reused.
+/// `CFRunLoopSource` CFNetwork hands back: one instance per call, never shared, never reused.
 private final class PACContinuationBox: @unchecked Sendable {
 
     // MARK: - Private properties
@@ -94,7 +97,7 @@ private final class PACContinuationBox: @unchecked Sendable {
 
     // MARK: - Internal methods
 
-    /// Runs entirely on the dedicated thread `PACEvaluator.evaluate(...)` spun up for it --
+    /// Runs entirely on the dedicated thread `PACEvaluator.evaluate(...)` spun up for it. It
     /// blocks that thread (and only that thread) until `resume(returning:)`/`resume(throwing:)`
     /// has been called exactly once, one way or another.
     func run(scriptURL: URL, targetURL: URL, timeout: Double) {
@@ -119,7 +122,7 @@ private final class PACContinuationBox: @unchecked Sendable {
         defer { CFRunLoopRemoveSource(runLoop, source, .defaultMode) }
 
         // `false`: only `CFRunLoopStop(_:)` (fired by `pacEvaluationCallback` below, the instant
-        // the result is in) or `timeout` elapsing ends this -- not merely the first source this
+        // the result is in) or `timeout` elapsing ends this, not merely the first source this
         // run loop happens to service, which need not be the PAC one.
         let result = CFRunLoopRunInMode(.defaultMode, timeout, false)
 
@@ -145,7 +148,7 @@ private final class PACContinuationBox: @unchecked Sendable {
     }
 }
 
-/// `@convention(c)`, so it cannot capture anything -- `info` (round-tripped through
+/// `@convention(c)`, so it cannot capture anything: `info` (round-tripped through
 /// `CFStreamClientContext` unretained, since the box already outlives the call by blocking its
 /// own thread in `CFRunLoopRunInMode` for exactly this long) is how `PACContinuationBox.run(...)`
 /// hands this its identity back.

--- a/Sources/RequestDLInternals/Sources/Session/Proxy/Internals.PACProxyCache.swift
+++ b/Sources/RequestDLInternals/Sources/Session/Proxy/Internals.PACProxyCache.swift
@@ -15,7 +15,7 @@ extension Internals {
 
     /// Caches `Internals.PACEvaluator.evaluate(...)`'s result per `(scriptURL, targetURL)` pair,
     /// so a burst of requests to the same host doesn't each pay for a fresh network fetch and
-    /// JavaScript evaluation of the same PAC script -- the cost the original "PAC is skipped
+    /// JavaScript evaluation of the same PAC script: the cost the original "PAC is skipped
     /// entirely" version of this resolver was written specifically to avoid paying per request.
     package actor PACProxyCache {
 
@@ -29,7 +29,7 @@ extension Internals {
         /// Matches `Internals.Storage`/`Internals.ClientManager`'s own default lifetime.
         private static let lifetime: Int64 = 5 * 60 * 1_000_000_000
 
-        /// Bounds one evaluation's fetch-and-execute time -- without this, an unreachable PAC
+        /// Bounds one evaluation's fetch-and-execute time. Without this, an unreachable PAC
         /// server would hang every request routed through it, not just the first. 30s, not a
         /// tighter bound: a PAC file is commonly hosted on a slow internal server reached over a
         /// real (if sluggish) corporate network, and this only ever costs one request's worth of
@@ -50,9 +50,11 @@ extension Internals {
         // MARK: - Internal methods
 
         /// The proxy `scriptURL`'s PAC script resolves `targetURL` to, or `nil` for a direct
-        /// connection -- including when evaluation itself fails (a stale/misconfigured PAC file,
-        /// an unreachable PAC server, a script that throws): failing safe to direct is the same
-        /// choice `Internals.SystemProxyResolver.firstResolution(in:)` already makes for any other
+        /// connection, including when evaluation itself fails (a stale/misconfigured PAC file,
+        /// an unreachable PAC server, a script that throws).
+        ///
+        /// Failing safe to direct is the same choice
+        /// `Internals.SystemProxyResolver.firstResolution(in:)` already makes for any other
         /// proxy-list entry it can't parse.
         package func proxy(forScriptURL scriptURL: URL, targetURL: URL) async -> Internals.Proxy? {
             let key = Key(scriptURL: scriptURL, targetURL: targetURL)
@@ -96,7 +98,7 @@ extension Internals {
 
         private struct Entry {
             let proxy: Internals.Proxy?
-            // Monotonic, not wall clock -- same rationale as `Internals.Storage`/
+            // Monotonic, not wall clock: same rationale as `Internals.Storage`/
             // `Internals.ClientManager`: a `Date`-based deadline moves if the user or NTP moves
             // the system clock, and this must not advance while the device is suspended either
             // way.

--- a/Sources/RequestDLInternals/Sources/Session/Proxy/Internals.Proxy.swift
+++ b/Sources/RequestDLInternals/Sources/Session/Proxy/Internals.Proxy.swift
@@ -97,23 +97,25 @@ extension Internals.Proxy: Hashable {
 extension Internals.Proxy {
 
     /// `URLSessionConfiguration.connectionProxyDictionary`'s legacy CFNetwork keys for this
-    /// proxy -- URLSession has no typed proxy API to mirror `HTTPClient.Configuration.Proxy`
+    /// proxy: URLSession has no typed proxy API to mirror `HTTPClient.Configuration.Proxy`
     /// with, only this untyped dictionary. String literals rather than the `CFNetwork` constants
     /// (`kCFNetworkProxiesHTTPEnable` etc.) because they are stable, widely relied upon by
     /// networking libraries, and avoid an extra platform-conditional import for three key names.
     ///
     /// `.http` sets both the `HTTP*` and `HTTPS*` key triples, since HTTPS targets are what
     /// actually trigger the `CONNECT` tunnel this proxy exists to build. `.socks` sets the analogous
-    /// `SOCKS*` triple -- no separate HTTPS variant exists for SOCKS, one set of keys covers both.
+    /// `SOCKS*` triple: no separate HTTPS variant exists for SOCKS, one set of keys covers both.
+    ///
     /// Neither branch sets a `*Version` key: `URLSession` defaults to SOCKS5 on its own (confirmed
-    /// by capturing the actual bytes it sends -- a standard SOCKS5 greeting, `05 01 00`, offering
-    /// no-authentication -- not assumed from documentation, which doesn't cover this default at
+    /// by capturing the actual bytes it sends: a standard SOCKS5 greeting, `05 01 00`, offering
+    /// no-authentication, not assumed from documentation, which doesn't cover this default at
     /// all), and this executor's SOCKS support doesn't need SOCKS4's narrower feature set.
     ///
     /// `.socks` was excluded from `.urlSession` entirely until this mapping existed
-    /// (`Internals.ExecutorIncompatibilityReason.proxySOCKSUnderURLSession`, now removed) --
-    /// the original analysis called SOCKS via this dictionary "unreliable/undocumented" and
-    /// declined to attempt it. That framing didn't hold up once actually tested:
+    /// (`Internals.ExecutorIncompatibilityReason.proxySOCKSUnderURLSession`, now removed): the
+    /// original analysis called SOCKS via this dictionary "unreliable/undocumented" and declined
+    /// to attempt it. That framing didn't hold up once actually tested.
+    ///
     /// `InternalsSOCKSProxyDictionaryPlatformTests` confirms (with a negative control, not just a
     /// single positive result) that `URLSession` genuinely dials the configured SOCKS address on
     /// both macOS and an iOS Simulator, and `InternalsURLSessionClientSOCKSProxyTests`
@@ -121,13 +123,14 @@ extension Internals.Proxy {
     /// and actually carries traffic end to end.
     ///
     /// Verified working on macOS for non-loopback destinations (confirmed with a real listener
-    /// standing in for the proxy) -- see `InternalsProxyDictionaryPlatformTests` for the
-    /// up-to-date per-platform picture. **Not**
-    /// provable the same way against `127.0.0.1`/`localhost` targets specifically: macOS bypasses
-    /// any configured proxy for loopback destinations as a matter of OS policy, independent of
-    /// this mapping being correct -- `LocalServer`/`LocalHTTPConnectProxy`-based round trips in
-    /// `InternalsURLSessionClientProxyTests` document that gap specifically, they are not
-    /// evidence against this mapping.
+    /// standing in for the proxy); see `InternalsProxyDictionaryPlatformTests` for the
+    /// up-to-date per-platform picture.
+    ///
+    /// **Not** provable the same way against `127.0.0.1`/`localhost` targets specifically: macOS
+    /// bypasses any configured proxy for loopback destinations as a matter of OS policy,
+    /// independent of this mapping being correct. `LocalServer`/`LocalHTTPConnectProxy`-based
+    /// round trips in `InternalsURLSessionClientProxyTests` document that gap specifically; they
+    /// are not evidence against this mapping.
     package func buildConnectionProxyDictionary() -> [AnyHashable: Any] {
         switch connectionProtocol {
         case .http:

--- a/Sources/RequestDLInternals/Sources/Session/Proxy/Internals.SystemProxyResolver.swift
+++ b/Sources/RequestDLInternals/Sources/Session/Proxy/Internals.SystemProxyResolver.swift
@@ -24,9 +24,9 @@ extension Internals {
     /// `AsyncHTTPClient` has no discovery of its own: its proxy is explicit configuration and
     /// nothing else. `URLSession` goes through CFNetwork, which reads the system settings, and
     /// that difference is why an interception proxy such as Proxyman or Charles captures one
-    /// and not the other. Both executors go through this same resolver -- including proxy
-    /// auto-configuration (PAC) scripts, evaluated via `Internals.PACEvaluator`/
-    /// `Internals.PACProxyCache` -- so `SystemProxy()` behaves identically regardless of which
+    /// and not the other. Both executors go through this same resolver, including proxy
+    /// auto-configuration (PAC) scripts evaluated via `Internals.PACEvaluator`/
+    /// `Internals.PACProxyCache`, so `SystemProxy()` behaves identically regardless of which
     /// executor a session resolves to.
     package enum SystemProxyResolver {
 
@@ -69,7 +69,7 @@ extension Internals.SystemProxyResolver {
         }
     }
 
-    /// What one entry in a CFNetwork proxy-list dictionary resolves to -- shared between the
+    /// What one entry in a CFNetwork proxy-list dictionary resolves to: shared between the
     /// direct `CFNetworkCopyProxiesForURL` result here and a PAC script's own evaluated result
     /// (`Internals.PACEvaluator`), since both use the identical dictionary shape.
     package enum Resolution: Sendable, Equatable {
@@ -79,12 +79,12 @@ extension Internals.SystemProxyResolver {
         case proxy(Internals.Proxy)
         /// A PAC script still needs to be fetched and evaluated
         /// (`kCFProxyTypeAutoConfigurationURL`) before a proxy (or direct connection) is known.
-        /// Never itself produced by evaluating a PAC script -- CFNetwork's own guarantee that a
+        /// Never itself produced by evaluating a PAC script: CFNetwork's own guarantee that a
         /// script cannot chain to another PAC file.
         case autoConfiguration(URL)
     }
 
-    /// Walks `proxies` and returns the first entry this package recognizes -- `.direct` ends the
+    /// Walks `proxies` and returns the first entry this package recognizes: `.direct` ends the
     /// search outright (later entries are fallbacks for a failed proxy, not alternatives), an
     /// unrecognized or unparseable entry is skipped in favor of the next one.
     package static func firstResolution(in proxies: [[String: Any]]) -> Resolution? {

--- a/Sources/RequestDLInternals/Sources/Session/Session Configuration/Internals.Session.Configuration.swift
+++ b/Sources/RequestDLInternals/Sources/Session/Session Configuration/Internals.Session.Configuration.swift
@@ -19,12 +19,13 @@ extension Internals.Session {
         package var proxy: Internals.Proxy?
         package var ignoreUncleanSSLShutdown: Bool = false
 
-        /// The tracer RequestDL itself uses to instrument requests -- started, ended, and populated
+        /// The tracer RequestDL itself uses to instrument requests: started, ended, and populated
         /// with attributes by `RawTask.result()`, not handed to `async-http-client`.
+        ///
         /// `async-http-client`'s own built-in tracing (`HTTPClient.Configuration.tracing.tracer`) is
         /// unconditionally suppressed in `build()` below: its span-start reads `ServiceContext
         /// .current` only after hopping onto a SwiftNIO `EventLoop`, which loses Swift's task-locals
-        /// and makes it impossible to parent the span correctly -- RequestDL owns the whole span
+        /// and makes it impossible to parent the span correctly. RequestDL owns the whole span
         /// lifecycle itself instead, one layer up, entirely within the caller's own task.
         ///
         /// Defaults to a no-op tracer rather than inheriting ambient global state: RequestDL's API is
@@ -36,18 +37,21 @@ extension Internals.Session {
         /// `Internals.Proxy.connectHeaders` being excluded from `Hashable`.
         package var tracer: any Tracer = NoOpTracer()
 
-        /// Off by default on every platform -- decompression is opt-in, matching the fact that
-        /// the risky posture is decompressing unbounded, not leaving compressed bytes alone. This
-        /// used to differ on Apple platforms, matching URLSession's own forced, unconditional
-        /// auto-decompression there -- that divergence only existed because there was no way to
-        /// turn URLSession's transparent decoding off. `requiresManualURLSessionHandling` below
-        /// now takes over `Accept-Encoding` (`identity`) to get real `.disabled` parity on
-        /// `.urlSession` too, so the two platforms no longer need different defaults.
+        /// Off by default on every platform: decompression is opt-in, matching the fact that
+        /// the risky posture is decompressing unbounded, not leaving compressed bytes alone.
+        ///
+        /// This used to differ on Apple platforms, matching URLSession's own forced,
+        /// unconditional auto-decompression there; that divergence only existed because there
+        /// was no way to turn URLSession's transparent decoding off.
+        ///
+        /// `requiresManualURLSessionHandling` below now takes over `Accept-Encoding` (`identity`)
+        /// to get real `.disabled` parity on `.urlSession` too, so the two platforms no longer
+        /// need different defaults.
         package var decompression: Internals.Decompression = .disabled
 
         package var dnsOverride: [String: String] = [:]
 
-        /// Renamed from the old `networkFrameworkWaitForConnectivity` -- no longer a straight
+        /// Renamed from the old `networkFrameworkWaitForConnectivity`: no longer a straight
         /// forward to AsyncHTTPClient's own field of that name (which only took effect on
         /// NIOTransportServices). Consumed by `Internals.NetworkPathGate` instead, via
         /// `networkPathConstraints`, uniformly across every executor. See `build()`.
@@ -62,14 +66,14 @@ extension Internals.Session {
         package var maximumConcurrentConnections: Int?
 
         /// Soft hint: reorders `resolveExecutor()`'s pick among the executors this configuration
-        /// is already compatible with -- never forces one it isn't. `nil` leaves the default
+        /// is already compatible with; never forces one it isn't. `nil` leaves the default
         /// priority order (`.urlSession` › `.nioTransportServices` › `.nio`) untouched. See
         /// `Session.preferredExecutor(_:)`.
         package var preferredExecutor: Internals.Executor?
 
         /// Hard pin: `requireExecutor(_:)` throws `IncompatibleExecutorConfigurationError` rather
         /// than falling back when this is set and the configuration can't actually run on it.
-        /// `nil` means no pin -- resolution is free to fall back. See
+        /// `nil` means no pin: resolution is free to fall back. See
         /// `Session.requiredExecutor(_:)`.
         package var requiredExecutor: Internals.Executor?
 
@@ -117,7 +121,7 @@ extension Internals.Session {
                 configuration.httpVersion = httpVersion.build()
             }
 
-            // Always suppressed here, regardless of `tracer` above -- see the doc comment on that
+            // Always suppressed here, regardless of `tracer` above; see the doc comment on that
             // property for why `async-http-client`'s own built-in tracing is never engaged.
             configuration.tracing.tracer = NoOpTracer()
 
@@ -173,7 +177,7 @@ extension Internals.Session.Configuration {
     }
 
     /// The bucket-D fields that keep a configuration off `.urlSession` regardless of what
-    /// `secureConnection` allows -- these are AsyncHTTPClient/HTTP-layer concerns orthogonal to
+    /// `secureConnection` allows: these are AsyncHTTPClient/HTTP-layer concerns orthogonal to
     /// which TLS transport is underneath, so they're checked here rather than on `SecureConnection`.
     package func urlSessionIncompatibilityReasons() -> [Internals.ExecutorIncompatibilityReason] {
         var reasons = secureConnection?.urlSessionIncompatibilityReasons() ?? []
@@ -202,12 +206,14 @@ extension Internals.Session.Configuration {
     /// The mirror image of `urlSessionIncompatibilityReasons()`: fields that keep a configuration
     /// off `.nio`/`.nioTransportServices` instead of off `.urlSession`. Today just a
     /// `Decompressor.requiresURLSession` algorithm (`BrotliURLSessionOnlyAlgorithm`, or a
-    /// third-party one answering the same way) -- neither NIO-backed executor goes through
-    /// CFNetwork, and `NIOHTTPCompression` has no decoder for whatever such an algorithm stands
-    /// in for, so there is no fallback of any kind for them to reach.
+    /// third-party one answering the same way).
+    ///
+    /// Neither NIO-backed executor goes through CFNetwork, and `NIOHTTPCompression` has no
+    /// decoder for whatever such an algorithm stands in for, so there is no fallback of any kind
+    /// for them to reach.
     ///
     /// - Important: Only consulted by `requireExecutor(_:)`, deliberately not by
-    /// `resolveExecutor()` -- see that method's own doc comment for why automatic resolution
+    /// `resolveExecutor()`; see that method's own doc comment for why automatic resolution
     /// tolerates this instead of failing over it.
     package func nonURLSessionExecutorIncompatibilityReasons() -> [Internals.ExecutorIncompatibilityReason] {
         guard
@@ -221,8 +227,8 @@ extension Internals.Session.Configuration {
     }
 
     /// `nil` when none of the four network-availability knobs were touched, so `RawTask.result()`
-    /// can skip `Internals.NetworkPathGate` -- and therefore skip ever starting
-    /// `Internals.NetworkPathMonitor` -- entirely for sessions that never use this API.
+    /// can skip `Internals.NetworkPathGate`, and therefore skip ever starting
+    /// `Internals.NetworkPathMonitor`, entirely for sessions that never use this API.
     package var networkPathConstraints: Internals.NetworkPathGate.Constraints? {
         guard
             allowsCellularAccess != nil
@@ -264,7 +270,7 @@ extension Internals.Session.Configuration: Equatable {
             && lhs.enableNetworkFramework == rhs.enableNetworkFramework
             && lhs.maximumConcurrentConnections == rhs.maximumConcurrentConnections
             // `preferredExecutor` is a soft hint, so two configurations differing only there could
-            // arguably still share a pooled client -- but `requiredExecutor` is a hard pin, and
+            // arguably still share a pooled client, but `requiredExecutor` is a hard pin, and
             // `Internals.ClientManager` uses this `==` as its pooled-client cache key
             // (`item.sessionConfiguration == sessionConfiguration`). Omitting either would let a
             // request pinned to one executor silently reuse a pooled client resolved for another,
@@ -279,40 +285,45 @@ extension Internals.Session.Configuration {
 
     /// Picks the best executor this configuration actually supports, in priority order.
     ///
-    /// URLSession is tried first on Apple platforms -- best OS integration (background transfers,
-    /// ATS, HTTP/3 maturity) -- then NIOTransportServices, then plain NIO as the universal
+    /// URLSession is tried first on Apple platforms (best OS integration: background transfers,
+    /// ATS, HTTP/3 maturity), then NIOTransportServices, then plain NIO as the universal
     /// fallback. `.urlSession` and `.nioTransportServices` are independent capability checks, not
     /// a hierarchy: a field can be reachable on one and not the other (see
     /// `urlSessionIncompatibilityReasons()`/`SecureConnection.networkFrameworkIncompatibilityReasons()`).
-    /// This is a default ordering, not a fixed law -- `preferredExecutor`/`requiredExecutor`
+    /// This is a default ordering, not a fixed law: `preferredExecutor`/`requiredExecutor`
     /// (public API) let a caller override it.
     ///
     /// - Important: `requiredExecutor`, when set, is returned unconditionally, without
-    /// re-checking compatibility here -- that check already happened, and already threw if it
+    /// re-checking compatibility here: that check already happened, and already threw if it
     /// failed, in `requireExecutor(_:)` (called separately, before this, by `RawTask.result()`).
     /// A caller that reaches this method with `requiredExecutor` set and never called
-    /// `requireExecutor(_:)` first bypasses that guarantee -- same contract `Internals.ClientManager
+    /// `requireExecutor(_:)` first bypasses that guarantee; same contract `Internals.ClientManager
     /// .resolvedClient(provider:sessionConfiguration:)`'s own callers already have to honor.
     ///
     /// - Important: `enableNetworkFramework(true)` (`Session.enableNetworkFramework(_:)`, already
     /// public/released API predating `preferredExecutor`) is treated as an implicit
-    /// `preferredExecutor(.nioTransportServices)` when nothing else already set one. Needed
-    /// because this method's own NIOTransportServices-vs-plain-NIO answer now actually drives a
-    /// real request (rather than only `enableNetworkFramework`, read independently by
-    /// `Internals.ClientManager.client(provider:sessionConfiguration:)`): without the implicit
-    /// preference, `.urlSession`'s default first-priority position would otherwise silently take
-    /// over for anyone calling only `enableNetworkFramework(true)` -- a transport switch neither
-    /// this flag's existing callers nor its own doc comment ever signed up for. An explicit
-    /// `preferredExecutor` (any case, including `.urlSession`) still wins over this implicit one.
+    /// `preferredExecutor(.nioTransportServices)` when nothing else already set one.
+    ///
+    /// This is needed because this method's own NIOTransportServices-vs-plain-NIO answer now
+    /// actually drives a real request (rather than only `enableNetworkFramework`, read
+    /// independently by `Internals.ClientManager.client(provider:sessionConfiguration:)`):
+    /// without the implicit preference, `.urlSession`'s default first-priority position would
+    /// otherwise silently take over for anyone calling only `enableNetworkFramework(true)`, a
+    /// transport switch neither this flag's existing callers nor its own doc comment ever
+    /// signed up for.
+    ///
+    /// An explicit `preferredExecutor` (any case, including `.urlSession`) still wins over this
+    /// implicit one.
     ///
     /// - Important: A `Decompressor.requiresURLSession` algorithm (`BrotliURLSessionOnlyAlgorithm`)
     /// is deliberately **not** checked here. Automatic resolution has no explicit instruction to
     /// honor, so it degrades gracefully instead of failing a request outright over an algorithm
     /// that may never even be exercised (the response might never actually come back `br`-encoded
-    /// at all) -- worst case, `.nio`/`.nioTransportServices` gets picked and the existing
+    /// at all): worst case, `.nio`/`.nioTransportServices` gets picked and the existing
     /// manual-dispatch machinery reports the mismatch only if and when a `br` response actually
     /// arrives, exactly as it already does for every other unresolvable `Content-Encoding`.
-    /// `requireExecutor(_:)` is the one that enforces this eagerly -- an explicit
+    ///
+    /// `requireExecutor(_:)` is the one that enforces this eagerly: an explicit
     /// `.requiredExecutor(_:)` pin is a deliberate instruction, and honoring it silently despite a
     /// guaranteed failure would be the same silent-degradation bug class #289 already fixed for
     /// every other field here.
@@ -328,7 +339,7 @@ extension Internals.Session.Configuration {
         let effectivePreferredExecutor = preferredExecutor ?? (enableNetworkFramework ? .nioTransportServices : nil)
 
         // `effectivePreferredExecutor` only ever reorders among the candidates the two checks
-        // above already say are compatible -- it is never consulted on its own, and never
+        // above already say are compatible: it is never consulted on its own, and never
         // returned without the matching compatibility check passing first. `.nio` needs no such
         // check: it is the universal fallback (see this method's own `- Important` note above for
         // the one field that's still allowed to fail later rather than block that fallback here).
@@ -358,7 +369,7 @@ extension Internals.Session.Configuration {
     ///
     /// This is the direct fix for the bug class #289 closed: NIOTransportServices used to
     /// silently drop settings it couldn't carry over instead of failing loudly. A caller pinning
-    /// an executor explicitly is asking for a guarantee, not a best-effort -- ignoring what it
+    /// an executor explicitly is asking for a guarantee, not a best-effort: ignoring what it
     /// can't do here would just move that same silent-degradation bug to a new call site.
     package func requireExecutor(_ executor: Internals.Executor) throws {
         let reasons: [Internals.ExecutorIncompatibilityReason]
@@ -423,7 +434,7 @@ extension NIOSSL.TLSVersion {
 
 extension Internals.Session.Configuration {
 
-    /// `URLSession` counterpart to `build() -> HTTPClient.Configuration` -- built fresh per
+    /// `URLSession` counterpart to `build() -> HTTPClient.Configuration`: built fresh per
     /// `Internals.URLSessionClient` instance, mirroring how `build()` is also called once per
     /// `Internals.Client`.
     ///
@@ -449,24 +460,28 @@ extension Internals.Session.Configuration {
     /// Compression is environment/`Payload`-driven, carried on `RequestConfiguration` rather than
     /// pooled per session, so there's no field on this type for it to translate.
     /// `RequestConfiguration.applyCompression()` compresses `RequestBody` itself, once, before
-    /// either this method or `RequestConfiguration.build(eventLoop:)` ever runs -- every executor
+    /// either this method or `RequestConfiguration.build(eventLoop:)` ever runs: every executor
     /// receives an already-compressed body, so there is nothing left for this method to translate.
     func buildURLSessionConfiguration() -> URLSessionConfiguration {
         let configuration = URLSessionConfiguration.ephemeral
 
-        // `.ephemeral` only means "don't persist to disk" -- it still ships a real, if small,
+        // `.ephemeral` only means "don't persist to disk": it still ships a real, if small,
         // in-memory `URLCache` and defaults `requestCachePolicy` to `.useProtocolCachePolicy`,
         // which independently interprets standard HTTP caching semantics (including request
         // directives like `Cache-Control: only-if-cached`) against that cache before a request
-        // ever reaches the network. `Internals.CacheControl`/`DataCache` already own caching
-        // entirely on RequestDL's side; a second, invisible cache layer underneath URLSession
-        // does nothing useful and actively conflicts with it -- an `only-if-cached` request
-        // RequestDL's own logic correctly decided should hit the network (nothing configured
-        // locally to serve it from) would otherwise fail outright with `NSURLErrorDomain` -2000
-        // ("can't load from network"), since URLSession's own cache has nothing either and
-        // `.useProtocolCachePolicy` refuses to fall through past that. Ignoring URLSession's
-        // cache unconditionally routes every request to the network, where RequestDL's own
-        // cache/strategy logic already decided whether it should run at all.
+        // ever reaches the network.
+        //
+        // `Internals.CacheControl`/`DataCache` already own caching entirely on RequestDL's side;
+        // a second, invisible cache layer underneath URLSession does nothing useful and actively
+        // conflicts with it: an `only-if-cached` request RequestDL's own logic correctly decided
+        // should hit the network (nothing configured locally to serve it from) would otherwise
+        // fail outright with `NSURLErrorDomain` -2000 ("can't load from network"), since
+        // URLSession's own cache has nothing either and `.useProtocolCachePolicy` refuses to
+        // fall through past that.
+        //
+        // Ignoring URLSession's cache unconditionally routes every request to the network,
+        // where RequestDL's own cache/strategy logic already decided whether it should run at
+        // all.
         configuration.requestCachePolicy = .reloadIgnoringLocalCacheData
 
         if let read = timeout.read {

--- a/Sources/RequestDLInternals/Sources/Session/Session Configuration/Models/Internals.Compression+Encode.swift
+++ b/Sources/RequestDLInternals/Sources/Session/Session Configuration/Models/Internals.Compression+Encode.swift
@@ -10,7 +10,7 @@ import NIOPosix
 
 extension Internals.Compression.Algorithm {
 
-    /// The wire name this algorithm's `Content-Encoding` value takes -- `NIOCompression
+    /// The wire name this algorithm's `Content-Encoding` value takes: `NIOCompression
     /// .Algorithm`'s own `description`, so this always matches whatever `NIOHTTPRequestCompressor`
     /// itself would have written into the header.
     package var contentEncodingValue: String {
@@ -21,44 +21,50 @@ extension Internals.Compression.Algorithm {
 extension Internals {
 
     /// Compresses through the same codec `NIOHTTPRequestCompressor` applies on the wire for the
-    /// `.nio` executor -- driven through a persistent `EmbeddedChannel` rather than a live
+    /// `.nio` executor, driven through a persistent `EmbeddedChannel` rather than a live
     /// connection pipeline, so it can be fed incrementally, one `callAsFunction(compressing:)`
     /// call per chunk, across the lifetime of a single request, rather than only in one big
     /// write-all/read-all round trip.
     ///
-    /// Reusing the handler itself -- rather than binding `CNIOExtrasZlib` directly, which isn't a
-    /// public product of `swift-nio-extras` -- keeps this byte-for-byte identical to what
+    /// Reusing the handler itself (rather than binding `CNIOExtrasZlib` directly, which isn't a
+    /// public product of `swift-nio-extras`) keeps this byte-for-byte identical to what
     /// `NIOHTTPRequestCompressor` running in a live connection pipeline would produce.
     ///
     /// - Important: `EmbeddedChannel`/`EmbeddedEventLoop` require every call to happen on the
     /// exact OS thread that created them. This type is driven from
     /// `Internals.CompressingByteSequence.AsyncIterator.next()`, which resumes after each `await
     /// sourceIterator.next()` on whatever thread Swift Concurrency's
-    /// cooperative pool happens to pick, not necessarily the one that created this stream. Every
-    /// touch of `channel` is therefore routed through `eventLoop` -- one real, persistent-thread
-    /// loop captured once at `init` -- so `channel` is always created and always operated on that
-    /// same single thread no matter which thread `callAsFunction`/`finish` themselves get called
-    /// from. `CompressorStream` is a synchronous protocol (mirroring the public, sync-by-design
-    /// `RequestDL.CompressorStream`), so this hops over with a blocking `.wait()` rather than
-    /// `async`/`await` -- safe here because `eventLoop` is backed by a genuine OS thread entirely
-    /// outside Swift Concurrency's cooperative pool, and each call is a microsecond-scale zlib
-    /// operation, not a real wait.
+    /// cooperative pool happens to pick, not necessarily the one that created this stream.
     ///
-    /// - Important: Thread affinity isn't only a concern for the calls above -- `EmbeddedChannel`
+    /// Every touch of `channel` is therefore routed through `eventLoop` (one real,
+    /// persistent-thread loop captured once at `init`), so `channel` is always created and
+    /// always operated on that same single thread no matter which thread `callAsFunction`/
+    /// `finish` themselves get called from.
+    ///
+    /// `CompressorStream` is a synchronous protocol (mirroring the public, sync-by-design
+    /// `RequestDL.CompressorStream`), so this hops over with a blocking `.wait()` rather than
+    /// `async`/`await`. That's safe here because `eventLoop` is backed by a genuine OS thread
+    /// entirely outside Swift Concurrency's cooperative pool, and each call is a
+    /// microsecond-scale zlib operation, not a real wait.
+    ///
+    /// - Important: Thread affinity isn't only a concern for the calls above: `EmbeddedChannel`
     /// itself does real work in `deinit` (resolving its close promise), which also asserts the
-    /// creating thread. Ordinarily `finish()` is always the last thing that happens to a stream
+    /// creating thread.
+    ///
+    /// Ordinarily `finish()` is always the last thing that happens to a stream
     /// (see `Internals.CompressingByteSequence.AsyncIterator.next()`), and it already nils out
     /// `Box.channel` from within its own `eventLoop.submit`, so the *stored* reference is gone
-    /// before this value (or the existential box wrapping it) is ever deallocated off-thread. But
-    /// if a request is cancelled or fails mid-upload, `finish()` may never run, and ARC then drops
-    /// the last reference to `Box` -- and transitively to `channel` -- from whatever thread
+    /// before this value (or the existential box wrapping it) is ever deallocated off-thread.
+    ///
+    /// But if a request is cancelled or fails mid-upload, `finish()` may never run, and ARC then
+    /// drops the last reference to `Box`, and transitively to `channel`, from whatever thread
     /// happens to release it. `Box.deinit` guards that path: it moves the one remaining reference
     /// into an `Unmanaged` handle (invisible to ARC's automatic, scope-exit release) and only
-    /// releases it from inside `eventLoop.submit`, so the *actual* deallocation -- wherever it's
-    /// triggered from -- always lands on the thread `channel` was created on.
+    /// releases it from inside `eventLoop.submit`, so the *actual* deallocation, wherever it's
+    /// triggered from, always lands on the thread `channel` was created on.
     package struct NIOHTTPCompressorStream: Internals.CompressorStream {
 
-        /// `@unchecked` -- `channel` is only ever read or mutated from inside a closure submitted
+        /// `@unchecked`: `channel` is only ever read or mutated from inside a closure submitted
         /// to `eventLoop`, i.e. always serialized onto that single thread; see the type's own doc
         /// comment for why that invariant matters here specifically.
         private final class Box: @unchecked Sendable {
@@ -82,13 +88,14 @@ extension Internals {
                 }
 
                 // `handle` is built inside this `if let` (rather than a function-scope `guard
-                // let`) so `channel`'s local, unwrapped binding goes out of scope -- releasing
-                // its own reference -- right here, before `eventLoop.submit` below ever runs.
+                // let`) so `channel`'s local, unwrapped binding goes out of scope, releasing
+                // its own reference, right here, before `eventLoop.submit` below ever runs.
                 // That leaves the `Unmanaged` retain as the *only* remaining reference, so
                 // releasing it on `eventLoop`'s thread is what actually triggers deallocation.
+                //
                 // A function-scope binding would instead stay alive until `deinit` itself
                 // returns, releasing its own reference back on whatever thread triggered this
-                // deinit in the first place -- silently reintroducing the exact bug this exists
+                // deinit in the first place: silently reintroducing the exact bug this exists
                 // to avoid.
                 var handle: UnmanagedChannelHandle?
 
@@ -107,13 +114,13 @@ extension Internals {
             }
         }
 
-        /// Thrown by `callAsFunction(compressing:)`/`finish()` if `box.channel` is already `nil`
-        /// -- reachable only if one of them is called again after `finish()` already ran, which
+        /// Thrown by `callAsFunction(compressing:)`/`finish()` if `box.channel` is already `nil`:
+        /// reachable only if one of them is called again after `finish()` already ran, which
         /// violates `CompressorStream`'s contract (a single `finish()`, last). Guards the caller
         /// mistake without a force unwrap, rather than asserting it can never happen.
         private struct ChannelAlreadyFinishedError: Error {}
 
-        /// Wraps the raw pointer `Box.deinit` hands across the `eventLoop.submit` boundary --
+        /// Wraps the raw pointer `Box.deinit` hands across the `eventLoop.submit` boundary:
         /// `UnsafeMutableRawPointer` itself isn't `Sendable` (pointers don't promise anything
         /// about what they point to), but this one is safe to move: it's a manually-retained
         /// (`Unmanaged.passRetained`) reference nothing else holds or touches concurrently, and
@@ -169,7 +176,7 @@ extension Internals {
                 _ = try? channel.finish()
 
                 // Drops the stored reference here, on `eventLoop`'s own thread, rather than
-                // leaving it for whenever/wherever this value's box eventually gets deallocated --
+                // leaving it for whenever/wherever this value's box eventually gets deallocated;
                 // see the type's own doc comment.
                 box.channel = nil
                 return result

--- a/Sources/RequestDLInternals/Sources/Session/Session Configuration/Models/Internals.Compression.swift
+++ b/Sources/RequestDLInternals/Sources/Session/Session Configuration/Models/Internals.Compression.swift
@@ -7,7 +7,7 @@ import NIOHTTPCompression
 
 extension Internals {
 
-    /// Namespace only -- compression is per-request/environment-driven, carried on
+    /// Namespace only: compression is per-request/environment-driven, carried on
     /// `RequestConfiguration` rather than pooled on the session, so there's no `.disabled`/
     /// `.enabled` state to carry here. `Algorithm` and `DuplicateHeaderBehavior` stay nested
     /// under this name to group them with the rest of the compression-related types below.
@@ -48,7 +48,7 @@ extension Internals.Compression {
 
 extension Internals {
 
-    /// Internals-layer counterpart to `RequestDL.Compressor`. Shared by both transports -- though
+    /// Internals-layer counterpart to `RequestDL.Compressor`. Shared by both transports, though
     /// unlike decompression, compression always runs through this package's own code on every
     /// executor (there is no native, OS-provided outgoing-compression equivalent to CFNetwork's
     /// transparent response decoding to defer to), so a compressor configured through the public
@@ -59,7 +59,7 @@ extension Internals {
     }
 
     /// Internals-layer counterpart to `RequestDL.CompressorStream`, operating on `ByteBuffer`
-    /// instead of `[UInt8]` -- the boundary conversion lives in the adapter that wraps a public
+    /// instead of `[UInt8]`: the boundary conversion lives in the adapter that wraps a public
     /// `Compressor`/`CompressorStream` into these.
     package protocol CompressorStream {
         mutating func callAsFunction(compressing bytes: ByteBuffer) throws -> ByteBuffer

--- a/Sources/RequestDLInternals/Sources/Session/Session Configuration/Models/Internals.Decompression.swift
+++ b/Sources/RequestDLInternals/Sources/Session/Session Configuration/Models/Internals.Decompression.swift
@@ -14,8 +14,8 @@ extension Internals {
         // MARK: - Internal properties
 
         /// Whether resolving this configuration to `.urlSession` requires this package to set its
-        /// own `Accept-Encoding` header on every request -- i.e. whether any configured algorithm
-        /// isn't one CFNetwork already decodes transparently on its own (`gzip`/`deflate`/`br`).
+        /// own `Accept-Encoding` header on every request: whether any configured algorithm isn't
+        /// one CFNetwork already decodes transparently on its own (`gzip`/`deflate`/`br`).
         ///
         /// `.disabled` also needs this: URLSession's automatic decoding can only be switched off
         /// by taking over `Accept-Encoding` ourselves (`identity`), the same mechanism a genuinely
@@ -45,13 +45,15 @@ extension Internals {
 
         /// `async-http-client`'s own native gzip/deflate decoder strips `Content-Encoding` once it
         /// successfully decodes a response (see `NIOHTTPResponseDecompressor`), so enabling it
-        /// whenever a natively-decoded algorithm is anywhere in the configured list is always safe
-        /// -- whatever it leaves untouched (a custom algorithm, or nothing at all) is exactly what
-        /// manual dispatch downstream is for. Unlike `.urlSession`, there is no all-or-nothing
-        /// constraint here: `NIOHTTPResponseDecompressor` only ever reacts to a `Content-Encoding:
-        /// gzip`/`deflate` response, so it can stay on alongside manual dispatch for anything else.
+        /// whenever a natively-decoded algorithm is anywhere in the configured list is always safe:
+        /// whatever it leaves untouched (a custom algorithm, or nothing at all) is exactly what
+        /// manual dispatch downstream is for.
         ///
-        /// - Important: Gated on `isNativelyDecodedByNIO`, not `contentEncodingValue` --
+        /// Unlike `.urlSession`, there is no all-or-nothing constraint here. `NIOHTTPResponseDecompressor`
+        /// only ever reacts to a `Content-Encoding: gzip`/`deflate` response, so it can stay on
+        /// alongside manual dispatch for anything else.
+        ///
+        /// - Important: Gated on `isNativelyDecodedByNIO`, not `contentEncodingValue`, since
         /// `NIOHTTPResponseDecompressor` is a single switch triggered purely by the response's own
         /// header, with no notion of which algorithm instance was configured. A genuinely custom
         /// algorithm that happens to declare `contentEncodingValue == "gzip"` must not enable this,
@@ -74,12 +76,14 @@ extension Internals {
 extension Internals.Decompression: Equatable {
 
     /// `any Internals.DecompressionAlgorithm` has no equality of its own, so this compares what
-    /// actually drives observable behavior -- the set of `Content-Encoding` values configured,
-    /// plus the limit -- rather than instance identity. Two configurations with the same set
-    /// produce byte-identical `HTTPClient.Configuration`/`Accept-Encoding` output, so treating
-    /// them as equal keeps the common case (plain `.gzip`/`.deflate`) pooling connections the way
-    /// it always has, instead of paying `RedirectConfiguration.strategy`'s "never equal, fresh
-    /// client every time" cost for a case that doesn't need it.
+    /// actually drives observable behavior (the set of `Content-Encoding` values configured,
+    /// plus the limit) rather than instance identity.
+    ///
+    /// Two configurations with the same set produce byte-identical
+    /// `HTTPClient.Configuration`/`Accept-Encoding` output, so treating them as equal keeps the
+    /// common case (plain `.gzip`/`.deflate`) pooling connections the way it always has, instead
+    /// of paying `RedirectConfiguration.strategy`'s "never equal, fresh client every time" cost
+    /// for a case that doesn't need it.
     package static func == (_ lhs: Self, _ rhs: Self) -> Bool {
         switch (lhs, rhs) {
         case (.disabled, .disabled):

--- a/Sources/RequestDLInternals/Sources/Session/Session Configuration/Models/Internals.DecompressionAlgorithm.swift
+++ b/Sources/RequestDLInternals/Sources/Session/Session Configuration/Models/Internals.DecompressionAlgorithm.swift
@@ -7,51 +7,54 @@ import NIOCore
 extension Internals {
 
     /// Internals-layer counterpart to `RequestDL.Decompressor`. Shared by both transports so a
-    /// decompressor configured through the public protocol behaves identically under either --
-    /// see `Internals.Decompression` for how each executor actually consumes this.
+    /// decompressor configured through the public protocol behaves identically under either.
+    /// See `Internals.Decompression` for how each executor actually consumes this.
     package protocol DecompressionAlgorithm: Sendable {
         var contentEncodingValue: String { get }
 
-        /// Mirrors `RequestDL.Decompressor.requiresURLSession` -- see
+        /// Mirrors `RequestDL.Decompressor.requiresURLSession`. See
         /// `Internals.Session.Configuration.nonURLSessionExecutorIncompatibilityReasons()` for
         /// what configuring one of these actually does to executor resolution.
         var requiresURLSession: Bool { get }
 
         /// Whether CFNetwork decodes this *specific algorithm* transparently under `.urlSession`,
-        /// with no way to opt out short of taking over `Accept-Encoding` entirely -- see
+        /// with no way to opt out short of taking over `Accept-Encoding` entirely. See
         /// `Internals.Decompression.requiresManualURLSessionHandling`.
         ///
-        /// Deliberately a per-conformer answer, not a check against `contentEncodingValue` --
+        /// Deliberately a per-conformer answer, not a check against `contentEncodingValue`.
         /// `InternalsDecompressionAlgorithmAdapter` (in `RequestDL`) overrides this to `true` only
         /// for the exact built-in types (`GzipAlgorithm`, `DeflateAlgorithm`,
         /// `BrotliURLSessionOnlyAlgorithm`) that are themselves nothing but placeholders standing
-        /// in for CFNetwork's own decoding. A genuinely custom `Decompressor` that happens to
-        /// declare `contentEncodingValue == "gzip"` is not one of those -- its whole point is to
-        /// run its own logic, so this must default to `false` for it, forcing manual dispatch
-        /// (and thus actually invoking it) rather than silently deferring to CFNetwork the same
-        /// way the built-in placeholder would.
+        /// in for CFNetwork's own decoding.
+        ///
+        /// A genuinely custom `Decompressor` that happens to declare
+        /// `contentEncodingValue == "gzip"` is not one of those: its whole point is to run its
+        /// own logic, so this must default to `false` for it, forcing manual dispatch (and thus
+        /// actually invoking it) rather than silently deferring to CFNetwork the same way the
+        /// built-in placeholder would.
         var isNativelyDecodedByURLSession: Bool { get }
 
         /// Whether `async-http-client`'s own `NIOHTTPResponseDecompressor` decodes this *specific
-        /// algorithm* transparently under `.nio`/`.nioTransportServices` -- see
+        /// algorithm* transparently under `.nio`/`.nioTransportServices`. See
         /// `Internals.Decompression.build()`.
         ///
         /// Same reasoning as `isNativelyDecodedByURLSession`, and the same structural, per-type
         /// check in `InternalsDecompressionAlgorithmAdapter` (`GzipAlgorithm`/`DeflateAlgorithm`
-        /// only -- `NIOHTTPCompression` has no brotli decoder at all, so
-        /// `BrotliURLSessionOnlyAlgorithm` is never natively decoded here). A custom `Decompressor`
-        /// declaring `contentEncodingValue == "gzip"` must default to `false`: `async-http-client`'s
-        /// decompressor is a single switch triggered purely by the response's own
-        /// `Content-Encoding` header, with no notion of which algorithm instance was configured,
-        /// so leaving it on for a wire value a custom algorithm claims would decode the response
-        /// out from under it before manual dispatch ever got a chance to run.
+        /// only: `NIOHTTPCompression` has no brotli decoder at all, so
+        /// `BrotliURLSessionOnlyAlgorithm` is never natively decoded here).
+        ///
+        /// A custom `Decompressor` declaring `contentEncodingValue == "gzip"` must default to
+        /// `false`: `async-http-client`'s decompressor is a single switch triggered purely by the
+        /// response's own `Content-Encoding` header, with no notion of which algorithm instance
+        /// was configured, so leaving it on for a wire value a custom algorithm claims would
+        /// decode the response out from under it before manual dispatch ever got a chance to run.
         var isNativelyDecodedByNIO: Bool { get }
 
         func callAsFunction() throws -> any Internals.DecompressorStream
     }
 
     /// Internals-layer counterpart to `RequestDL.DecompressorStream`, operating on `ByteBuffer`
-    /// instead of `[UInt8]` -- the boundary conversion lives in the adapter that wraps a public
+    /// instead of `[UInt8]`; the boundary conversion lives in the adapter that wraps a public
     /// `Decompressor`/`DecompressorStream` into these.
     package protocol DecompressorStream {
         mutating func callAsFunction(decompressing bytes: ByteBuffer) throws -> ByteBuffer

--- a/Sources/RequestDLInternals/Sources/Session/Session Configuration/Models/Internals.Executor.swift
+++ b/Sources/RequestDLInternals/Sources/Session/Session Configuration/Models/Internals.Executor.swift
@@ -7,7 +7,7 @@ extension Internals {
     /// The transport a `Session` ultimately executes a request through.
     ///
     /// Three independent capability checks decide which executor a given configuration can run
-    /// on -- `.urlSession` and `.nioTransportServices` are not a strict hierarchy of each other,
+    /// on: `.urlSession` and `.nioTransportServices` are not a strict hierarchy of each other,
     /// since some fields are reachable on one and not the other. `.nio` is the universal
     /// fallback: every configuration is compatible with it.
     package enum Executor: Sendable, Hashable {

--- a/Sources/RequestDLInternals/Sources/Session/Session Configuration/Models/Internals.ExecutorIncompatibilityReason.swift
+++ b/Sources/RequestDLInternals/Sources/Session/Session Configuration/Models/Internals.ExecutorIncompatibilityReason.swift
@@ -7,7 +7,7 @@ extension Internals {
     /// One entry per configuration field that keeps a session off a given executor.
     ///
     /// Named per field, not per executor, since the same field can be fine on one executor and
-    /// not another -- the `*IncompatibilityReasons()` functions decide which of these apply for
+    /// not another: the `*IncompatibilityReasons()` functions decide which of these apply for
     /// which executor.
     package enum ExecutorIncompatibilityReason: Sendable, Hashable {
         case keyLogger

--- a/Sources/RequestDLInternals/Sources/Session/Session Configuration/Models/Internals.IncompatibleExecutorConfigurationError.swift
+++ b/Sources/RequestDLInternals/Sources/Session/Session Configuration/Models/Internals.IncompatibleExecutorConfigurationError.swift
@@ -7,7 +7,7 @@ extension Internals {
     /// Thrown when a `requireExecutor(_:)` call is pinned to an `Executor` the session's
     /// configuration cannot actually run on.
     ///
-    /// `RequestDL`'s public `ExecutorRequirementError` -- the documented, user-facing error --
+    /// `RequestDL`'s public `ExecutorRequirementError` (the documented, user-facing error)
     /// lives in the `RequestDL` module and cannot be referenced from here, since `RequestDL`
     /// depends on this module rather than the other way around. Callers catch this at the same
     /// site the session bootstraps and rewrap it into `ExecutorRequirementError`.

--- a/Sources/RequestDLInternals/Sources/Session/Session Configuration/Models/Internals.MultipathServiceType.swift
+++ b/Sources/RequestDLInternals/Sources/Session/Session Configuration/Models/Internals.MultipathServiceType.swift
@@ -8,7 +8,7 @@ extension Internals {
     /// exposes a plain on/off `enableMultipath` flag on `HTTPClient.Configuration`, with no
     /// equivalent to the handover/interactive/aggregate distinction, so the collapse to `Bool`
     /// happens inline as `self != .none` at the one call site that needs it
-    /// (`Internals.Session.Configuration.build()`) rather than through a `build()` method here --
+    /// (`Internals.Session.Configuration.build()`) rather than through a `build()` method here:
     /// that mapping is lossy (4 cases to 1), not a 1:1 translation like the other `Internals`
     /// enums in this file's sibling models.
     package enum MultipathServiceType: Sendable, Hashable {

--- a/Sources/RequestDLInternals/Sources/Session/Session Configuration/Models/Internals.NIORedirectStrategyAdapter.swift
+++ b/Sources/RequestDLInternals/Sources/Session/Session Configuration/Models/Internals.NIORedirectStrategyAdapter.swift
@@ -12,7 +12,7 @@ extension Internals {
     /// directly from its own redirect delegate.
     ///
     /// - Important: Only `url`/`method`/`headers` round-trip through `Internals.RedirectRequest`.
-    /// `HTTPClientRequest.body` -- along with everything else `HTTPClientRequest` carries -- is
+    /// `HTTPClientRequest.body` (along with everything else `HTTPClientRequest` carries) is
     /// taken from AsyncHTTPClient's own candidate request untouched, since
     /// `Internals.RedirectRequest` has no supported way to replace it (see
     /// ``Internals/RedirectRequest/hasBody``).
@@ -30,7 +30,7 @@ extension Internals {
             let decision = try strategy.redirectDecision(
                 for: .init(
                     redirectRequest: .init(context.redirectRequest),
-                    // `context.response` is the response of `history`'s last entry -- see
+                    // `context.response` is the response of `history`'s last entry: see
                     // `HTTPClientRedirectContext`'s own doc comment ("the full per-request
                     // `history`... including the one that produced [the response]").
                     response: .init(context.response, url: history.last?.request.url ?? ""),

--- a/Sources/RequestDLInternals/Sources/Session/Session Configuration/Models/Internals.NetworkPath.swift
+++ b/Sources/RequestDLInternals/Sources/Session/Session Configuration/Models/Internals.NetworkPath.swift
@@ -7,7 +7,7 @@ extension Internals {
     /// A platform-agnostic snapshot of a network path's availability characteristics.
     ///
     /// Exists because `Network.framework`'s own `NWPath` has no public initializer, so nothing
-    /// built directly on it could be exercised by a fake in a unit test --
+    /// built directly on it could be exercised by a fake in a unit test.
     /// ``Internals/NetworkPathGate`` and ``Internals/NetworkPathObserving`` are written against
     /// this type instead, never against `NWPath` directly.
     package struct NetworkPath: Sendable, Equatable {

--- a/Sources/RequestDLInternals/Sources/Session/Session Configuration/Models/Internals.NetworkPathGate.swift
+++ b/Sources/RequestDLInternals/Sources/Session/Session Configuration/Models/Internals.NetworkPathGate.swift
@@ -9,7 +9,7 @@ extension Internals {
     /// since AsyncHTTPClient has no hook to configure the equivalent `NWParameters` itself (see
     /// swift-server/async-http-client#915 and #918, both closed with no path forward).
     ///
-    /// Pre-flight only, checked once before the request is dispatched -- never re-evaluated once
+    /// Pre-flight only, checked once before the request is dispatched, never re-evaluated once
     /// a transfer is under way. This matches `URLSession` itself: `waitsForConnectivity`/
     /// `taskIsWaitingForConnectivity` only ever cover the initial connection phase, and a network
     /// change mid-transfer surfaces there as an ordinary task error, not a retry. So this is
@@ -83,8 +83,8 @@ extension Internals {
         // MARK: - Private static methods
 
         /// The single source of truth for whether `path` satisfies `constraints`: `nil` means it
-        /// does, any other value names the first constraint it violates, checked in this order --
-        /// connectivity, then cellular, then expensive, then constrained.
+        /// does, any other value names the first constraint it violates, checked in this order
+        /// (connectivity, then cellular, then expensive, then constrained).
         private static func reason(
             for path: NetworkPath,
             _ constraints: Constraints

--- a/Sources/RequestDLInternals/Sources/Session/Session Configuration/Models/Internals.NetworkPathObserving.swift
+++ b/Sources/RequestDLInternals/Sources/Session/Session Configuration/Models/Internals.NetworkPathObserving.swift
@@ -5,7 +5,7 @@
 extension Internals {
 
     /// What ``Internals/NetworkPathGate`` needs from a network path source, independent of
-    /// `Network.framework` -- implemented by `Internals.NetworkPathMonitor` on Darwin, and by
+    /// `Network.framework`, implemented by `Internals.NetworkPathMonitor` on Darwin, and by
     /// fakes in tests, so the gate's wait/fail logic can be exercised without ever touching a
     /// real `NWPathMonitor`.
     package protocol NetworkPathObserving: Sendable {
@@ -17,7 +17,7 @@ extension Internals {
         /// the new subscriber and then yielding every subsequent change. Ends when the
         /// subscribing task is cancelled.
         ///
-        /// - Note: `_Concurrency.AsyncStream`, explicitly qualified -- an unqualified reference here
+        /// - Note: `_Concurrency.AsyncStream`, explicitly qualified: an unqualified reference here
         /// would resolve to `Internals.AsyncStream` instead, a throwing, replay-everything type
         /// meant for one-shot response bodies, a poor fit for a long-lived, ever-changing path
         /// signal.

--- a/Sources/RequestDLInternals/Sources/Session/Session Configuration/Models/Internals.RedirectConfiguration.swift
+++ b/Sources/RequestDLInternals/Sources/Session/Session Configuration/Models/Internals.RedirectConfiguration.swift
@@ -12,7 +12,7 @@ extension Internals {
         case follow(max: Int, allowCycles: Bool)
 
         /// Redirects are handed to a pluggable ``Internals/RedirectStrategy``. There is no
-        /// built-in redirect-count/cycle limit in this mode -- it replaces, not composes with,
+        /// built-in redirect-count/cycle limit in this mode: it replaces, not composes with,
         /// `.follow`'s limits, mirroring `AsyncHTTPClient.HTTPClient.Configuration
         /// .RedirectConfiguration.strategy(_:)`, which this bridges to for the NIO executor. See
         /// `RequestDL.RedirectStrategy` for why.
@@ -35,7 +35,7 @@ extension Internals {
 
 // MARK: - Equatable
 
-// `.strategy` carries an existential with no meaningful notion of equality, so -- like `NaN` --
+// `.strategy` carries an existential with no meaningful notion of equality, so, like `NaN`,
 // a `.strategy` value is never equal to any other value, including another `.strategy`. This is
 // deliberate, matching AsyncHTTPClient's own `RedirectConfiguration.Mode`: a `Session` carrying a
 // `.strategy` never matches a previously pooled client's `Internals.Session.Configuration` by

--- a/Sources/RequestDLInternals/Sources/Session/Session Configuration/Models/Internals.RedirectRequest.swift
+++ b/Sources/RequestDLInternals/Sources/Session/Session Configuration/Models/Internals.RedirectRequest.swift
@@ -6,7 +6,7 @@ import NIOHTTP1
 
 extension Internals {
 
-    /// Internals-layer counterpart to `RequestDL.RedirectRequest` -- see it for the meaning of
+    /// Internals-layer counterpart to `RequestDL.RedirectRequest`. See it for the meaning of
     /// each property. Kept apart because `RequestDL.HTTPHeaders` lives one layer up and cannot be
     /// referenced from here.
     package struct RedirectRequest: Sendable {

--- a/Sources/RequestDLInternals/Sources/Session/Session Configuration/Models/Internals.ResourceDeadline.swift
+++ b/Sources/RequestDLInternals/Sources/Session/Session Configuration/Models/Internals.ResourceDeadline.swift
@@ -12,7 +12,7 @@ import struct Foundation.DispatchTime
 
 extension Internals {
 
-    /// Races one async operation against ``Timeout/Source/resource``'s deadline -- unlike
+    /// Races one async operation against ``Timeout/Source/resource``'s deadline. Unlike
     /// `connect`/`read` (per-phase timeouts AsyncHTTPClient enforces on its own), a resource
     /// timeout bounds the whole request end to end (connection, redirects, and the entire body
     /// transfer), the same way `URLSessionConfiguration.timeoutIntervalForResource` does.
@@ -23,11 +23,13 @@ extension Internals {
 
         // MARK: - Private properties
 
-        // Monotonic, not wall clock -- same rationale as `Internals.Storage`/`Internals.ClientManager`:
-        // a `Date`-based deadline moves if the user or NTP moves the system clock, and this must not
-        // advance while the device is suspended either way. `ContinuousClock` needs macOS 13/iOS 16/
-        // tvOS 16/watchOS 9, newer than this package's macOS 12/iOS 15/tvOS 15/watchOS 8 floor, so
-        // Darwin uses `DispatchTime.now().uptimeNanoseconds` instead; everywhere else already gets
+        // Monotonic, not wall clock: same rationale as `Internals.Storage`/`Internals.ClientManager`
+        // uses. A `Date`-based deadline moves if the user or NTP moves the system clock, and this
+        // must not advance while the device is suspended either way.
+        //
+        // `ContinuousClock` needs macOS 13/iOS 16/tvOS 16/watchOS 9, newer than this package's
+        // macOS 12/iOS 15/tvOS 15/watchOS 8 floor, so Darwin uses
+        // `DispatchTime.now().uptimeNanoseconds` instead; everywhere else already gets
         // `ContinuousClock` at whatever Swift version is available.
         #if canImport(Darwin)
         private let deadlineUptimeNanoseconds: UInt64?
@@ -39,7 +41,7 @@ extension Internals {
 
         /// - Parameter nanoseconds: `Internals.Timeout.resource`, measured from *now*. `nil`
         /// disables racing entirely, so `race(seed:_:)` becomes a plain `await` with no task-group
-        /// overhead -- the case every request without `.resource` configured takes.
+        /// overhead: the path every request without `.resource` configured takes.
         package init(nanoseconds: Int64?) {
             #if canImport(Darwin)
             deadlineUptimeNanoseconds = nanoseconds.map { DispatchTime.now().uptimeNanoseconds &+ UInt64($0) }
@@ -53,8 +55,8 @@ extension Internals {
         /// Runs `operation`, cancelling it (and `seed`, if given) and throwing
         /// ``ResourceTimeoutError`` if the deadline passes first.
         ///
-        /// - Parameter seed: Cancelled on timeout in addition to `operation`'s own task --
-        /// `operation`'s cancellation alone only stops *this* particular await; a `TaskSeed` is
+        /// - Parameter seed: Cancelled on timeout in addition to `operation`'s own task, since
+        /// `operation`'s cancellation alone only stops *this* particular await. A `TaskSeed` is
         /// what actually tears down the underlying connection or stream, exactly as if the caller
         /// had cancelled or dropped the response themselves. `nil` before a `TaskSeed` exists yet
         /// (the initial connect/redirect phase, before `RawTask` has a `SessionTask` to cancel).
@@ -67,12 +69,13 @@ extension Internals {
                 return try await operation()
             }
 
-            // A deadline that's already passed before `operation` even starts must not race it --
+            // A deadline that's already passed before `operation` even starts must not race it.
             // `Task.sleep(nanoseconds: 0)` below still goes through a real scheduler hop, so a fast
             // enough `operation` (a loopback request under `.urlSession`, say) can win that race
-            // and complete anyway, silently keeping a budget that was already spent. Checked here,
-            // synchronously, so "already elapsed" is deterministic instead of a coin flip between
-            // two child tasks' relative scheduling.
+            // and complete anyway, silently keeping a budget that was already spent.
+            //
+            // Checked here, synchronously, so "already elapsed" is deterministic instead of a coin
+            // flip between two child tasks' relative scheduling.
             guard DispatchTime.now().uptimeNanoseconds < deadlineUptimeNanoseconds else {
                 seed?()
                 throw ResourceTimeoutError()
@@ -116,7 +119,7 @@ extension Internals {
     }
 
     /// The internal marker `RawTask` catches and rewraps into `RequestDL`'s public
-    /// `ResourceTimeoutError` -- mirrors the split `NetworkAvailabilityError`/
+    /// `ResourceTimeoutError`. This mirrors the split `NetworkAvailabilityError`/
     /// `Internals.NetworkPathUnsatisfiedError` already uses.
     package struct ResourceTimeoutError: Swift.Error, Sendable {
         package init() {}

--- a/Sources/RequestDLInternals/Sources/Session/Session Configuration/Models/Internals.Timeout.swift
+++ b/Sources/RequestDLInternals/Sources/Session/Session Configuration/Models/Internals.Timeout.swift
@@ -10,15 +10,15 @@ extension Internals {
 
         // MARK: - Internal properties
 
-        /// Nanoseconds, matching `UnitTime.nanoseconds` -- `RequestDL`'s public unit of time.
+        /// Nanoseconds, matching `UnitTime.nanoseconds` (`RequestDL`'s public unit of time).
         package var connect: Int64?
 
-        /// Nanoseconds, matching `UnitTime.nanoseconds` -- `RequestDL`'s public unit of time.
+        /// Nanoseconds, matching `UnitTime.nanoseconds` (`RequestDL`'s public unit of time).
         package var read: Int64?
 
-        /// Nanoseconds, matching `UnitTime.nanoseconds` -- `RequestDL`'s public unit of time.
+        /// Nanoseconds, matching `UnitTime.nanoseconds` (`RequestDL`'s public unit of time).
         ///
-        /// Unlike `connect`/`read`, this isn't part of `HTTPClient.Configuration.Timeout` -- no
+        /// Unlike `connect`/`read`, this isn't part of `HTTPClient.Configuration.Timeout`: no
         /// AsyncHTTPClient knob covers a resource-wide deadline, so `build()` below doesn't
         /// forward it. `RawTask` reads it directly to drive `Internals.ResourceDeadline` instead.
         package var resource: Int64?

--- a/Sources/RequestDLInternals/Sources/Session/Session/Internals.Session.swift
+++ b/Sources/RequestDLInternals/Sources/Session/Session/Internals.Session.swift
@@ -42,7 +42,7 @@ extension Internals {
         /// `client()` above hands back unconditionally.
         ///
         /// Returns `Internals.ClientManager.Client` (the enum), not `any RequestExecutingClient`,
-        /// because that protocol -- and both concrete conformances -- live in the `RequestDL`
+        /// because that protocol, and both concrete conformances, live in the `RequestDL`
         /// module, which depends on this one (`RequestDLInternals`), not the other way around.
         /// `RawTask.result()`, in `RequestDL`, is what actually unwraps this into the protocol
         /// existential it needs.
@@ -53,13 +53,14 @@ extension Internals {
             )
         }
 
-        /// Forwards to `Internals.Client.execute(request:url:readingMode:uploadingBytes:cache:logger:)`
-        /// -- kept here, with this exact signature, only because it already has direct test
+        /// Forwards to `Internals.Client.execute(request:url:readingMode:uploadingBytes:cache:logger:)`.
+        /// Kept here, with this exact signature, only because it already has direct test
         /// callers (`SessionExecutionTests`, `LocalServerConcurrencyTests`,
-        /// `InternalsClientResponseReceiverTests`); the actual implementation moved onto
-        /// `Internals.Client` itself, since this method's body never touched `self`
-        /// (`provider`/`configuration`/`manager`) to begin with -- only `client`, taken as a
-        /// parameter.
+        /// `InternalsClientResponseReceiverTests`).
+        ///
+        /// The actual implementation moved onto `Internals.Client` itself, since this method's
+        /// body never touched `self` (`provider`/`configuration`/`manager`) to begin with, only
+        /// `client`, taken as a parameter.
         package func execute(
             client: Internals.Client,
             request: HTTPClient.Request,

--- a/Sources/RequestDLInternals/Sources/Session/Session/Models/Internals.ClientResponseReceiver.swift
+++ b/Sources/RequestDLInternals/Sources/Session/Session/Models/Internals.ClientResponseReceiver.swift
@@ -241,15 +241,16 @@ extension Internals {
         }
 
         /// Fails the streams as though the request had failed before this delegate was ever
-        /// invoked -- the outcome of a pre-flight rejection (`HTTPClient.Task.failedTask`, used
+        /// invoked: the outcome of a pre-flight rejection (`HTTPClient.Task.failedTask`, used
         /// e.g. for `.invalidRedirectConfiguration`/`.alreadyShutdown`), which resolves the
-        /// task's own `futureResult` without calling any delegate method. Left alone, that
-        /// failure is silent: this delegate never learns the request is over, so `head`/
-        /// `upload`/`download` never close and whoever is awaiting them hangs forever.
+        /// task's own `futureResult` without calling any delegate method.
+        ///
+        /// Left alone, that failure is silent: this delegate never learns the request is over,
+        /// so `head`/`upload`/`download` never close and whoever is awaiting them hangs forever.
         ///
         /// Guarded by the same lock/state machine as every real callback, so it is a no-op once
-        /// the delegate has actually been driven -- exactly the case a pre-flight rejection never
-        /// reaches, since it calls this delegate zero times.
+        /// the delegate has actually been driven, which is exactly the case a pre-flight
+        /// rejection never reaches, since it calls this delegate zero times.
         package func failIfNotStarted(_ error: Error) {
             decide {
                 guard _state == .idle, _reference == .none else {

--- a/Sources/RequestDLInternals/Sources/Session/Session/Models/Internals.ResponseHead.swift
+++ b/Sources/RequestDLInternals/Sources/Session/Session/Models/Internals.ResponseHead.swift
@@ -29,7 +29,7 @@ extension Internals {
         /// A single name-value header pair.
         ///
         /// `RequestDL.HTTPHeaders` is the rich, order-preserving representation `RequestDL`
-        /// exposes publicly, but it lives in the `RequestDL` module, which depends on this one --
+        /// exposes publicly, but it lives in the `RequestDL` module, which depends on this one,
         /// so `ResponseHead`, used throughout the transport layer, carries headers as a plain
         /// `Codable` array of pairs instead. `RequestDL` converts to/from its own `HTTPHeaders`
         /// at the boundary.

--- a/Sources/RequestDLInternals/Sources/Session/Session/Models/Internals.TaskCancelledError.swift
+++ b/Sources/RequestDLInternals/Sources/Session/Session/Models/Internals.TaskCancelledError.swift
@@ -6,12 +6,12 @@ extension Internals {
 
     /// A `SessionTask` was released or cancelled before its response was fully consumed.
     ///
-    /// Transport-neutral on purpose -- fires from `Internals.CacheControl`'s cache-hit path
-    /// (`makeCachedSession`) when the caller walks away
-    /// before reading a cached response, which has nothing to do with which executor a cache
-    /// *miss* would have run a real request on. Previously named `HTTPClientError.cancelled`
-    /// there, an AsyncHTTPClient-specific type with no reason to appear on a path that never
-    /// touches the network at all.
+    /// Transport-neutral on purpose: fires from `Internals.CacheControl`'s cache-hit path
+    /// (`makeCachedSession`) when the caller walks away before reading a cached response, which
+    /// has nothing to do with which executor a cache *miss* would have run a real request on.
+    ///
+    /// Previously named `HTTPClientError.cancelled` there, an AsyncHTTPClient-specific type with
+    /// no reason to appear on a path that never touches the network at all.
     package struct TaskCancelledError: Error, Sendable {
         package init() {}
     }

--- a/Sources/RequestDLInternals/Sources/Session/Session/Models/SessionTask.swift
+++ b/Sources/RequestDLInternals/Sources/Session/Session/Models/SessionTask.swift
@@ -7,7 +7,7 @@ import NIOCore
 /// A completed session's cancellation seed together with its response.
 ///
 /// Holds `Internals.AsyncResponse` rather than converting it into `RequestDL`'s
-/// public `AsyncResponse` wrapper here -- that wrapper is a `RequestDL`-domain concept,
+/// public `AsyncResponse` wrapper here, since that wrapper is a `RequestDL`-domain concept,
 /// so building it from `seed`/`response` is left to `RequestDL`'s own call sites.
 package struct SessionTask: Sendable {
 

--- a/Tests/RequestDLInternalsTests/Sources/Body/Models/InternalsBodySequenceTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Body/Models/InternalsBodySequenceTests.swift
@@ -230,8 +230,8 @@ struct InternalsBodySequenceTests {
 
     @Test
     func bodySequence_whenMultipleBuffersIncludingAFile_wholeFileURLReturnsNil() async throws {
-        // Given -- mirrors the multipart shape `bodySequence_whenReadingConcurrently...` above
-        // builds: a real request body is never *only* the file once there's more than one part.
+        // Given: mirrors the multipart shape `bodySequence_whenReadingConcurrently...` above
+        // builds; a real request body is never *only* the file once there's more than one part.
         let fileURLManager = try await InternalsFileBufferTests.FileURLManager()
         defer { _ = fileURLManager }
 

--- a/Tests/RequestDLInternalsTests/Sources/Buffers/File/InternalsFileBufferTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Buffers/File/InternalsFileBufferTests.swift
@@ -871,7 +871,7 @@ struct InternalsFileBufferTests {
 
     @Test
     func fileBuffer_whenBackedByRealFileUnread_wholeFileURLReturnsThatFile() async throws {
-        // Given -- a real, non-temporary file (constructed from an explicit `URL`, not one of
+        // Given: a real, non-temporary file (constructed from an explicit `URL`, not one of
         // the no-URL initializers that all go through `Internals.FileBufferURL.temporaryURL`).
         let fileURLManager = try await FileURLManager()
         defer { _ = fileURLManager }
@@ -888,7 +888,7 @@ struct InternalsFileBufferTests {
 
     @Test
     func fileBuffer_whenReaderIndexAdvanced_wholeFileURLReturnsNil() async throws {
-        // Given -- uploading straight from the file at this point would read more than this
+        // Given: uploading straight from the file at this point would read more than this
         // cursor has left, so the shortcut must decline once anything has been read.
         let fileURLManager = try await FileURLManager()
         defer { _ = fileURLManager }
@@ -907,9 +907,10 @@ struct InternalsFileBufferTests {
 
     @Test
     func fileBuffer_whenBackedByATemporaryResource_wholeFileURLReturnsNil() async throws {
-        // Given -- every no-URL initializer opens over `Internals.FileBufferURL.temporaryURL`,
-        // a file this package owns and may remove once nothing references it any more, so
-        // handing its `URL` to an unrelated, longer-lived caller (a `URLSessionUploadTask`)
+        // Given: every no-URL initializer opens over `Internals.FileBufferURL.temporaryURL`,
+        // a file this package owns and may remove once nothing references it any more.
+        //
+        // Handing its `URL` to an unrelated, longer-lived caller (a `URLSessionUploadTask`)
         // would be unsafe even though the reader index is untouched.
         let fileBuffer = await Internals.FileBuffer(Data("Hello world".utf8))
 

--- a/Tests/RequestDLInternalsTests/Sources/Client/Client Manager/InternalsClientManagerExecutorTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Client/Client Manager/InternalsClientManagerExecutorTests.swift
@@ -15,10 +15,11 @@ import NIOTransportServices
 
 /// `Internals.ClientManager.resolvedClient(provider:sessionConfiguration:)` actually selects and
 /// caches an `Internals.URLSessionClient` for a configuration `resolveExecutor()` picks
-/// `.urlSession` for, rather than that decision staying abstract. Distinct from
-/// `RequestConfigurationURLSessionClientTests` (`RequestDLTests`), which
+/// `.urlSession` for, rather than that decision staying abstract.
+///
+/// Distinct from `RequestConfigurationURLSessionClientTests` (`RequestDLTests`), which
 /// forces `.urlSession` by hand-building `Internals.URLSessionClient` directly and bypasses
-/// `Internals.ClientManager` entirely -- these tests are the ones that would fail if
+/// `Internals.ClientManager` entirely: these tests are the ones that would fail if
 /// `resolvedClient` merely inspected `resolveExecutor()` without ever building/caching a real
 /// client behind it.
 struct InternalsClientManagerExecutorTests {
@@ -30,7 +31,7 @@ struct InternalsClientManagerExecutorTests {
         let provider = Internals.SharedSessionProvider()
         let sessionConfiguration = Internals.Session.Configuration()
 
-        // `resolveExecutor()` alone only says what *could* run -- the point of this suite is
+        // `resolveExecutor()` alone only says what *could* run. The point of this suite is
         // confirming `resolvedClient` actually built and cached the client that decision points
         // to, not just returned a matching enum case with nothing behind it.
         #expect(sessionConfiguration.resolveExecutor() == .urlSession)
@@ -101,11 +102,11 @@ struct InternalsClientManagerExecutorTests {
 
     @Test
     func resolvedClient_whenConfigurationIsIncompatibleWithURLSession_fallsBackToNIO() async throws {
-        // Given -- a DNS override is excluded from `.urlSession` (bucket D; `URLSessionConfiguration`
+        // Given: a DNS override is excluded from `.urlSession` (bucket D; `URLSessionConfiguration`
         // has no equivalent to hook one in), so `resolveExecutor()` must fall through to
         // `.nio`/`.nioTransportServices`, and `resolvedClient` must cache a `.nio` entry rather
-        // than a `.urlSession` one. (A SOCKS proxy used to be this test's example -- no longer
-        // incompatible, see `InternalsSessionConfigurationExecutorTests
+        // than a `.urlSession` one. (A SOCKS proxy used to be this test's example, but it's no
+        // longer incompatible; see `InternalsSessionConfigurationExecutorTests
         // .configuration_whenSOCKSProxySet_doesNotContainReason`.)
         let manager = Internals.ClientManager(lifetime: .seconds(5 * 60))
         let provider = Internals.SharedSessionProvider()
@@ -128,13 +129,14 @@ struct InternalsClientManagerExecutorTests {
         }
     }
 
-    /// Regression coverage for the `enableNetworkFramework`/executor unification --
+    /// Regression coverage for the `enableNetworkFramework`/executor unification:
     /// `resolvedClient`'s `.nio` fallback branch used to always call
     /// `client(provider:sessionConfiguration:)` unmodified, which decides
     /// NIOTransportServices-vs-plain-NIO purely from the `enableNetworkFramework` flag, never from
     /// `resolveExecutor()`'s own (correct) answer. `preferredExecutor(.nioTransportServices)`
     /// therefore had zero effect on which event loop group backed a real client.
-    /// `enableNetworkFramework` is never set here at all -- proving this is `resolveExecutor()`'s
+    ///
+    /// `enableNetworkFramework` is never set here at all, proving this is `resolveExecutor()`'s
     /// decision alone, not the flag's.
     @Test
     func
@@ -194,7 +196,7 @@ struct InternalsClientManagerExecutorTests {
     }
 }
 
-/// Test-only stand-in for the real TLS challenge handling -- see the identical delegate in
+/// Test-only stand-in for the real TLS challenge handling; see the identical delegate in
 /// `InternalsURLSessionClientTests`/`RequestConfigurationURLSessionClientTests` for why this
 /// exists at all: `LocalServer` is always TLS-terminated with a throwaway self-signed
 /// certificate.

--- a/Tests/RequestDLInternalsTests/Sources/Client/Throttled Executor/InternalsThrottledExecutorTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Client/Throttled Executor/InternalsThrottledExecutorTests.swift
@@ -19,7 +19,7 @@ struct InternalsThrottledExecutorTests {
     }
 
     /// Mirrors `InternalsClientConcurrencyLimitTests`, but against the hoisted throttling logic
-    /// directly rather than through `Internals.Client` -- the wrapper any future concrete client
+    /// directly rather than through `Internals.Client`, the wrapper any future concrete client
     /// shares this gating behavior through.
     @Test
     func acquire_whenLimited_gatesConcurrentAcquisitions() async throws {

--- a/Tests/RequestDLInternalsTests/Sources/Client/URLSession Client/Identity/InternalsRawBytesIdentityBuilderTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Client/URLSession Client/Identity/InternalsRawBytesIdentityBuilderTests.swift
@@ -173,10 +173,10 @@ struct InternalsRawBytesIdentityBuilderTests {
 
     @Test(arguments: [Self.Curve.p256, .p384, .p521])
     func secKey_whenGivenPKCS8WrappedECDER_succeeds(_ curve: Self.Curve) throws {
-        // `CryptoKit`'s own `derRepresentation` -- confirmed PKCS#8 (a `SEQUENCE` containing an
-        // `INTEGER` then a nested `SEQUENCE` AlgorithmIdentifier, not SEC1's `OCTET STRING`), not
-        // assumed -- is exactly what a real caller exporting a CryptoKit-generated key would hand
-        // this executor.
+        // `CryptoKit`'s own `derRepresentation` is confirmed PKCS#8, not merely assumed to be: a
+        // `SEQUENCE` containing an `INTEGER` then a nested `SEQUENCE` AlgorithmIdentifier, not
+        // SEC1's `OCTET STRING`. That's exactly what a real caller exporting a
+        // CryptoKit-generated key would hand this executor.
         let der = curve.generateAndExportPKCS8DER()
 
         let secKey = try Internals.RawBytesIdentityBuilder.secKey(fromDER: der)
@@ -252,7 +252,7 @@ extension InternalsRawBytesIdentityBuilderTests {
         (SecKeyCopyAttributes(secKey) as? [CFString: Any])?[kSecAttrKeySizeInBits] as? Int
     }
 
-    /// A fresh, ephemeral 2048-bit RSA key's PKCS#1 DER, generated purely in memory --
+    /// A fresh, ephemeral 2048-bit RSA key's PKCS#1 DER, generated purely in memory:
     /// `kSecAttrIsPermanent` is deliberately left unset, so nothing here touches the Keychain.
     fileprivate static func makeRSAPKCS1DER() throws -> Data {
         var error: Unmanaged<CFError>?

--- a/Tests/RequestDLInternalsTests/Sources/Client/URLSession Client/InternalsURLSessionClientCookieTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Client/URLSession Client/InternalsURLSessionClientCookieTests.swift
@@ -18,7 +18,7 @@ import Security
 /// resolves to never silently changes behavior across requests sharing that session.
 ///
 /// `LocalServer.HTTPHandler` echoes back whatever `Cookie` header it actually received
-/// (`HTTPResult.receivedCookieHeader`) -- the only way to prove the *second* request didn't
+/// (`HTTPResult.receivedCookieHeader`): the only way to prove the *second* request didn't
 /// resend a cookie the *first* response set is to ask the server what it saw, not just what the
 /// client sent (which this test has no independent way to inspect).
 struct InternalsURLSessionClientCookieTests {
@@ -73,7 +73,7 @@ struct InternalsURLSessionClientCookieTests {
     }
 }
 
-/// Test-only stand-in for the real client's own TLS challenge handling -- see the identical
+/// Test-only stand-in for the real client's own TLS challenge handling. See the identical
 /// delegate in the other `Internals.URLSessionClient` test files for why this exists at all:
 /// `LocalServer` is always TLS-terminated with a throwaway self-signed certificate.
 private final class AcceptAnyServerTrustDelegate: NSObject, URLSessionTaskDelegate, @unchecked Sendable {

--- a/Tests/RequestDLInternalsTests/Sources/Client/URLSession Client/InternalsURLSessionClientProxyTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Client/URLSession Client/InternalsURLSessionClientProxyTests.swift
@@ -19,16 +19,18 @@ import Security
 /// **This suite's round trips only fail to pass on macOS and Mac Catalyst, for a reason unrelated
 /// to whether the mapping is correct:** `LocalServer`/`LocalHTTPConnectProxy` always bind to
 /// `localhost`, and macOS/Catalyst specifically bypass a configured proxy for `localhost` (by
-/// name) as OS-level policy -- confirmed directly, and precisely, in
+/// name) as OS-level policy, confirmed directly, and precisely, in
 /// `InternalsProxyDictionaryPlatformTests`, which is where the actual mapping-correctness proof
-/// and the full per-platform matrix live, not here. iOS, tvOS, watchOS, and visionOS Simulators
-/// do **not** bypass `localhost`, so these round trips genuinely pass there -- `withKnownIssue`
-/// below is conditioned on platform (`when:`) to match, rather than unconditionally expecting
-/// failure. If `LocalServer` ever stops being loopback-only, or Apple ever changes the
-/// macOS/Catalyst policy, these would need revisiting, not the mapping itself.
+/// and the full per-platform matrix live, not here.
 ///
-/// There was no pre-existing NIO-backend proxy round-trip suite to reuse -- `ProxyTests` and
-/// `InternalsProxyTests` only cover config mapping, never an actual proxied connection -- so
+/// iOS, tvOS, watchOS, and visionOS Simulators do **not** bypass `localhost`, so these round trips
+/// genuinely pass there; `withKnownIssue` below is conditioned on platform (`when:`) to match,
+/// rather than unconditionally expecting failure. If `LocalServer` ever stops being loopback-only,
+/// or Apple ever changes the macOS/Catalyst policy, these would need revisiting, not the mapping
+/// itself.
+///
+/// There was no pre-existing NIO-backend proxy round-trip suite to reuse: `ProxyTests` and
+/// `InternalsProxyTests` only cover config mapping, never an actual proxied connection.
 /// `LocalHTTPConnectProxy` exists specifically to make this checkable at all, for either executor.
 struct InternalsURLSessionClientProxyTests {
 
@@ -72,7 +74,7 @@ struct InternalsURLSessionClientProxyTests {
             delegate: AcceptAnyServerTrustDelegate()
         )
 
-        // Then -- expected to fail only on macOS/Catalyst (see the type doc comment); genuinely
+        // Then: expected to fail only on macOS/Catalyst (see the type doc comment); genuinely
         // passes elsewhere, reaching the destination and decoding `output`.
         try withKnownIssue(
             "macOS/Catalyst bypass a configured proxy for localhost -- see the type doc comment",
@@ -122,7 +124,7 @@ struct InternalsURLSessionClientProxyTests {
             delegate: AcceptAnyServerTrustDelegate()
         )
 
-        // Then -- expected to fail only on macOS/Catalyst (see the type doc comment); genuinely
+        // Then: expected to fail only on macOS/Catalyst (see the type doc comment); genuinely
         // passes elsewhere, reaching the destination and decoding `output`.
         try withKnownIssue(
             "macOS/Catalyst bypass a configured proxy for localhost -- see the type doc comment",
@@ -139,13 +141,13 @@ struct InternalsURLSessionClientProxyTests {
     }
 
     /// `URLSessionConfiguration.connectionProxyDictionary` left `nil` (its own default) means
-    /// "inherit whatever the OS's Network preferences currently say" -- `Internals.URLSessionClient`
+    /// "inherit whatever the OS's Network preferences currently say": `Internals.URLSessionClient`
     /// must explicitly set it to `[:]` when no `Proxy`/resolved `SystemProxy` is configured, or the
     /// documented "system proxy is ignored unless opted into" contract (`RequestDL.SystemProxy`'s
     /// own doc comment) silently breaks on this executor while still holding on the NIO one.
     ///
-    /// `URLSessionConfiguration` is a class, so the same instance passed in is what `init` mutates
-    /// -- inspecting it after construction directly observes what `Internals.URLSessionClient`
+    /// `URLSessionConfiguration` is a class, so the same instance passed in is what `init` mutates;
+    /// inspecting it after construction directly observes what `Internals.URLSessionClient`
     /// actually did, no need to reach into the private `URLSession` it built from it.
     @Test
     func init_whenNoProxyConfigured_explicitlyDisablesConnectionProxyDictionary() throws {
@@ -156,13 +158,13 @@ struct InternalsURLSessionClientProxyTests {
         // When
         _ = try Internals.URLSessionClient(configuration: configuration)
 
-        // Then -- explicitly `[:]`, not still `nil`: a `nil ?? [:]` fallback in the assertion
+        // Then: explicitly `[:]`, not still `nil`. A `nil ?? [:]` fallback in the assertion
         // itself would pass either way, defeating the point of this test.
         #expect(configuration.connectionProxyDictionary?.isEmpty == true)
     }
 }
 
-/// Test-only stand-in for the real client's own TLS challenge handling -- see the identical
+/// Test-only stand-in for the real client's own TLS challenge handling. See the identical
 /// delegate in the other `Internals.URLSessionClient` test files for why this exists at all:
 /// `LocalServer` is always TLS-terminated with a throwaway self-signed certificate.
 private final class AcceptAnyServerTrustDelegate: NSObject, URLSessionTaskDelegate, @unchecked Sendable {

--- a/Tests/RequestDLInternalsTests/Sources/Client/URLSession Client/InternalsURLSessionClientRedirectStrategyTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Client/URLSession Client/InternalsURLSessionClientRedirectStrategyTests.swift
@@ -14,13 +14,13 @@ import Foundation
 import Security
 
 /// Covers `.strategy` mode over `.urlSession`, plus the cross-origin header stripping shared by
-/// both `.follow` and `.strategy` -- see the doc comment on `TaskDelegate.urlSession(_:task:
+/// both `.follow` and `.strategy`; see the doc comment on `TaskDelegate.urlSession(_:task:
 /// willPerformHTTPRedirection:newRequest:completionHandler:)`.
 struct InternalsURLSessionClientRedirectStrategyTests {
 
     @Test
     func execute_whenRedirectCrossOrigin_stripsSensitiveHeadersBeforeStrategySees() async throws {
-        // Given -- two different LocalServer ports count as two different origins.
+        // Given: two different LocalServer ports count as two different origins.
         let origin = try await LocalServer(.standard)
         let destination = try await LocalServer(
             .init(host: "localhost", port: 8891, option: .none)
@@ -70,7 +70,7 @@ struct InternalsURLSessionClientRedirectStrategyTests {
             delegate: AcceptAnyServerTrustDelegate()
         )
 
-        // Then -- the redirect went through to the cross-origin destination...
+        // Then: the redirect went through to the cross-origin destination...
         #expect(result.head.status.code == 200)
         let decoded = try JSONDecoder().decode(HTTPResult<String>.self, from: result.body)
         #expect(decoded.response == output)
@@ -81,15 +81,16 @@ struct InternalsURLSessionClientRedirectStrategyTests {
         #expect(!headers.contains(name: "Cookie"))
     }
 
-    /// - Note: Asserts on `Cookie` and a plain custom header, not `Authorization` --
+    /// - Note: Asserts on `Cookie` and a plain custom header, not `Authorization`:
     /// `URLSession` drops `Authorization` on *every* redirect it performs, same-origin included,
     /// as an OS-level default this type has no hook to override (confirmed empirically: swapping
-    /// this test's header to `Authorization` fails even though nothing here strips it). That is
-    /// strictly more conservative than the RFC 9110-derived, origin-only stripping this type adds
-    /// on top for `Cookie`/`Origin`/`Proxy-Authorization`, so it is not a gap.
+    /// this test's header to `Authorization` fails even though nothing here strips it).
+    ///
+    /// That is strictly more conservative than the RFC 9110-derived, origin-only stripping this
+    /// type adds on top for `Cookie`/`Origin`/`Proxy-Authorization`, so it is not a gap.
     @Test
     func execute_whenRedirectSameOrigin_preservesHeaders() async throws {
-        // Given -- both hops on the same LocalServer, so same origin.
+        // Given: both hops on the same LocalServer, so same origin.
         let localServer = try await LocalServer(.standard)
         let originPath = "/" + UUID().uuidString
         let destinationPath = "/" + UUID().uuidString
@@ -173,7 +174,7 @@ struct InternalsURLSessionClientRedirectStrategyTests {
             delegate: AcceptAnyServerTrustDelegate()
         )
 
-        // Then -- the redirect response itself, not the destination.
+        // Then: the redirect response itself, not the destination.
         #expect(result.head.status.code == 302)
         #expect(result.head.headerValues(named: "Location").first == destination)
     }
@@ -213,14 +214,14 @@ struct InternalsURLSessionClientRedirectStrategyTests {
             )
             Issue.record("Not expecting success")
         } catch is ThrowingRedirectStrategy.SomeError {
-            // Then -- expected
+            // Then: expected
         }
     }
 }
 
 // MARK: - Test doubles
 
-/// Synchronous by design -- `Internals.RedirectStrategy.redirectDecision(for:)` isn't `async`, so
+/// Synchronous by design: `Internals.RedirectStrategy.redirectDecision(for:)` isn't `async`, so
 /// capturing what it saw for later assertions must not go through anything that would let the
 /// test read it before the callback (called from URLSession's own delegate queue) has finished.
 private final class CapturedContext: Sendable {
@@ -262,9 +263,9 @@ private struct ThrowingRedirectStrategy: Internals.RedirectStrategy {
     }
 }
 
-/// Test-only stand-in for the real client's own TLS challenge handling -- see the identical
+/// Test-only stand-in for the real client's own TLS challenge handling (see the identical
 /// delegate in `InternalsURLSessionClientRedirectTests`/`InternalsURLSessionClientTests` for why
-/// this exists at all: `LocalServer` is always TLS-terminated with a throwaway self-signed
+/// this exists at all): `LocalServer` is always TLS-terminated with a throwaway self-signed
 /// certificate, on every hop of a redirect chain, not only the first request.
 private final class AcceptAnyServerTrustDelegate: NSObject, URLSessionTaskDelegate, @unchecked Sendable {
 

--- a/Tests/RequestDLInternalsTests/Sources/Client/URLSession Client/InternalsURLSessionClientRedirectTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Client/URLSession Client/InternalsURLSessionClientRedirectTests.swift
@@ -15,7 +15,7 @@ import Security
 /// `Internals.RedirectConfiguration` enforced by hand over `.urlSession`, since URLSession has
 /// no native "max redirects" / "allow cycles" concept.
 ///
-/// There was no pre-existing NIO-backend redirect round-trip suite to port from -- only unit
+/// There was no pre-existing NIO-backend redirect round-trip suite to port from: only unit
 /// tests for `Internals.RedirectConfiguration.build()`'s mapping and the `Session.enableRedirect`/
 /// `disableRedirect` modifiers existed. These assertions are instead derived directly from
 /// AsyncHTTPClient's own `RedirectState.redirect(to:)` (vendored in `async-http-client`,
@@ -74,7 +74,7 @@ struct InternalsURLSessionClientRedirectTests {
 
     @Test
     func execute_whenRedirectChainExceedsMax_throwsRedirectLimitReachedError() async throws {
-        // Given -- two redirects (origin -> hop -> destination) against a client only willing to
+        // Given: two redirects (origin -> hop -> destination) against a client only willing to
         // follow one.
         let localServer = try await LocalServer(.standard)
         let origin = "/" + UUID().uuidString
@@ -118,13 +118,13 @@ struct InternalsURLSessionClientRedirectTests {
             )
             Issue.record("Not expecting success")
         } catch is Internals.URLSessionClient.RedirectLimitReachedError {
-            // Then -- expected
+            // Then: expected
         }
     }
 
     @Test
     func execute_whenRedirectRevisitsURL_throwsRedirectCycleDetectedError() async throws {
-        // Given -- origin -> hop -> origin, a two-hop cycle back to the first URL visited.
+        // Given: origin -> hop -> origin, a two-hop cycle back to the first URL visited.
         let localServer = try await LocalServer(.standard)
         let origin = "/" + UUID().uuidString
         let hop = "/" + UUID().uuidString
@@ -160,13 +160,13 @@ struct InternalsURLSessionClientRedirectTests {
             )
             Issue.record("Not expecting success")
         } catch is Internals.URLSessionClient.RedirectCycleDetectedError {
-            // Then -- expected
+            // Then: expected
         }
     }
 
     @Test
     func execute_whenRedirectAllowsCycles_followsBackToAVisitedURL() async throws {
-        // Given -- a two-hop cycle (origin -> hop -> origin -> ...), same URIs as the cycle test
+        // Given: a two-hop cycle (origin -> hop -> origin -> ...), same URIs as the cycle test
         // above, but with `allowCycles: true`.
         let localServer = try await LocalServer(.standard)
         let origin = "/" + UUID().uuidString
@@ -176,12 +176,13 @@ struct InternalsURLSessionClientRedirectTests {
         localServer.cleanup(at: hop)
 
         // `LocalServer.ResponseQueue` hands out one queued response per hit, most-recently-
-        // inserted first, then falls back to a bare `.ok` once exhausted -- unlike the other
+        // inserted first, then falls back to a bare `.ok` once exhausted. Unlike the other
         // redirect tests here, this chain actually revisits both URIs for real (that is the
         // point: `allowCycles: true` means the redirect is *followed*, not just permitted in the
-        // abstract), so each needs as many queued copies as it is genuinely re-fetched: origin is
-        // requested at redirects 0 and 2, hop at redirects 1 and 3 -- two hits apiece before the
-        // chain fails on the count, not the revisit.
+        // abstract), so each needs as many queued copies as it is genuinely re-fetched.
+        //
+        // Origin is requested at redirects 0 and 2, hop at redirects 1 and 3: two hits apiece
+        // before the chain fails on the count, not the revisit.
         for _ in 0..<2 {
             localServer.insert(
                 LocalServer.ResponseConfiguration(status: .found, headers: ["Location": hop], data: Data()),
@@ -204,7 +205,7 @@ struct InternalsURLSessionClientRedirectTests {
             redirectConfiguration: .follow(max: 3, allowCycles: true)
         )
 
-        // When -- origin -> hop -> origin -> hop is 3 redirects, exactly at `max`; a 4th would
+        // When: origin -> hop -> origin -> hop is 3 redirects, exactly at `max`; a 4th would
         // still be within `allowCycles: true`'s revisit tolerance but would exceed `max`, so the
         // chain must fail with the limit, not the cycle, error, proving `allowCycles` actually
         // suppressed cycle detection rather than the chain never revisiting anything.
@@ -215,7 +216,7 @@ struct InternalsURLSessionClientRedirectTests {
             )
             Issue.record("Not expecting success")
         } catch is Internals.URLSessionClient.RedirectLimitReachedError {
-            // Then -- expected: cycles are tolerated, only the count still gates it
+            // Then: expected, since cycles are tolerated and only the count still gates it
         }
     }
 
@@ -251,13 +252,13 @@ struct InternalsURLSessionClientRedirectTests {
             delegate: AcceptAnyServerTrustDelegate()
         )
 
-        // Then -- the redirect response itself, not an error and not the destination.
+        // Then: the redirect response itself, not an error and not the destination.
         #expect(result.head.status.code == 302)
         #expect(result.head.headerValues(named: "Location").first == destination)
     }
 }
 
-/// Test-only stand-in for the real client's own TLS challenge handling -- see the identical
+/// Test-only stand-in for the real client's own TLS challenge handling; see the identical
 /// delegate in `InternalsURLSessionClientTests`/`RequestConfigurationURLSessionClientTests` for
 /// why this exists at all: `LocalServer` is always TLS-terminated with a throwaway self-signed
 /// certificate, on every hop of a redirect chain, not only the first request.

--- a/Tests/RequestDLInternalsTests/Sources/Client/URLSession Client/InternalsURLSessionClientSOCKSProxyTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Client/URLSession Client/InternalsURLSessionClientSOCKSProxyTests.swift
@@ -13,7 +13,7 @@ import Foundation
 import Security
 
 /// `.socks`, mapped onto `URLSessionConfiguration.connectionProxyDictionary`'s `SOCKSEnable`/
-/// `SOCKSProxy`/`SOCKSPort` keys -- the SOCKS counterpart to
+/// `SOCKSProxy`/`SOCKSPort` keys: the SOCKS counterpart to
 /// `InternalsURLSessionClientProxyTests`, proving a full SOCKS5 handshake (`LocalSOCKSProxy`, a
 /// real hand-rolled server, not just a byte-counting listener) actually carries traffic end to
 /// end, not just that `URLSession` dials the configured address
@@ -21,11 +21,13 @@ import Security
 ///
 /// **Same macOS/Catalyst-only known issue as the `.http` suite, for the same reason:**
 /// `LocalServer`/`LocalSOCKSProxy` always bind to `localhost`, and macOS/Catalyst bypass a
-/// configured proxy for `localhost` by name as OS-level policy, independent of protocol --
-/// confirmed for `.http` in `InternalsProxyDictionaryPlatformTests`, and this OS policy has no
-/// reason to distinguish SOCKS from HTTP CONNECT (both are just "is this destination proxied at
-/// all," decided before either protocol is spoken). iOS, tvOS, watchOS, and visionOS Simulators
-/// don't bypass `localhost`, so these round trips genuinely pass there.
+/// configured proxy for `localhost` by name as OS-level policy, independent of protocol. This
+/// was confirmed for `.http` in `InternalsProxyDictionaryPlatformTests`, and this OS policy has
+/// no reason to distinguish SOCKS from HTTP CONNECT (both are just "is this destination proxied
+/// at all," decided before either protocol is spoken).
+///
+/// iOS, tvOS, watchOS, and visionOS Simulators don't bypass `localhost`, so these round trips
+/// genuinely pass there.
 struct InternalsURLSessionClientSOCKSProxyTests {
 
     /// See the type doc comment, and `InternalsProxyDictionaryPlatformTests`'s file-level one, for
@@ -68,7 +70,7 @@ struct InternalsURLSessionClientSOCKSProxyTests {
             delegate: AcceptAnyServerTrustDelegate()
         )
 
-        // Then -- expected to fail only on macOS/Catalyst (see the type doc comment); genuinely
+        // Then: expected to fail only on macOS/Catalyst (see the type doc comment); genuinely
         // passes elsewhere, reaching the destination through a real SOCKS5 handshake and decoding
         // `output`.
         try withKnownIssue(
@@ -86,7 +88,7 @@ struct InternalsURLSessionClientSOCKSProxyTests {
     }
 }
 
-/// Test-only stand-in for the real client's own TLS challenge handling -- see the identical
+/// Test-only stand-in for the real client's own TLS challenge handling; see the identical
 /// delegate in the other `Internals.URLSessionClient` test files for why this exists at all:
 /// `LocalServer` is always TLS-terminated with a throwaway self-signed certificate.
 private final class AcceptAnyServerTrustDelegate: NSObject, URLSessionTaskDelegate, @unchecked Sendable {

--- a/Tests/RequestDLInternalsTests/Sources/Client/URLSession Client/InternalsURLSessionClientSessionTaskTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Client/URLSession Client/InternalsURLSessionClientSessionTaskTests.swift
@@ -12,14 +12,14 @@ import Testing
 
 import Foundation
 
-/// `Internals.URLSessionClient`'s two `SessionTask`-producing `execute` overloads -- the pieces
+/// `Internals.URLSessionClient`'s two `SessionTask`-producing `execute` overloads: the pieces
 /// `RequestExecutingClient`'s `.urlSession` conformance
 /// (`Internals.URLSessionClient+RequestExecutingClient.swift`, `RequestDLTests`) is built from.
 /// Exercised directly here, no `RawTask`/`RequestConfiguration` involved.
 ///
 /// `.concurrent(watchdogAffectedPlatformConcurrencyLimit)`/`.nonFatalWatchdog`: real network I/O
 /// against a `LocalServer`, on the same simulator runners `WatchdogAffectedPlatformConcurrencyLimit.swift`
-/// documents as prone to scheduler-contention `AsyncLock.Watchdog` false positives -- see
+/// documents as prone to scheduler-contention `AsyncLock.Watchdog` false positives; see
 /// `RequestConfigurationURLSessionClientUploadTests`'s own copy of this note for the failure mode
 /// these two traits avoid.
 @Suite(.concurrent(watchdogAffectedPlatformConcurrencyLimit), .nonFatalWatchdog)
@@ -68,7 +68,7 @@ struct InternalsURLSessionClientSessionTaskTests {
             }
         }
 
-        // Then -- a GET has no body to report progress for, so `upload` closes with nothing in
+        // Then: a GET has no body to report progress for, so `upload` closes with nothing in
         // it, same as the NIO backend's own bodyless-request behavior.
         #expect(uploadSteps.isEmpty)
 
@@ -81,7 +81,7 @@ struct InternalsURLSessionClientSessionTaskTests {
     /// Mirrors `InternalsURLSessionClientCookieTests`'s own discipline for proving a test isn't
     /// tautological: verified by temporarily removing the `downloadBuffer.cacheStream(cacheStream)`
     /// call this test depends on and confirming it fails, then restoring it and confirming it
-    /// passes again -- not shipped as two versions of the code, just how this test was checked.
+    /// passes again. Not shipped as two versions of the code, just how this test was checked.
     @Test
     func sessionTask_whenCacheProvided_teesDownloadedChunksToCache() async throws {
         // Given
@@ -131,7 +131,7 @@ struct InternalsURLSessionClientSessionTaskTests {
             }
         }
 
-        // Then -- the cache stream must close on its own once the download finishes, or
+        // Then: the cache stream must close on its own once the download finishes, or
         // `cachedChunks` above would hang forever; it does, since `Internals.DownloadBuffer`
         // closes `_cacheStream` alongside its own `stream` in `_close()`.
         let assembledDownload = downloadedChunks.reduce(Data(), +)
@@ -143,7 +143,7 @@ struct InternalsURLSessionClientSessionTaskTests {
 
     @Test
     func sessionTask_whenCancelledMidDownload_stopsRunningSoonAfter() async throws {
-        // Given -- large enough that cancelling after the first chunk still leaves real work
+        // Given: large enough that cancelling after the first chunk still leaves real work
         // in flight for cancellation to actually interrupt, not race a download that already
         // finished.
         let localServer = try await LocalServer(.standard)
@@ -182,7 +182,7 @@ struct InternalsURLSessionClientSessionTaskTests {
 
         sessionTask.seed()
 
-        // Then -- `didCompleteWithError:` (cancellation included) is what releases the
+        // Then: `didCompleteWithError:` (cancellation included) is what releases the
         // `operationQueue` slot `isRunning` reads, so this polls briefly instead of asserting
         // immediately after an async cancel with no ordering guarantee of its own.
         var stillRunning = client.isRunning
@@ -194,18 +194,20 @@ struct InternalsURLSessionClientSessionTaskTests {
         #expect(!stillRunning)
     }
 
-    /// **Used to be a confirmed `withKnownIssue`** -- the original `uploadTask(withStreamedRequest:)`
+    /// **Used to be a confirmed `withKnownIssue`.** The original `uploadTask(withStreamedRequest:)`
     /// bridge hit a confirmed CFNetwork bug (a custom `InputStream` is never recognized as
     /// reaching end-of-body); it was replaced with `Internals.URLSessionUploadFile` (small bodies
     /// stay in memory and upload
     /// via `uploadTask(with:from:)`; anything past `inMemoryThreshold` spills to a temp file and
     /// uploads via `uploadTask(with:fromFile:)`), neither of which touches `InputStream`/
-    /// `needNewBodyStream`, so neither is affected -- this test's 128 KiB payload takes the
-    /// in-memory branch. One genuine bug was found and fixed while diagnosing the old known issue,
+    /// `needNewBodyStream`, so neither is affected. This test's 128 KiB payload takes the
+    /// in-memory branch.
+    ///
+    /// One genuine bug was found and fixed while diagnosing the old known issue,
     /// independent of that fix and still in effect: `upload` was only closing from
     /// `onDownloadComplete` (task completion), not as soon as the body actually finished sending
     /// the way `Internals.ClientResponseReceiver.didReceiveHead`/`didSendRequest` close it on the
-    /// NIO side -- a live progress bar would otherwise have hung waiting for the whole download
+    /// NIO side. A live progress bar would otherwise have hung waiting for the whole download
     /// before ever hearing "upload done."
     @Test
     func sessionTask_whenStreamingUploadAndDownload_reportsUploadProgressInIncreasingOrder() async throws {
@@ -318,7 +320,7 @@ struct InternalsURLSessionClientSessionTaskTests {
     }
 }
 
-/// Test-only stand-in for the real client's own TLS challenge handling -- see the identical
+/// Test-only stand-in for the real client's own TLS challenge handling. See the identical
 /// delegate elsewhere in this suite for why this exists at all: `LocalServer` is always
 /// TLS-terminated with a throwaway self-signed certificate.
 private final class AcceptAnyServerTrustDelegate: NSObject, URLSessionTaskDelegate, @unchecked Sendable {

--- a/Tests/RequestDLInternalsTests/Sources/Client/URLSession Client/InternalsURLSessionClientTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Client/URLSession Client/InternalsURLSessionClientTests.swift
@@ -53,7 +53,7 @@ struct InternalsURLSessionClientTests {
 
     @Test
     func execute_whenMaximumConcurrentConnectionsSet_stillCompletesEveryRequest() async throws {
-        // Given -- not a concurrency-gating assertion (that lives in
+        // Given: not a concurrency-gating assertion (that lives in
         // `InternalsThrottledExecutorTests`); just confirms the client wires the cap through
         // without breaking the request itself.
         let localServer = try await LocalServer(.standard)
@@ -84,11 +84,12 @@ struct InternalsURLSessionClientTests {
     }
 
     /// `execute(request:delegate:)` bridges `dataTask(with:)` to `async`/`await` by hand
-    /// (`session.data(for:delegate:)` has a confirmed crash under load -- see the method's own
-    /// doc comment) -- unlike that Foundation API, nothing cancels the underlying
-    /// `URLSessionTask` for free just because the awaiting Swift `Task` was cancelled. This
-    /// confirms `CancellableTaskBox` actually restores that: cancelling the caller's `Task` both
-    /// makes the call throw and stops the real network request, not just the first of the two.
+    /// (`session.data(for:delegate:)` has a confirmed crash under load; see the method's own
+    /// doc comment). Unlike that Foundation API, nothing cancels the underlying
+    /// `URLSessionTask` for free just because the awaiting Swift `Task` was cancelled.
+    ///
+    /// This confirms `CancellableTaskBox` actually restores that: cancelling the caller's `Task`
+    /// both makes the call throw and stops the real network request, not just the first of the two.
     @Test
     func execute_whenTaskCancelledMidFlight_cancelsUnderlyingURLSessionTaskAndThrows() async throws {
         try await withHangingServer { port in
@@ -123,7 +124,7 @@ struct InternalsURLSessionClientTests {
     }
 }
 
-/// Test-only stand-in for the real client's own TLS challenge handling -- see the identical
+/// Test-only stand-in for the real client's own TLS challenge handling; see the identical
 /// delegate in `RequestConfigurationURLSessionClientTests` (`RequestDLTests`) for why this exists
 /// at all: `LocalServer` is always TLS-terminated with a throwaway self-signed certificate.
 private final class AcceptAnyServerTrustDelegate: NSObject, URLSessionTaskDelegate, @unchecked Sendable {

--- a/Tests/RequestDLInternalsTests/Sources/Client/URLSession Client/Upload/InternalsURLSessionUploadFileTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Client/URLSession Client/Upload/InternalsURLSessionUploadFileTests.swift
@@ -18,16 +18,16 @@ import Foundation
 /// Unit coverage for `Internals.URLSessionUploadFile`, the replacement for the `InputStream`-based
 /// upload bridge (`Internals.URLSessionUploadStream`, removed) that was found to be permanently
 /// broken against `uploadTask(withStreamedRequest:)`. Independent of `URLSession`/a real network
-/// round trip -- that's `RequestConfigurationURLSessionClientUploadTests` in `RequestDLTests`.
+/// round trip: that's `RequestConfigurationURLSessionClientUploadTests` in `RequestDLTests`.
 ///
 /// `inMemoryThreshold` is passed explicitly and small throughout, rather than relying on the
-/// production default (`Internals.URLSessionUploadFile.inMemoryThreshold`, 8 MiB) -- these tests
+/// production default (`Internals.URLSessionUploadFile.inMemoryThreshold`, 8 MiB); these tests
 /// need to force each branch deterministically without allocating megabytes of payload per case.
 struct InternalsURLSessionUploadFileTests {
 
     @Test
     func write_whenBodyFitsWithinThreshold_returnsDataWithoutTouchingDisk() async throws {
-        // Given -- a recognizable, non-repeating byte pattern, so any reordering or corruption
+        // Given: a recognizable, non-repeating byte pattern, so any reordering or corruption
         // shows up as a content mismatch, not just a wrong total.
         let payload = Data((0..<1_000).map { UInt8($0 % 251) })
         let chunkSize = 77
@@ -69,7 +69,7 @@ struct InternalsURLSessionUploadFileTests {
 
     @Test
     func write_whenBodyExceedsThreshold_spillsToFileWithAllBytesInOrder() async throws {
-        // Given -- comfortably past a deliberately tiny threshold, so this exercises the spillover
+        // Given: comfortably past a deliberately tiny threshold, so this exercises the spillover
         // path (buffer what's already read, then keep draining straight to the file) rather than
         // the in-memory one.
         let payload = Data((0..<10_000).map { UInt8($0 % 251) })
@@ -98,7 +98,7 @@ struct InternalsURLSessionUploadFileTests {
 
     @Test
     func write_whenBodyThrowsWithinThreshold_rethrowsWithoutTouchingDisk() async throws {
-        // Given -- fails before the threshold is ever reached, so this exercises the in-memory
+        // Given: fails before the threshold is ever reached, so this exercises the in-memory
         // read loop's own error path, which never creates a file at all.
         struct UpstreamError: Error, Equatable {}
 
@@ -114,7 +114,7 @@ struct InternalsURLSessionUploadFileTests {
 
     @Test
     func write_whenBodyThrowsAfterSpillover_removesTheTemporaryFileAndRethrows() async throws {
-        // Given -- exceeds the threshold first (forcing the spillover file into existence), then
+        // Given: exceeds the threshold first (forcing the spillover file into existence), then
         // fails while still draining the remainder into it.
         struct UpstreamError: Error, Equatable {}
 
@@ -122,7 +122,7 @@ struct InternalsURLSessionUploadFileTests {
         continuation.yield(ByteBuffer(repeating: 0, count: 4_096))
         continuation.finish(throwing: UpstreamError())
 
-        // When / Then -- the failing path never hands back a `FileBufferURL` for the caller to
+        // When / Then: the failing path never hands back a `FileBufferURL` for the caller to
         // clean up itself, so a matching catch is the whole assertion: the file it wrote partway
         // through is already gone by the time this throws.
         await #expect(throws: UpstreamError.self) {

--- a/Tests/RequestDLInternalsTests/Sources/Secure Connection/Certificate/InternalsCertificateTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Secure Connection/Certificate/InternalsCertificateTests.swift
@@ -90,7 +90,7 @@ struct InternalsCertificateTests {
                 // Then
                 // The finer-grained classification (relative-path detection, "can't open" vs.
                 // "invalid contents") lives entirely in `RequestDL.SecureFileError.init`, built
-                // from exactly this `resource`/`path`/`underlying` triple -- see
+                // from exactly this `resource`/`path`/`underlying` triple; see
                 // `SecureFileErrorTests` in `RequestDLTests` for that coverage.
                 #expect(error.resource == .certificate)
                 #expect(error.path == path)

--- a/Tests/RequestDLInternalsTests/Sources/Secure Connection/CertificateFixturesExpirationTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Secure Connection/CertificateFixturesExpirationTests.swift
@@ -19,12 +19,13 @@ import typealias Foundation.TimeInterval
 ///
 /// Not hypothetical: the originals were issued for 30 years with no Extended Key Usage or SAN
 /// (see the git history of `Tests/RequestDLTests/Resources/SSL.md`), which
-/// `SecTrustEvaluateWithError` -- the URLSession executor's certificate validation -- rejects
-/// outright even when the certificate is explicitly anchored as trusted. The replacements
-/// `.scripts/generate-test-certificates.sh` produces are deliberately short-lived (under Apple's
-/// enforced validity cap), which is exactly
-/// why this check exists: it turns a stale fixture into one immediate, actionable failure here,
-/// instead of a confusing TLS handshake error discovered later in an unrelated test.
+/// `SecTrustEvaluateWithError` (the URLSession executor's certificate validation) rejects
+/// outright even when the certificate is explicitly anchored as trusted.
+///
+/// The replacements `.scripts/generate-test-certificates.sh` produces are deliberately
+/// short-lived (under Apple's enforced validity cap), which is exactly why this check exists:
+/// it turns a stale fixture into one immediate, actionable failure here, instead of a confusing
+/// TLS handshake error discovered later in an unrelated test.
 struct CertificateFixturesExpirationTests {
 
     @Test

--- a/Tests/RequestDLInternalsTests/Sources/Secure Connection/Private Key/InternalsPrivateKeyTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Secure Connection/Private Key/InternalsPrivateKeyTests.swift
@@ -174,7 +174,7 @@ struct InternalsPrivateKeyTests {
                 // Then
                 // Relative-path detection and "can't open" vs. "invalid contents"
                 // classification live entirely in `RequestDL.SecureFileError.init`, built from
-                // exactly this `resource`/`path`/`underlying` triple -- see `SecureFileErrorTests`
+                // exactly this `resource`/`path`/`underlying` triple; see `SecureFileErrorTests`
                 // in `RequestDLTests` for that coverage.
                 #expect(error.resource == .privateKey)
                 #expect(error.path == path)

--- a/Tests/RequestDLInternalsTests/Sources/Session/Network Path Monitor/InternalsNetworkPathGateTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Session/Network Path Monitor/InternalsNetworkPathGateTests.swift
@@ -22,7 +22,7 @@ private struct FakeNetworkPathObserver: Internals.NetworkPathObserving {
     }
 }
 
-/// An observer whose `updates()` stream never yields and never finishes on its own -- used to
+/// An observer whose `updates()` stream never yields and never finishes on its own; used to
 /// exercise real `Task` cancellation while `NetworkPathGate.wait(for:)` is awaiting it.
 private struct HangingNetworkPathObserver: Internals.NetworkPathObserving {
 

--- a/Tests/RequestDLInternalsTests/Sources/Session/Proxy/InternalsPACEvaluatorTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Session/Proxy/InternalsPACEvaluatorTests.swift
@@ -13,29 +13,31 @@ import Foundation
 import Network
 
 /// `Internals.PACEvaluator.evaluate(scriptURL:targetURL:timeout:)` against real, locally-served
-/// PAC scripts -- a bare `NWListener` speaking just enough HTTP/1.1 to serve one script and close,
+/// PAC scripts: a bare `NWListener` speaking just enough HTTP/1.1 to serve one script and close,
 /// so this doesn't depend on the CI machine's actual system proxy settings (unlike
 /// `SystemProxyTests`/`InternalsSystemProxyResolverTests`'s own integration tests) while still
 /// exercising the genuine `CFNetworkExecuteProxyAutoConfigurationURL` fetch + JavaScript
 /// evaluation + `CFRunLoopSource` pumping end to end, not a mock of any part of it.
 ///
 /// `file://` was tried first and rejected: `CFNetworkExecuteProxyAutoConfigurationURL` fails
-/// every `file://` script with `kCFURLErrorUnsupportedURLScheme` (-1002) -- PAC fetching only
+/// every `file://` script with `kCFURLErrorUnsupportedURLScheme` (-1002). PAC fetching only
 /// speaks HTTP(S), the same as every browser's own PAC support.
 ///
 /// `.serialized`: every test here spins up a real dedicated `Thread` plus real network I/O
-/// against a local listener -- running them concurrently with each other adds self-inflicted
-/// contention on top of whatever the rest of the job is already under, the same class of problem
-/// `RequestConfigurationURLSessionClientUploadTests` (request-dl-nio#327) traced part of its own
-/// CI timeouts back to; every other suite here doing comparable real I/O (`SessionExecutionTests`,
-/// `DataCacheTests`, `CachedRequestTests`) already serializes for the same reason.
+/// against a local listener, and running them concurrently with each other adds self-inflicted
+/// contention on top of whatever the rest of the job is already under. That's the same class of
+/// problem `RequestConfigurationURLSessionClientUploadTests` (request-dl-nio#327) traced part of
+/// its own CI timeouts back to; every other suite here doing comparable real I/O
+/// (`SessionExecutionTests`, `DataCacheTests`, `CachedRequestTests`) already serializes for the
+/// same reason.
+///
 /// `.concurrent(watchdogAffectedPlatformConcurrencyLimit)`/`.nonFatalWatchdog`: on the same
 /// simulator runners `WatchdogAffectedPlatformConcurrencyLimit.swift` documents as prone to
-/// scheduler-contention `AsyncLock.Watchdog` false positives -- confirmed directly: a run under
+/// scheduler-contention `AsyncLock.Watchdog` false positives. Confirmed directly: a run under
 /// severe simulator contention (every test in the job, including trivial synchronous ones, taking
 /// 80-160s instead of milliseconds) blew both this suite's own generous timing margins and,
 /// separately, crashed the whole job's process via the watchdog, taking every other in-flight test
-/// down with it -- the exact failure mode these two traits exist to prevent.
+/// down with it, which is the exact failure mode these two traits exist to prevent.
 @Suite(.serialized, .concurrent(watchdogAffectedPlatformConcurrencyLimit), .nonFatalWatchdog)
 struct InternalsPACEvaluatorTests {
 
@@ -113,7 +115,7 @@ struct InternalsPACEvaluatorTests {
 
     @Test
     func evaluate_whenScriptBranchesOnHost_choosesAccordingly() async throws {
-        // Given -- proves `targetURL` genuinely reaches the script, not just that some fixed
+        // Given: proves `targetURL` genuinely reaches the script, not just that some fixed
         // return value comes back regardless of input.
         let server = try await LocalPACServer.start(
             scriptContents: """
@@ -168,19 +170,20 @@ struct InternalsPACEvaluatorTests {
 
     @Test
     func evaluate_whenScriptUnreachable_throwsWithinTimeout() async throws {
-        // Given -- nothing listens on this port; connection refused, not a slow fetch, but still
-        // exercised the same way a genuinely hung PAC server would be.
+        // Given: nothing listens on this port, so the connection is refused rather than slow to
+        // fetch, but it's still exercised the same way a genuinely hung PAC server would be.
         let scriptURL = try #require(URL(string: "http://127.0.0.1:1/proxy.pac"))
 
-        // When / Then -- bounded by the timeout below, not the run's own default (much longer),
+        // When / Then: bounded by the timeout below, not the run's own default (much longer),
         // proving the timeout is actually enforced rather than merely accepted as a parameter.
-        // 120s, not a tighter multiple of the 3s `timeout` itself: the wall-clock bound
+        //
+        // 120s, not a tighter multiple of the 3s `timeout` itself, because the wall-clock bound
         // `CFRunLoopRunInMode` enforces only fires once this thread is actually scheduled to check
-        // it, so under severe CI Simulator scheduler contention it can slip well past the
-        // configured value -- confirmed directly, a contended run already pushed this as high as
-        // 82s at a 60s margin. Still meaningfully bounded relative to
-        // `Internals.PACProxyCache`'s own much longer default timeout, so a genuine regression
-        // (the timeout parameter silently stops being honored at all) still fails this.
+        // it. Under severe CI Simulator scheduler contention it can slip well past the configured
+        // value; confirmed directly, a contended run already pushed this as high as 82s at a 60s
+        // margin. Still meaningfully bounded relative to `Internals.PACProxyCache`'s own much
+        // longer default timeout, so a genuine regression (the timeout parameter silently stops
+        // being honored at all) still fails this.
         let start = DispatchTime.now()
 
         await #expect(throws: (any Error).self) {
@@ -198,8 +201,8 @@ struct InternalsPACEvaluatorTests {
 
 /// Serves exactly one PAC script to exactly one connection at a time, in the minimal HTTP/1.1
 /// this needs: no request parsing at all (whatever `CFNetworkExecuteProxyAutoConfigurationURL`
-/// sends is ignored -- the response is the same regardless of path/headers), and every connection
-/// gets the same canned `200 OK` response, then closes.
+/// sends is ignored, since the response is the same regardless of path/headers), and every
+/// connection gets the same canned `200 OK` response, then closes.
 private final class LocalPACServer: @unchecked Sendable {
 
     // MARK: - Internal properties
@@ -285,8 +288,8 @@ private final class LocalPACServer: @unchecked Sendable {
 private struct MissingListenerPortError: Error {}
 
 /// Bridges `NWListener.stateUpdateHandler` (called repeatedly) to a `CheckedContinuation` (usable
-/// exactly once) -- resumes on the first `.ready`/`.failed`, ignores every later call. Mirrors
-/// `InternalsProxyDictionaryPlatformTests`'s identical, file-private helper -- not shared, since
+/// exactly once): resumes on the first `.ready`/`.failed`, ignores every later call. Mirrors
+/// `InternalsProxyDictionaryPlatformTests`'s identical, file-private helper; not shared, since
 /// neither file is a dependency of the other.
 private final class PortContinuationBox: @unchecked Sendable {
 

--- a/Tests/RequestDLInternalsTests/Sources/Session/Proxy/InternalsPACProxyCacheTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Session/Proxy/InternalsPACProxyCacheTests.swift
@@ -35,7 +35,7 @@ struct InternalsPACProxyCacheTests {
         let targetURL = try #require(URL(string: "https://example.com/"))
         let cache = Internals.PACProxyCache()
 
-        // When -- first call fetches and evaluates for real.
+        // When: first call fetches and evaluates for real.
         let first = await cache.proxy(forScriptURL: server.scriptURL, targetURL: targetURL)
 
         // Then the server goes away entirely: a second call that still needs a fresh fetch would
@@ -67,7 +67,7 @@ struct InternalsPACProxyCacheTests {
 
         let cache = Internals.PACProxyCache()
 
-        // When -- two different target URLs against the same script, both uncached.
+        // When: two different target URLs against the same script, both uncached.
         let internalProxy = await cache.proxy(
             forScriptURL: server.scriptURL,
             targetURL: try #require(URL(string: "https://internal.example.com/"))
@@ -77,7 +77,7 @@ struct InternalsPACProxyCacheTests {
             targetURL: try #require(URL(string: "https://external.example.com/"))
         )
 
-        // Then -- the cache key includes the target URL, so this isn't just the first result
+        // Then: the cache key includes the target URL, so this isn't just the first result
         // reused for the second, different, URL.
         #expect(internalProxy == nil)
         #expect(externalProxy?.host == "127.0.0.1")
@@ -85,17 +85,17 @@ struct InternalsPACProxyCacheTests {
 
     @Test
     func proxy_whenEvaluationFails_cachesDirectRatherThanRetryingEveryCall() async throws {
-        // Given -- nothing listens on this port.
+        // Given: nothing listens on this port.
         let scriptURL = try #require(URL(string: "http://127.0.0.1:1/proxy.pac"))
         let targetURL = try #require(URL(string: "https://example.com/"))
         let cache = Internals.PACProxyCache()
 
-        // When -- two calls for the same unreachable script; if the failure weren't cached, both
+        // When: two calls for the same unreachable script. If the failure weren't cached, both
         // would separately pay the same (short but nonzero) connection-refused round trip.
         let first = await cache.proxy(forScriptURL: scriptURL, targetURL: targetURL)
         let second = await cache.proxy(forScriptURL: scriptURL, targetURL: targetURL)
 
-        // Then -- fails safe to direct, same as `Internals.SystemProxyResolver.firstResolution(in:)`
+        // Then: fails safe to direct, same as `Internals.SystemProxyResolver.firstResolution(in:)`
         // already does for any other unparseable entry, not thrown back out to the caller.
         #expect(first == nil)
         #expect(second == nil)
@@ -103,7 +103,7 @@ struct InternalsPACProxyCacheTests {
 }
 
 /// Serves exactly one PAC script to exactly one connection at a time. Mirrors
-/// `InternalsPACEvaluatorTests`'s identical, file-private helper -- not shared, since neither
+/// `InternalsPACEvaluatorTests`'s identical, file-private helper; not shared, since neither
 /// file is a dependency of the other.
 private final class LocalPACServer: @unchecked Sendable {
 
@@ -190,7 +190,7 @@ private final class LocalPACServer: @unchecked Sendable {
 private struct MissingListenerPortError: Error {}
 
 /// Bridges `NWListener.stateUpdateHandler` (called repeatedly) to a `CheckedContinuation` (usable
-/// exactly once) -- resumes on the first `.ready`/`.failed`, ignores every later call.
+/// exactly once): resumes on the first `.ready`/`.failed`, ignores every later call.
 private final class PortContinuationBox: @unchecked Sendable {
 
     private let lock = NSLock()

--- a/Tests/RequestDLInternalsTests/Sources/Session/Proxy/InternalsProxyDictionaryPlatformTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Session/Proxy/InternalsProxyDictionaryPlatformTests.swift
@@ -15,7 +15,7 @@ import SwiftAsyncStream
 /// runs on (macOS, and every Simulator/Catalyst destination `xcodebuild test` can target).
 ///
 /// Deliberately independent of `LocalServer`/`LocalHTTPConnectProxy` (NIOSSL-backed, HTTP/1
-/// codec) -- those exist to prove a *working tunnel* end to end, which needs the platform's
+/// codec): those exist to prove a *working tunnel* end to end, which needs the platform's
 /// TLS/HTTP stack to cooperate for reasons orthogonal to the question this file asks. This file
 /// only asks whether the configured proxy address is contacted **at all**, using a bare
 /// `Network.framework` `NWListener` standing in for "some process listening on the configured
@@ -24,17 +24,18 @@ import SwiftAsyncStream
 /// **Finding, corrected from an earlier pass in this same investigation:** `connectionProxyDictionary`
 /// is *not* broken. The first version of this check pointed at a loopback destination (matching
 /// `LocalServer`, which only ever binds to `127.0.0.1`/`localhost`) and saw the proxy never
-/// contacted, which was misread as `URLSession` ignoring the dictionary outright. Comparing
-/// destinations directly (`127.0.0.1`, `localhost`, an arbitrary non-loopback IP, and a
+/// contacted, which was misread as `URLSession` ignoring the dictionary outright.
+///
+/// Comparing destinations directly (`127.0.0.1`, `localhost`, an arbitrary non-loopback IP, and a
 /// non-resolving hostname), across macOS, Mac Catalyst, and iOS/tvOS/watchOS/visionOS Simulators,
-/// isolated the real cause -- and a second, narrower one underneath it:
+/// isolated the real cause, and a second, narrower one underneath it:
 ///
 /// - Every platform bypasses a configured proxy for the **literal** loopback IP
 ///   (`127.0.0.1`) as OS-level policy, independent of this dictionary being wired correctly.
 /// - **macOS and Mac Catalyst additionally bypass `localhost` by name.** iOS, tvOS, watchOS, and
-///   visionOS Simulators do **not** -- `localhost` gets proxied there exactly like any other
+///   visionOS Simulators do **not**: `localhost` gets proxied there exactly like any other
 ///   hostname. (Simulators share their host Mac's network stack for the underlying socket, but
-///   evidently not this particular CFNetwork policy decision -- Catalyst, which really does run
+///   evidently not this particular CFNetwork policy decision. Catalyst, which really does run
 ///   the macOS frameworks directly, matches macOS exactly, which is what makes this a platform
 ///   distinction and not a "shares the same kernel" artifact.)
 /// - Non-loopback destinations are proxied reliably everywhere.
@@ -55,7 +56,7 @@ struct InternalsProxyDictionaryPlatformTests {
 
     @Test
     func urlSession_whenConnectionProxyDictionarySet_bypassesProxyForLiteralLoopbackIP() async throws {
-        // Given / When -- unlike `localhost` below, contacting `127.0.0.1` directly is bypassed
+        // Given / When: unlike `localhost` below, contacting `127.0.0.1` directly is bypassed
         // on every platform this was checked on.
         let contacted = try await proxyWasContacted(destination: "https://127.0.0.1:9/")
 
@@ -68,7 +69,7 @@ struct InternalsProxyDictionaryPlatformTests {
         // Given / When
         let contacted = try await proxyWasContacted(destination: "https://localhost:9/")
 
-        // Then -- see the file-level doc comment for why this genuinely differs by platform
+        // Then: see the file-level doc comment for why this genuinely differs by platform
         // rather than being flaky: macOS/Catalyst bypass `localhost` same as the literal IP;
         // every Simulator platform proxies it like any other hostname.
         #if os(macOS) || targetEnvironment(macCatalyst)
@@ -134,7 +135,7 @@ struct InternalsProxyDictionaryPlatformTests {
         // ever touched.
         _ = try? await session.data(for: URLRequest(url: URL(string: destination)!))
 
-        // Give a just-missed connection a moment to land -- `data(for:)` returning doesn't
+        // Give a just-missed connection a moment to land: `data(for:)` returning doesn't
         // guarantee the listener's callback (a separate queue) has already run.
         try? await _Concurrency.Task.sleep(nanoseconds: 300_000_000)
 
@@ -163,7 +164,7 @@ private final class ConnectAttemptCounter: @unchecked Sendable {
 }
 
 /// Bridges `NWListener.stateUpdateHandler` (called repeatedly) to a `CheckedContinuation` (usable
-/// exactly once) -- resumes on the first `.ready`/`.failed`, ignores every later call.
+/// exactly once): resumes on the first `.ready`/`.failed`, ignores every later call.
 private final class ContinuationBox: @unchecked Sendable {
 
     private let lock = Lock()

--- a/Tests/RequestDLInternalsTests/Sources/Session/Proxy/InternalsSOCKSProxyDictionaryPlatformTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Session/Proxy/InternalsSOCKSProxyDictionaryPlatformTests.swift
@@ -14,24 +14,25 @@ import SwiftAsyncStream
 /// doc comment already flags: whether `URLSession` honors `connectionProxyDictionary`'s legacy
 /// SOCKS keys (`SOCKSEnable`/`SOCKSProxy`/`SOCKSPort`) *at all*, before committing to building a
 /// real SOCKS4/5 server test double to prove a working tunnel end to end. Mirrors
-/// `InternalsProxyDictionaryPlatformTests`'s own bare-`NWListener` technique exactly -- a listener
+/// `InternalsProxyDictionaryPlatformTests`'s own bare-`NWListener` technique exactly: a listener
 /// standing in for "some process at the configured proxy address," counting connection attempts,
-/// nothing that speaks the SOCKS protocol itself -- since that same technique already correctly
-/// separated "is the dictionary honored" from "does the resulting tunnel actually carry traffic"
-/// for the `.http` keys.
+/// nothing that speaks the SOCKS protocol itself. That's because the same technique already
+/// correctly separated "is the dictionary honored" from "does the resulting tunnel actually carry
+/// traffic" for the `.http` keys.
 ///
-/// Uses `https://example.invalid/` as the destination, not a loopback address --
+/// Uses `https://example.invalid/` as the destination, not a loopback address, because
 /// `InternalsProxyDictionaryPlatformTests`'s own finding is that every platform bypasses a
 /// configured proxy for loopback destinations as OS policy, independent of whether a given key
 /// set is honored at all, which would make a loopback destination here prove nothing either way.
 ///
 /// **Finding, confirmed by actually running both tests, not assumed:** `URLSession` does contact
-/// the configured SOCKS proxy address -- on macOS and an iOS Simulator alike, and confirmed
+/// the configured SOCKS proxy address on macOS and an iOS Simulator alike, and confirmed
 /// non-tautological by the negative-control test (no dictionary set, listener never contacted).
+///
 /// This overturns the "unreliable/undocumented" framing the original analysis carried forward
-/// into excluding `.socks` from `.urlSession` entirely -- at least the connection-attempt half of
+/// into excluding `.socks` from `.urlSession` entirely: at least the connection-attempt half of
 /// the picture works. It does **not** yet prove a working SOCKS tunnel end to end (handshake,
-/// auth negotiation, address relay) -- only that `URLSession` is willing to dial the configured
+/// auth negotiation, address relay); only that `URLSession` is willing to dial the configured
 /// address, which is the bare minimum a real SOCKS4/5 server test double (this file's own
 /// deliberately narrower scope) would need to even get contacted in the first place.
 struct InternalsSOCKSProxyDictionaryPlatformTests {
@@ -45,7 +46,7 @@ struct InternalsSOCKSProxyDictionaryPlatformTests {
         #expect(contacted)
     }
 
-    /// Negative control for the test above -- without this, a listener that happened to be
+    /// Negative control for the test above: without this, a listener that happened to be
     /// contacted for some unrelated reason (a stray system connection, ATS probing, ...) would
     /// make the positive result meaningless. Same discipline `InternalsURLSessionClientCookieTests`
     /// already holds itself to for its own tee assertion.
@@ -111,7 +112,7 @@ struct InternalsSOCKSProxyDictionaryPlatformTests {
         // test is whether the proxy gets contacted before (or instead of) any of that.
         _ = try? await session.data(for: URLRequest(url: URL(string: "https://example.invalid/")!))
 
-        // Give a just-missed connection a moment to land -- `data(for:)` returning doesn't
+        // Give a just-missed connection a moment to land: `data(for:)` returning doesn't
         // guarantee the listener's callback (a separate queue) has already run.
         try? await _Concurrency.Task.sleep(nanoseconds: 300_000_000)
 
@@ -140,7 +141,7 @@ private final class ConnectAttemptCounter: @unchecked Sendable {
 }
 
 /// Bridges `NWListener.stateUpdateHandler` (called repeatedly) to a `CheckedContinuation` (usable
-/// exactly once) -- resumes on the first `.ready`/`.failed`, ignores every later call.
+/// exactly once): resumes on the first `.ready`/`.failed`, ignores every later call.
 private final class ContinuationBox: @unchecked Sendable {
 
     private let lock = Lock()

--- a/Tests/RequestDLInternalsTests/Sources/Session/Proxy/InternalsSystemProxyResolverTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Session/Proxy/InternalsSystemProxyResolverTests.swift
@@ -12,10 +12,10 @@ import CFNetwork
 import Foundation
 
 /// `Internals.SystemProxyResolver.firstResolution(in:)`/`firstUsableProxy(in:)` against synthetic
-/// CFNetwork proxy-list dictionaries -- the same shape `CFNetworkCopyProxiesForURL` and a PAC
+/// CFNetwork proxy-list dictionaries: the same shape `CFNetworkCopyProxiesForURL` and a PAC
 /// script's own evaluated result both use, exercised directly here instead of through either of
-/// those (both depend on state -- system settings, or a real script fetch -- this suite doesn't
-/// control).
+/// those (both depend on state, either system settings or a real script fetch, that this suite
+/// doesn't control).
 struct InternalsSystemProxyResolverTests {
 
     @Test
@@ -41,7 +41,7 @@ struct InternalsSystemProxyResolverTests {
 
     @Test
     func firstResolution_whenNoneEntryPrecedesAnHTTPEntry_stopsAtDirect() async throws {
-        // Given -- later entries are fallbacks for a failed proxy, not alternatives to try
+        // Given: later entries are fallbacks for a failed proxy, not alternatives to try
         // instead of an explicit direct connection.
         let proxies: [[String: Any]] = [
             [kCFProxyTypeKey as String: kCFProxyTypeNone],
@@ -132,7 +132,7 @@ struct InternalsSystemProxyResolverTests {
 
     @Test
     func firstResolution_whenEntryMissingHostOrPort_skipsToNextEntry() async throws {
-        // Given -- an HTTP entry missing its port is unusable and skipped, falling through to
+        // Given: an HTTP entry missing its port is unusable and skipped, falling through to
         // the SOCKS entry after it.
         let proxies: [[String: Any]] = [
             [
@@ -177,7 +177,7 @@ struct InternalsSystemProxyResolverTests {
 
     @Test
     func firstUsableProxy_whenAutoConfigurationURLEntry_isNil() async throws {
-        // Given -- `firstUsableProxy(in:)` is `Internals.PACEvaluator`'s own entry point, parsing
+        // Given: `firstUsableProxy(in:)` is `Internals.PACEvaluator`'s own entry point, parsing
         // an *already evaluated* PAC result, which CFNetwork guarantees never itself contains an
         // auto-configuration entry. Defensively treated the same as "nothing this package
         // recognizes" rather than recursing.

--- a/Tests/RequestDLInternalsTests/Sources/Session/Session Configuration/InternalsSessionConfigurationExecutorTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Session/Session Configuration/InternalsSessionConfigurationExecutorTests.swift
@@ -11,11 +11,11 @@ import Testing
 
 struct InternalsSessionConfigurationExecutorTests {
 
-    /// A stand-in for `BrotliURLSessionOnlyAlgorithm` -- that concrete type lives in `RequestDL`,
+    /// A stand-in for `BrotliURLSessionOnlyAlgorithm`: that concrete type lives in `RequestDL`,
     /// which this target doesn't depend on, so `Internals.Session.Configuration
     /// .nonURLSessionExecutorIncompatibilityReasons()` is exercised here against any
     /// `Internals.DecompressionAlgorithm` answering `requiresURLSession: true`, matching how
-    /// `InternalsDecompressionAlgorithmAdapter` (in `RequestDL`) actually produces that answer --
+    /// `InternalsDecompressionAlgorithmAdapter` (in `RequestDL`) actually produces that answer,
     /// via `algorithm is BrotliURLSessionOnlyAlgorithm`, not a public protocol requirement.
     private struct MockURLSessionOnlyAlgorithm: Internals.DecompressionAlgorithm {
         var contentEncodingValue: String { "br" }
@@ -116,7 +116,7 @@ struct InternalsSessionConfigurationExecutorTests {
     }
 
     /// A SOCKS proxy is reachable under `.urlSession` via `connectionProxyDictionary`'s legacy
-    /// `SOCKSEnable`/`SOCKSProxy`/`SOCKSPort` keys -- confirmed empirically (a bare `NWListener`
+    /// `SOCKSEnable`/`SOCKSProxy`/`SOCKSPort` keys. Confirmed empirically (a bare `NWListener`
     /// probe, `InternalsSOCKSProxyDictionaryPlatformTests`, shows `URLSession` genuinely dials the
     /// configured address) before removing this from the exclusion list, not assumed from the
     /// original analysis's "unreliable/undocumented" framing.
@@ -140,7 +140,7 @@ struct InternalsSessionConfigurationExecutorTests {
 
     @Test
     func configuration_whenProxyBearerAuthorizationSet_containsReason() async throws {
-        // Given -- no `URLCredential` shape can carry an arbitrary bearer token, unlike
+        // Given: no `URLCredential` shape can carry an arbitrary bearer token, unlike
         // `.basic`/`.basicRawCredentials`, which map onto the proxy authentication challenge
         // delegate cleanly.
         var configuration = Internals.Session.Configuration()
@@ -184,7 +184,7 @@ struct InternalsSessionConfigurationExecutorTests {
         // When
         configuration.decompression = .disabled
 
-        // Then -- `.disabled` gets real parity with NIO on `.urlSession` now, via
+        // Then: `.disabled` gets real parity with NIO on `.urlSession` now, via
         // `Accept-Encoding: identity` at request-build time, so it no longer disqualifies the
         // executor the way it used to.
         #expect(configuration.urlSessionIncompatibilityReasons().isEmpty)
@@ -243,7 +243,7 @@ struct InternalsSessionConfigurationExecutorTests {
         var configuration = Internals.Session.Configuration()
         configuration.decompression = .enabled(algorithms: [], limit: .none)
 
-        // When -- fine under NIOTransportServices, unsupported under URLSession (bucket D)
+        // When: fine under NIOTransportServices, unsupported under URLSession (bucket D)
         configuration.httpVersion = .http1Only
 
         let sut = configuration.resolveExecutor()
@@ -404,7 +404,7 @@ struct InternalsSessionConfigurationExecutorTests {
 
     @Test
     func resolveExecutor_whenNIOTransportServicesPreferredAndCompatible_resolvesToItOverURLSession() async throws {
-        // Given -- compatible with both `.urlSession` and `.nioTransportServices`, so the
+        // Given: compatible with both `.urlSession` and `.nioTransportServices`, so the
         // preference is what breaks the tie rather than falling to the default priority order.
         var configuration = Internals.Session.Configuration()
         configuration.decompression = .enabled(algorithms: [], limit: .none)
@@ -423,7 +423,7 @@ struct InternalsSessionConfigurationExecutorTests {
 
     @Test
     func resolveExecutor_whenNIOPreferred_resolvesToNIORegardlessOfOtherCompatibility() async throws {
-        // Given -- compatible with everything, yet `.nio` is explicitly preferred.
+        // Given: compatible with everything, yet `.nio` is explicitly preferred.
         var configuration = Internals.Session.Configuration()
         configuration.decompression = .enabled(algorithms: [], limit: .none)
         configuration.preferredExecutor = .nio
@@ -465,7 +465,7 @@ struct InternalsSessionConfigurationExecutorTests {
 
     @Test
     func resolveExecutor_whenURLSessionPreferredButIncompatible_fallsBackToNIOTransportServices() async throws {
-        // Given -- unreachable under URLSession (bucket D), unaffected under NIOTransportServices
+        // Given: unreachable under URLSession (bucket D), unaffected under NIOTransportServices
         var configuration = Internals.Session.Configuration()
         configuration.decompression = .enabled(algorithms: [], limit: .none)
         configuration.preferredExecutor = .urlSession
@@ -485,7 +485,7 @@ struct InternalsSessionConfigurationExecutorTests {
     // MARK: - resolveExecutor() with enableNetworkFramework
 
     /// `enableNetworkFramework(true)` (`Session.enableNetworkFramework(_:)`) is already public,
-    /// released API that predates `preferredExecutor` -- its whole point, historically, was
+    /// released API that predates `preferredExecutor`; its whole point, historically, was
     /// opting a session into NIOTransportServices. Since this method's own
     /// NIOTransportServices-vs-plain-NIO answer drives a real request, `.urlSession`'s default
     /// first-priority position would otherwise silently take over for a caller who only ever set
@@ -496,7 +496,7 @@ struct InternalsSessionConfigurationExecutorTests {
     func resolveExecutor_whenNetworkFrameworkEnabledWithoutExplicitPreference_resolvesToNIOTransportServices()
         async throws
     {
-        // Given -- compatible with `.urlSession` too, so the implicit preference is what breaks
+        // Given: compatible with `.urlSession` too, so the implicit preference is what breaks
         // the tie rather than `.urlSession`'s own default priority.
         var configuration = Internals.Session.Configuration()
         configuration.decompression = .enabled(algorithms: [], limit: .none)
@@ -517,7 +517,7 @@ struct InternalsSessionConfigurationExecutorTests {
     func resolveExecutor_whenNetworkFrameworkEnabledAndURLSessionExplicitlyPreferred_explicitPreferenceWins()
         async throws
     {
-        // Given -- an explicit `preferredExecutor` (any case) always outranks the implicit one
+        // Given: an explicit `preferredExecutor` (any case) always outranks the implicit one
         // `enableNetworkFramework` contributes.
         var configuration = Internals.Session.Configuration()
         configuration.decompression = .enabled(algorithms: [], limit: .none)
@@ -535,7 +535,7 @@ struct InternalsSessionConfigurationExecutorTests {
         #endif
     }
 
-    /// The flag's implicit preference is still just a preference, not a guarantee -- a
+    /// The flag's implicit preference is still just a preference, not a guarantee: a
     /// NIOTransportServices-incompatible field must still fall through past it, the same way an
     /// explicit `preferredExecutor(.nioTransportServices)` already does two tests above this
     /// section (including why the fallback lands on `.nio`, not `.urlSession`).
@@ -559,18 +559,19 @@ struct InternalsSessionConfigurationExecutorTests {
 
     // MARK: - resolveExecutor() with requiredExecutor
 
-    /// Regression coverage for a real bug end-to-end testing caught -- `resolveExecutor()`'s own
+    /// Regression coverage for a real bug end-to-end testing caught: `resolveExecutor()`'s own
     /// doc comment already claimed `requiredExecutor` "lets a caller override it," but the
-    /// implementation below only ever consulted `preferredExecutor`. `requiredExecutor(.nio)`
-    /// validated (via `requireExecutor(_:)`,
-    /// called separately) without ever actually being the executor a real request dispatched
-    /// over -- `resolveExecutor()` picked `.urlSession` anyway on a compatible config, silently.
-    /// Caught by a `DataTaskTests` test pinning `.requiredExecutor(.nio)` to keep a client-cert
-    /// mTLS test off `.urlSession`'s unconditional Keychain-Sharing gap, which kept hitting that
-    /// gap anyway until this was fixed.
+    /// implementation below only ever consulted `preferredExecutor`.
+    ///
+    /// `requiredExecutor(.nio)` validated (via `requireExecutor(_:)`, called separately) without
+    /// ever actually being the executor a real request dispatched over; `resolveExecutor()`
+    /// picked `.urlSession` anyway on a compatible config, silently. Caught by a `DataTaskTests`
+    /// test pinning `.requiredExecutor(.nio)` to keep a client-cert mTLS test off `.urlSession`'s
+    /// unconditional Keychain-Sharing gap, which kept hitting that gap anyway until this was
+    /// fixed.
     @Test
     func resolveExecutor_whenNIORequired_resolvesToNIORegardlessOfPreferredExecutorOrCompatibility() async throws {
-        // Given -- compatible with `.urlSession`, and even prefers it, yet `.nio` is required.
+        // Given: compatible with `.urlSession`, and even prefers it, yet `.nio` is required.
         var configuration = Internals.Session.Configuration()
         configuration.decompression = .enabled(algorithms: [], limit: .none)
         configuration.preferredExecutor = .urlSession
@@ -585,7 +586,7 @@ struct InternalsSessionConfigurationExecutorTests {
 
     @Test
     func resolveExecutor_whenURLSessionRequired_resolvesToURLSessionRegardlessOfPreferredExecutor() async throws {
-        // Given -- `requiredExecutor` is trusted unconditionally, on every platform (see the
+        // Given: `requiredExecutor` is trusted unconditionally, on every platform (see the
         // "without prior validation" test below for why that's fine in practice even here).
         var configuration = Internals.Session.Configuration()
         configuration.decompression = .enabled(algorithms: [], limit: .none)
@@ -601,15 +602,17 @@ struct InternalsSessionConfigurationExecutorTests {
 
     /// `resolveExecutor()` trusts `requiredExecutor` unconditionally and platform-independently
     /// by design (see its own doc comment, and the fact this returns before the
-    /// `#if canImport(Darwin)` gate below) -- the compatibility check already happened, and
-    /// already threw, in `requireExecutor(_:)`. This test documents that trust rather than
-    /// re-deriving it: a config `requiredExecutor` claims is `.urlSession`-compatible despite
-    /// `httpVersion == .http1Only` (a genuine bucket-D exclusion) still resolves to `.urlSession`
-    /// here, on every platform, because nothing calls `requireExecutor(_:)` in this test to catch
-    /// the mismatch first -- exactly mirroring what a caller who skips that call gets in
-    /// production too. `Internals.ClientManager.resolvedClient(provider:sessionConfiguration:)`'s
-    /// own non-Darwin branch is what actually keeps this harmless there in practice (it never
-    /// looks at `resolveExecutor()`'s answer at all outside Darwin), not this method.
+    /// `#if canImport(Darwin)` gate below): the compatibility check already happened, and
+    /// already threw, in `requireExecutor(_:)`.
+    ///
+    /// This test documents that trust rather than re-deriving it: a config `requiredExecutor`
+    /// claims is `.urlSession`-compatible despite `httpVersion == .http1Only` (a genuine
+    /// bucket-D exclusion) still resolves to `.urlSession` here, on every platform, because
+    /// nothing calls `requireExecutor(_:)` in this test to catch the mismatch first, exactly
+    /// mirroring what a caller who skips that call gets in production too.
+    /// `Internals.ClientManager.resolvedClient(provider:sessionConfiguration:)`'s own non-Darwin
+    /// branch is what actually keeps this harmless there in practice (it never looks at
+    /// `resolveExecutor()`'s answer at all outside Darwin), not this method.
     @Test
     func resolveExecutor_whenRequiredExecutorSetWithoutPriorValidation_isTrustedAnywayOnEveryPlatform() async throws {
         // Given
@@ -799,7 +802,7 @@ struct InternalsSessionConfigurationExecutorTests {
         var configuration = Internals.Session.Configuration()
         configuration.decompression = .enabled(algorithms: [MockURLSessionOnlyAlgorithm()], limit: .none)
 
-        // When / Then -- the one executor such an algorithm actually requires is, naturally,
+        // When / Then: the one executor such an algorithm actually requires is, naturally,
         // still fine with it.
         try configuration.requireExecutor(.urlSession)
     }
@@ -828,7 +831,7 @@ struct InternalsSessionConfigurationExecutorTests {
     /// `requireExecutor(_:)` hard-pin tests above: there was no explicit instruction to honor, so
     /// forcing `.urlSession` itself incompatible (`dnsOverride`) still resolves to whatever the
     /// normal fallback order would have picked anyway (`.nioTransportServices` here, since
-    /// nothing makes that incompatible either) rather than throwing -- the request goes ahead,
+    /// nothing makes that incompatible either) rather than throwing. The request goes ahead,
     /// and the existing manual-dispatch machinery only ever reports a problem if a `br` response
     /// actually arrives, same as any other `Content-Encoding` this package can't decode. See
     /// `resolveExecutor()`'s own doc comment.

--- a/Tests/RequestDLInternalsTests/Sources/Session/Session Configuration/InternalsSessionConfigurationTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Session/Session Configuration/InternalsSessionConfigurationTests.swift
@@ -344,7 +344,7 @@ struct InternalsSessionConfigurationTests {
         // Given
         let configuration = Internals.Session.Configuration()
 
-        // Then -- `false` regardless of `secureConnection`, since the caller never asked for
+        // Then: `false` regardless of `secureConnection`, since the caller never asked for
         // Network framework in the first place.
         #expect(!configuration.isCompatibleWithNetworkFramework)
     }
@@ -412,7 +412,7 @@ struct InternalsSessionConfigurationTests {
         // When
         let builtConfiguration = try configuration.build().httpClientConfiguration
 
-        // Then -- `async-http-client`'s own tracing is always suppressed; RequestDL owns the span
+        // Then: `async-http-client`'s own tracing is always suppressed; RequestDL owns the span
         // lifecycle itself (see the doc comment on `Configuration.tracer`).
         #expect((builtConfiguration.tracing.tracer as? NoOpTracer) != nil)
     }
@@ -446,7 +446,7 @@ struct InternalsSessionConfigurationTests {
         #expect(builtConfiguration.timeout.connect == nil)
         #expect(builtConfiguration.timeout.read == nil)
         #expect(builtConfiguration.proxy == nil)
-        // Off by default on every platform now -- decompression is opt-in, and `.disabled` gets
+        // Off by default on every platform now: decompression is opt-in, and `.disabled` gets
         // real parity with `.urlSession` via `Accept-Encoding: identity`, so the two platforms no
         // longer need different defaults.
         let expectedDecompression = HTTPClient.Decompression.disabled

--- a/Tests/RequestDLInternalsTests/Sources/Session/Session Configuration/Models/InternalsDecompressionTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Session/Session Configuration/Models/InternalsDecompressionTests.swift
@@ -11,7 +11,7 @@ struct InternalsDecompressionTests {
 
     /// `isNativelyDecodedByURLSession`/`isNativelyDecodedByNIO: true` here stand in for what
     /// `InternalsDecompressionAlgorithmAdapter` (in `RequestDL`) actually answers for the real
-    /// `GzipAlgorithm` -- a structural type check, not a `contentEncodingValue` comparison. See
+    /// `GzipAlgorithm`: a structural type check, not a `contentEncodingValue` comparison. See
     /// `MockCustomAlgorithmNamedGzip` below for why that distinction is the whole point.
     private struct MockGzipAlgorithm: Internals.DecompressionAlgorithm {
         var contentEncodingValue: String { "gzip" }
@@ -39,12 +39,14 @@ struct InternalsDecompressionTests {
     }
 
     /// A genuinely custom algorithm that happens to share `contentEncodingValue` with the
-    /// built-in `GzipAlgorithm` -- `isNativelyDecodedByURLSession`/`isNativelyDecodedByNIO` both
+    /// built-in `GzipAlgorithm`: `isNativelyDecodedByURLSession`/`isNativelyDecodedByNIO` both
     /// default to `false` (neither is overridden here), matching what a real third-party
-    /// `Decompressor` gets. This is exactly the case the type-based checks exist for: without
-    /// them, this would be indistinguishable from `MockGzipAlgorithm` above and would get
-    /// silently bypassed -- by CFNetwork under `.urlSession`, by `NIOHTTPResponseDecompressor`
-    /// under `.nio`/`.nioTransportServices` -- instead of actually running.
+    /// `Decompressor` gets.
+    ///
+    /// This is exactly the case the type-based checks exist for: without them, this would be
+    /// indistinguishable from `MockGzipAlgorithm` above and would get silently bypassed instead
+    /// of actually running (by CFNetwork under `.urlSession`, by `NIOHTTPResponseDecompressor`
+    /// under `.nio`/`.nioTransportServices`).
     private struct MockCustomAlgorithmNamedGzip: Internals.DecompressionAlgorithm {
         var contentEncodingValue: String { "gzip" }
         func callAsFunction() throws -> any Internals.DecompressorStream {
@@ -82,7 +84,7 @@ struct InternalsDecompressionTests {
         // When
         let sut = decompression.build()
 
-        // Then -- gzip/deflate are always delegated to `async-http-client`'s own native handler,
+        // Then: gzip/deflate are always delegated to `async-http-client`'s own native handler,
         // regardless of what else is configured alongside them.
         #expect(
             String(describing: sut)
@@ -95,7 +97,7 @@ struct InternalsDecompressionTests {
 
     @Test
     func decompression_whenEnabledWithOnlyCustomAlgorithm_buildsDisabled() {
-        // Given -- nothing `NIOHTTPResponseDecompressor` recognizes, so the native NIO handler
+        // Given: nothing `NIOHTTPResponseDecompressor` recognizes, so the native NIO handler
         // stays off and manual dispatch owns the whole response.
         let decompression = Internals.Decompression.enabled(
             algorithms: [MockCustomAlgorithm()],
@@ -112,10 +114,10 @@ struct InternalsDecompressionTests {
 
     @Test
     func decompression_whenCustomAlgorithmSharesGzipContentEncoding_stillRequiresManualURLSessionHandling() {
-        // Given -- a genuinely custom algorithm whose `contentEncodingValue` happens to be
+        // Given: a genuinely custom algorithm whose `contentEncodingValue` happens to be
         // "gzip", same as the built-in placeholder. `isNativelyDecodedByURLSession` is a
         // structural check against the built-in types, not a `contentEncodingValue` comparison,
-        // so this must NOT be treated the same as `MockGzipAlgorithm` -- otherwise `.urlSession`
+        // so this must NOT be treated the same as `MockGzipAlgorithm`; otherwise `.urlSession`
         // would let CFNetwork decode the response transparently and this algorithm would never
         // actually run.
         let decompression = Internals.Decompression.enabled(
@@ -129,7 +131,7 @@ struct InternalsDecompressionTests {
 
     @Test
     func decompression_whenCustomAlgorithmSharesGzipContentEncoding_buildsDisabledUnderNIO() {
-        // Given -- same collision as the `.urlSession` test above, but checked against the NIO
+        // Given: same collision as the `.urlSession` test above, but checked against the NIO
         // side: `NIOHTTPResponseDecompressor` is a single switch triggered purely by the
         // response's `Content-Encoding` header, so leaving it on here would decode the response
         // before this custom algorithm's manual dispatch ever got a chance to run.
@@ -152,8 +154,8 @@ struct InternalsDecompressionTests {
             limit: .none
         )
 
-        // Then -- `.urlSession` can't leave CFNetwork decoding gzip transparently while also
-        // taking over `Accept-Encoding` for the custom algorithm -- the moment anything
+        // Then: `.urlSession` can't leave CFNetwork decoding gzip transparently while also
+        // taking over `Accept-Encoding` for the custom algorithm. The moment anything
         // non-native is in the list, this package decodes everything in it itself.
         #expect(decompression.requiresManualURLSessionHandling)
 
@@ -177,7 +179,7 @@ struct InternalsDecompressionTests {
 
     @Test
     func decompression_whenEnabledWithSameContentEncodingValues_equals() {
-        // Given -- equality compares the set of `Content-Encoding` values and the limit, not
+        // Given: equality compares the set of `Content-Encoding` values and the limit, not
         // algorithm identity, so two configurations that behave identically are equal.
         let lhs = Internals.Decompression.enabled(algorithms: [MockGzipAlgorithm()], limit: .none)
         let rhs = Internals.Decompression.enabled(algorithms: [MockGzipAlgorithm()], limit: .none)

--- a/Tests/RequestDLInternalsTests/Sources/Session/Session Configuration/Models/InternalsNIORedirectStrategyAdapterTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Session/Session Configuration/Models/InternalsNIORedirectStrategyAdapterTests.swift
@@ -10,7 +10,7 @@ import Testing
 @testable import RequestDLInternals
 
 /// Covers `Internals.NIORedirectStrategyAdapter`'s conversions in isolation, without a real
-/// network round trip -- the strategy mechanism itself (rewriting a redirect request, refusing
+/// network round trip. The strategy mechanism itself (rewriting a redirect request, refusing
 /// one, detecting cycles via history, a strategy that throws) is AsyncHTTPClient's own, covered
 /// by its own test suite; what's authored here, and worth its own coverage, is the mapping to and
 /// from `Internals.RedirectContext`/`RedirectRequest`/`RedirectDecision`.
@@ -18,7 +18,7 @@ struct InternalsNIORedirectStrategyAdapterTests {
 
     @Test
     func redirectDecision_whenFollowing_onlyOverridesURLMethodAndHeaders() throws {
-        // Given -- a candidate request AsyncHTTPClient already built, carrying a body the
+        // Given: a candidate request AsyncHTTPClient already built, carrying a body the
         // strategy never touches.
         var candidateRequest = HTTPClientRequest(url: "https://example.com/redirected")
         candidateRequest.method = .GET
@@ -59,7 +59,7 @@ struct InternalsNIORedirectStrategyAdapterTests {
         #expect(resultingRequest.url == "https://example.com/adjusted")
         #expect(resultingRequest.method == .POST)
         #expect(resultingRequest.headers.first(name: "X-Adjusted") == "yes")
-        // Body -- untouched, since `Internals.RedirectRequest` has no way to replace it.
+        // Body: untouched, since `Internals.RedirectRequest` has no way to replace it.
         #expect(resultingRequest.body != nil)
 
         // The strategy saw the candidate's own url/method/headers, unmodified.

--- a/Tests/RequestDLInternalsTests/Sources/Session/Session Configuration/Models/InternalsResourceDeadlineTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Session/Session Configuration/Models/InternalsResourceDeadlineTests.swift
@@ -10,16 +10,17 @@ import Testing
 /// `operation`'s own ~10ms sleep, sized against scheduler jitter rather than `operation`'s
 /// duration.
 ///
-/// 10s already wasn't hypothetical headroom -- it replaced a 2s margin that flaked once already.
-/// It still wasn't enough: CI's iOS/iPadOS/tvOS/watchOS/visionOS *Simulator* runners (unlike
+/// 10s already wasn't hypothetical headroom: it replaced a 2s margin that flaked once already.
+/// It still wasn't enough. CI's iOS/iPadOS/tvOS/watchOS/visionOS *Simulator* runners (unlike
 /// macOS/Mac Catalyst, which run at host speed, or Linux/Android, which don't run this suite
 /// under a simulator at all) have been directly observed stalling this same 10ms operation for
-/// 35-64 real seconds under contention -- confirmed from the raw `xcodebuild` log of failing CI
+/// 35-64 real seconds under contention. Confirmed from the raw `xcodebuild` log of failing CI
 /// runs, where the whole suite (1000+ tests) still finished in under two minutes and named this
-/// exact test as one of only a handful of real failures, not a hang or crash. 120s gives headroom
-/// over the worst observed stall (64s) with room to spare, while every non-simulator platform
-/// keeps the original tight 10s -- loosening it there would only slow down catching a genuine
-/// regression on runners that were never the problem.
+/// exact test as one of only a handful of real failures, not a hang or crash.
+///
+/// 120s gives headroom over the worst observed stall (64s) with room to spare, while every
+/// non-simulator platform keeps the original tight 10s: loosening it there would only slow down
+/// catching a genuine regression on runners that were never the problem.
 private let raceMarginNanoseconds: Int64 = {
     #if (os(iOS) && !targetEnvironment(macCatalyst)) || os(tvOS) || os(watchOS) || os(visionOS)
     return 120_000_000_000
@@ -47,7 +48,7 @@ struct InternalsResourceDeadlineTests {
 
     @Test
     func race_whenOperationFinishesBeforeDeadline_returnsItsResult() async throws {
-        // Given -- see `raceMarginNanoseconds`'s doc comment for why this is wider on Simulator
+        // Given: see `raceMarginNanoseconds`'s doc comment for why this is wider on Simulator
         // platforms than on host-speed ones.
         let deadline = Internals.ResourceDeadline(nanoseconds: raceMarginNanoseconds)
 
@@ -63,7 +64,7 @@ struct InternalsResourceDeadlineTests {
 
     @Test
     func race_whenOperationOutlivesDeadline_throwsResourceTimeoutError() async throws {
-        // Given -- deadline much shorter than the operation.
+        // Given: deadline much shorter than the operation.
         let deadline = Internals.ResourceDeadline(nanoseconds: 10_000_000)
 
         // When / Then
@@ -106,14 +107,15 @@ struct InternalsResourceDeadlineTests {
 
     /// Regression coverage for a real race, not just a hypothetical one: with `.urlSession` as
     /// the default executor on Darwin, a fast enough loopback `operation` could actually win
-    /// against an already-elapsed deadline before this fast path existed -- `race(seed:_:)` used
+    /// against an already-elapsed deadline before this fast path existed. `race(seed:_:)` used
     /// to always start `operation` and the deadline's own `Task.sleep(nanoseconds:)` (even a
     /// zero-duration one still needs a real scheduler hop) as two equally-real competing child
-    /// tasks, so "already in the past" was a coin flip, not a guarantee. This deadline is built
-    /// already elapsed (`nanoseconds: 0`, so even `DispatchTime.now()` right after `init` is
-    /// past it), and `operation` never suspends at all -- as fast as an operation can possibly
-    /// be -- so if this ever raced instead of short-circuiting, `operation` winning would be the
-    /// likely outcome, not the timeout.
+    /// tasks, so "already in the past" was a coin flip, not a guarantee.
+    ///
+    /// This deadline is built already elapsed (`nanoseconds: 0`, so even `DispatchTime.now()`
+    /// right after `init` is past it), and `operation` never suspends at all: as fast as an
+    /// operation can possibly be. So if this ever raced instead of short-circuiting, `operation`
+    /// winning would be the likely outcome, not the timeout.
     @Test
     func race_whenDeadlineAlreadyElapsed_throwsWithoutRunningOperationEvenWhenOperationNeverSuspends() async throws {
         // Given
@@ -138,7 +140,7 @@ struct InternalsResourceDeadlineTests {
     }
 
     /// Companion to the test above: an already-elapsed deadline must cancel `seed` too, the same
-    /// as the outlives-deadline path already does -- `RawTask`/`AsyncResponse.Iterator` depend on
+    /// as the outlives-deadline path already does. `RawTask`/`AsyncResponse.Iterator` depend on
     /// that to tear down a connection this fast path now bypasses starting `operation` for.
     @Test
     func race_whenDeadlineAlreadyElapsed_cancelsGivenSeed() async throws {
@@ -170,7 +172,7 @@ struct InternalsResourceDeadlineTests {
 
     @Test
     func race_whenOperationFinishesBeforeDeadline_neverCancelsGivenSeed() async throws {
-        // Given -- see `raceMarginNanoseconds`'s doc comment above.
+        // Given: see `raceMarginNanoseconds`'s doc comment above.
         let deadline = Internals.ResourceDeadline(nanoseconds: raceMarginNanoseconds)
 
         actor CancellationFlag {

--- a/Tests/RequestDLInternalsTests/Sources/Session/Session/Models/InternalsClientResponseReceiverTests.swift
+++ b/Tests/RequestDLInternalsTests/Sources/Session/Session/Models/InternalsClientResponseReceiverTests.swift
@@ -11,7 +11,7 @@ import Testing
 
 /// Executes a bare GET against `urlString` through `session`, mirroring what
 /// `RequestDL`'s `RawTask` does once it has resolved a `RequestConfiguration` into a plain
-/// `HTTPClient.Request` -- this file has no access to `RequestConfiguration` itself, since that
+/// `HTTPClient.Request`. This file has no access to `RequestConfiguration` itself, since that
 /// type lives in `RequestDL`, which depends on this module rather than the other way around.
 private func execute(session: Internals.Session, urlString: String) async throws -> Internals.AsyncResponse {
     let client = try await session.client()

--- a/Tests/RequestDLTestSupport/HTTP/LocalServer.HTTPHandler.swift
+++ b/Tests/RequestDLTestSupport/HTTP/LocalServer.HTTPHandler.swift
@@ -19,7 +19,7 @@ extension LocalServer {
 
     /// `@unchecked` rather than provably `Sendable`: NIO guarantees every `ChannelHandler`
     /// callback for one channel runs on that channel's own `EventLoop`, one at a time, so the
-    /// mutable state below is never actually touched concurrently -- the compiler just can't see
+    /// mutable state below is never actually touched concurrently; the compiler just can't see
     /// that guarantee through the `EventLoopFuture` callbacks in `channelReadComplete`, which is
     /// what actually needs this.
     final class HTTPHandler: ChannelInboundHandler, @unchecked Sendable {
@@ -112,14 +112,15 @@ extension LocalServer {
             )
 
             // `channel`, not `context` itself, is what's safe to hold onto across these
-            // `EventLoopFuture` callbacks -- `Channel` is `Sendable`, `ChannelHandlerContext` isn't.
+            // `EventLoopFuture` callbacks: `Channel` is `Sendable`, `ChannelHandlerContext` isn't.
             // Written as raw `HTTPServerResponsePart` values, not `self.wrapOutboundOut(...)`'s
-            // `NIOAny` -- `Channel.writeAndFlush` has a generic `Sendable`-constrained overload for
+            // `NIOAny`: `Channel.writeAndFlush` has a generic `Sendable`-constrained overload for
             // exactly this (`HTTPServerResponsePart` is `Sendable`: `HTTPResponseHead` and `IOData`
-            // both are), where the `NIOAny`-typed overload is deprecated. Safe to skip the pipeline
-            // position `wrapOutboundOut`/`context` would preserve, since this handler is the only
-            // one ever installed on this channel's pipeline (see `LocalServer`'s
-            // `childChannelInitializer`).
+            // both are), where the `NIOAny`-typed overload is deprecated.
+            //
+            // Safe to skip the pipeline position `wrapOutboundOut`/`context` would preserve, since
+            // this handler is the only one ever installed on this channel's pipeline (see
+            // `LocalServer`'s `childChannelInitializer`).
             let channel = context.channel
 
             channel.writeAndFlush(HTTPServerResponsePart.head(head))
@@ -162,7 +163,7 @@ extension LocalServer {
             }
 
             // Lets a test prove what the client actually sent, not just what the server chose to
-            // send back -- e.g. confirming a cookie set by an earlier response was (or, under
+            // send back: e.g. confirming a cookie set by an earlier response was (or, under
             // `.urlSession`'s no-jar normalization, was *not*) resent automatically.
             if let cookie = _incomeHeaders?.first(name: "Cookie") {
                 jsonObject["receivedCookieHeader"] = .string(cookie)

--- a/Tests/RequestDLTestSupport/HTTP/Models/HTTPResult.swift
+++ b/Tests/RequestDLTestSupport/HTTP/Models/HTTPResult.swift
@@ -15,17 +15,21 @@ struct HTTPResult<Response: Codable>: Codable, Equatable where Response: Equatab
     let receivedBytes: Int
     let response: Response
 
-    /// The `Cookie` header value `LocalServer` actually received on this request, if any --
+    /// The `Cookie` header value `LocalServer` actually received on this request, if any;
     /// `nil` for every existing response shape (defaulted, so this stays additive: no other
-    /// construction or decode call site needs to change). `var`, not `let`: a `let` with an
-    /// inline default is never decoded by the synthesized `init(from:)` at all -- it would stay
-    /// `nil` even when the JSON has the key. See `LocalServer.HTTPHandler.responseData()`.
+    /// construction or decode call site needs to change).
+    ///
+    /// `var`, not `let`: a `let` with an inline default is never decoded by the synthesized
+    /// `init(from:)` at all; it would stay `nil` even when the JSON has the key. See
+    /// `LocalServer.HTTPHandler.responseData()`.
     var receivedCookieHeader: String? = nil
 
-    /// The `User-Agent` header value `LocalServer` actually received on this request, if any --
-    /// same additive shape as ``receivedCookieHeader`` above. Lets a test prove what actually
-    /// reached the wire: RequestDL's own neutral default, a caller-supplied value untouched, or
-    /// -- once dropped under `.urlSession` -- URLSession's own native `CFNetwork`/`Darwin` report.
+    /// The `User-Agent` header value `LocalServer` actually received on this request, if any;
+    /// same additive shape as ``receivedCookieHeader`` above.
+    ///
+    /// Lets a test prove what actually reached the wire: RequestDL's own neutral default, a
+    /// caller-supplied value untouched, or, once dropped under `.urlSession`, URLSession's own
+    /// native `CFNetwork`/`Darwin` report.
     var receivedUserAgentHeader: String? = nil
 }
 

--- a/Tests/RequestDLTestSupport/Local Proxy/LocalHTTPConnectProxy.swift
+++ b/Tests/RequestDLTestSupport/Local Proxy/LocalHTTPConnectProxy.swift
@@ -14,24 +14,29 @@ import struct Foundation.Data
 
 /// A minimal HTTP `CONNECT` proxy.
 ///
-/// No pre-existing NIO-backend proxy round-trip fixture existed to reuse -- `ProxyTests`
+/// No pre-existing NIO-backend proxy round-trip fixture existed to reuse: `ProxyTests`
 /// (`RequestDLTests`) and `InternalsProxyTests` (`RequestDLInternalsTests`) only cover config
-/// mapping, never an actual proxied connection. This stands in for a real forward proxy just
-/// enough to prove a `CONNECT` tunnel (with optional Basic proxy authentication) actually carries
-/// traffic: it accepts one `CONNECT host:port` request, optionally challenges it for
-/// `Proxy-Authorization`, replies `200 Connection Established`, then relays raw bytes both ways
-/// between the accepted connection and a freshly dialed one to `host:port` -- opaque after that
-/// point, so it works equally for a plain or TLS-wrapped tunnel (`LocalServer` is always TLS).
+/// mapping, never an actual proxied connection.
 ///
-/// Deliberately hand-parses the `CONNECT` request/writes the response as raw bytes rather than
-/// using `NIOHTTP1`'s codec (`HTTPRequestDecoder`/`HTTPResponseEncoder`) removed mid-connection --
-/// an earlier version did that, and removing handlers asynchronously while the client is free to
-/// start writing tunnel bytes (a TLS `ClientHello`, the instant it sees the `200`) the moment the
-/// response is flushed raced the removal on iOS/tvOS/watchOS/visionOS Simulators (reliably; never
-/// observed on macOS): bytes meant for the tunnel could still reach the not-yet-removed
-/// `HTTPRequestDecoder`, which trips `NIOAny`'s type-mismatch fatal error on anything that isn't
-/// a well-formed HTTP request. One handler for the whole connection, switching mode internally
-/// once the `CONNECT` is answered, has no such window -- nothing is ever removed from the pipeline.
+/// This stands in for a real forward proxy just enough to prove a `CONNECT` tunnel (with
+/// optional Basic proxy authentication) actually carries traffic: it accepts one `CONNECT
+/// host:port` request, optionally challenges it for `Proxy-Authorization`, replies `200
+/// Connection Established`, then relays raw bytes both ways between the accepted connection and
+/// a freshly dialed one to `host:port`. It's opaque after that point, so it works equally for a
+/// plain or TLS-wrapped tunnel (`LocalServer` is always TLS).
+///
+/// Deliberately hand-parses the `CONNECT` request and writes the response as raw bytes, rather
+/// than using `NIOHTTP1`'s codec (`HTTPRequestDecoder`/`HTTPResponseEncoder`) removed
+/// mid-connection. An earlier version did that: removing handlers asynchronously while the
+/// client is free to start writing tunnel bytes (a TLS `ClientHello`, the instant it sees the
+/// `200`) the moment the response is flushed raced the removal on iOS/tvOS/watchOS/visionOS
+/// Simulators (reliably; never observed on macOS).
+///
+/// Bytes meant for the tunnel could still reach the not-yet-removed `HTTPRequestDecoder`, which
+/// trips `NIOAny`'s type-mismatch fatal error on anything that isn't a well-formed HTTP request.
+///
+/// One handler for the whole connection, switching mode internally once the `CONNECT` is
+/// answered, has no such window: nothing is ever removed from the pipeline.
 struct LocalHTTPConnectProxy: Sendable {
 
     // MARK: - Internal properties
@@ -42,7 +47,7 @@ struct LocalHTTPConnectProxy: Sendable {
     /// How many `CONNECT` requests this proxy has actually received, successful or not.
     ///
     /// Exists so a test can assert the proxy was genuinely used rather than the request having
-    /// somehow reached its destination directly -- both `127.0.0.1` targets and system-level
+    /// somehow reached its destination directly: both `127.0.0.1` targets and system-level
     /// "bypass proxy for local addresses" rules are exactly the kind of thing that silently
     /// short-circuits proxying and would otherwise let a broken `connectionProxyDictionary`
     /// mapping pass every test for the wrong reason.
@@ -110,14 +115,16 @@ final class ConnectAttemptCounter: @unchecked Sendable {
 /// One instance per accepted connection. Starts in `.awaitingRequest`, hand-parsing raw bytes
 /// until a full `CONNECT` request (terminated by a blank line) has arrived; once answered, flips
 /// to `.relaying` and every subsequent byte is forwarded to the dialed destination channel
-/// instead -- the same handler, the same pipeline position, throughout.
+/// instead: the same handler, the same pipeline position, throughout.
 ///
 /// `@unchecked` rather than provably `Sendable`: NIO guarantees every `ChannelHandler` callback
 /// for one channel runs on that channel's own `EventLoop`, one at a time, so `mode`/`buffer` are
-/// never actually touched concurrently. `startRelay(...)`'s `[weak self]` capture (needed since
-/// `ClientBootstrap(...).connect(...)`'s completion isn't guaranteed to land back on that same
-/// `EventLoop`) is itself what actually needs this -- the write to `mode` inside it is explicitly
-/// hopped onto `clientChannel.eventLoop` (this handler's own) before touching it.
+/// never actually touched concurrently.
+///
+/// `startRelay(...)`'s `[weak self]` capture (needed since `ClientBootstrap(...).connect(...)`'s
+/// completion isn't guaranteed to land back on that same `EventLoop`) is itself what actually
+/// needs this: the write to `mode` inside it is explicitly hopped onto `clientChannel.eventLoop`
+/// (this handler's own) before touching it.
 private final class ConnectHandler: ChannelInboundHandler, @unchecked Sendable {
     typealias InboundIn = ByteBuffer
     typealias OutboundOut = ByteBuffer
@@ -173,7 +180,7 @@ private final class ConnectHandler: ChannelInboundHandler, @unchecked Sendable {
 
     // MARK: - Private methods
 
-    /// A `CONNECT` request has no body -- the blank line ending its headers also ends the
+    /// A `CONNECT` request has no body: the blank line ending its headers also ends the
     /// request, so waiting for `"\r\n\r\n"` is sufficient (no `Content-Length`/chunked handling
     /// needed, unlike a general HTTP/1.1 parser).
     private func processBufferedRequest(context: ChannelHandlerContext) {
@@ -236,7 +243,7 @@ private final class ConnectHandler: ChannelInboundHandler, @unchecked Sendable {
         let host = String(components[0])
 
         // Anything the client pipelined onto the same TCP segment as the `CONNECT` request
-        // itself (a TLS `ClientHello`, in principle) is tunnel data, not more request to parse --
+        // itself (a TLS `ClientHello`, in principle) is tunnel data, not more request to parse;
         // held onto and relayed once the tunnel exists, not dropped. `headerEndRange` is already
         // in `buffer`'s own (absolute) index space, same as `ByteBufferView`'s throughout.
         let leftoverStart = headerEndRange.lowerBound + 4
@@ -258,11 +265,12 @@ private final class ConnectHandler: ChannelInboundHandler, @unchecked Sendable {
         var out = context.channel.allocator.buffer(capacity: response.utf8.count)
         out.writeString(response)
 
-        // Raw `ByteBuffer`, not `wrapOutboundOut(out)`'s `NIOAny` -- `Channel.writeAndFlush` has a
+        // Raw `ByteBuffer`, not `wrapOutboundOut(out)`'s `NIOAny`: `Channel.writeAndFlush` has a
         // generic `Sendable`-constrained overload for exactly this (`ByteBuffer` is `Sendable`),
-        // where the `NIOAny`-typed overload is deprecated. `channel`, not `context`, is what's
-        // safe to hold onto across `whenComplete` -- see `LocalServer.HTTPHandler`'s own comment
-        // on the same pattern.
+        // where the `NIOAny`-typed overload is deprecated.
+        //
+        // `channel`, not `context`, is what's safe to hold onto across `whenComplete`; see
+        // `LocalServer.HTTPHandler`'s own comment on the same pattern.
         let channel = context.channel
 
         channel.writeAndFlush(out).whenComplete { _ in
@@ -274,7 +282,7 @@ private final class ConnectHandler: ChannelInboundHandler, @unchecked Sendable {
         buffer.clear()
     }
 
-    /// Dials `host:port`, answers the `CONNECT` with `200`, and flips `mode` to `.relaying` --
+    /// Dials `host:port`, answers the `CONNECT` with `200`, and flips `mode` to `.relaying`:
     /// from here on `channelRead` forwards to `outboundChannel` directly, and a lightweight
     /// closure-based handler on `outboundChannel`'s own pipeline forwards the other direction.
     /// Nothing is ever added to or removed from *this* channel's pipeline.
@@ -317,7 +325,7 @@ private final class ConnectHandler: ChannelInboundHandler, @unchecked Sendable {
     // MARK: - Private static methods
 
     /// `ByteBufferView` has no built-in subsequence search (that's `swift-algorithms`, not a
-    /// dependency here) -- header sizes here are a few hundred bytes at most, so the naive scan
+    /// dependency here); header sizes here are a few hundred bytes at most, so the naive scan
     /// is more than fast enough.
     private static func firstRange(of pattern: [UInt8], in view: ByteBufferView) -> Range<Int>? {
         guard !pattern.isEmpty, view.count >= pattern.count else {
@@ -347,7 +355,7 @@ private final class ConnectHandler: ChannelInboundHandler, @unchecked Sendable {
 }
 
 /// The destination side of a tunnel: forwards every byte read back to the original client
-/// connection, and closes it once the destination goes away. Not `private` -- `LocalSOCKSProxy`
+/// connection, and closes it once the destination goes away. Not `private`: `LocalSOCKSProxy`
 /// reuses this verbatim for its own tunnel, the relay half being identical regardless of which
 /// proxy protocol negotiated it.
 ///
@@ -381,7 +389,7 @@ extension StringProtocol {
     }
 
     /// `trimmingCharacters(in: .whitespaces)` needs full `Foundation` (`CharacterSet`), not
-    /// available under `FoundationEssentials` on Linux -- this header-value trim only ever needs
+    /// available under `FoundationEssentials` on Linux; this header-value trim only ever needs
     /// to strip plain ASCII spaces, so it doesn't need `Foundation` at all.
     fileprivate func trimmingLeadingAndTrailingSpaces() -> String {
         var value = Substring(self)

--- a/Tests/RequestDLTestSupport/Local Proxy/LocalSOCKSProxy.swift
+++ b/Tests/RequestDLTestSupport/Local Proxy/LocalSOCKSProxy.swift
@@ -8,18 +8,20 @@ import SwiftAsyncStream
 
 /// A minimal SOCKS5 proxy (RFC 1928), no authentication.
 ///
-/// Exists for the same reason `LocalHTTPConnectProxy` does -- no pre-existing NIO-backend fixture
+/// Exists for the same reason `LocalHTTPConnectProxy` does: no pre-existing NIO-backend fixture
 /// proves a proxied connection actually carries traffic, only that `Internals.Proxy`'s config
-/// mapping is shaped correctly. Accepts the greeting (`VER NMETHODS METHODS`), replies with
-/// no-authentication (`0x00`) if offered, accepts one `CONNECT` request (`VER CMD RSV ATYP
-/// DST.ADDR DST.PORT`), replies success, then relays raw bytes both ways between the accepted
-/// connection and a freshly dialed one to the requested address -- opaque after that point,
-/// exactly like `LocalHTTPConnectProxy`'s own tunnel (`OutboundRelayHandler`, shared verbatim).
+/// mapping is shaped correctly.
+///
+/// Accepts the greeting (`VER NMETHODS METHODS`), replies with no-authentication (`0x00`) if
+/// offered, accepts one `CONNECT` request (`VER CMD RSV ATYP DST.ADDR DST.PORT`), replies
+/// success, then relays raw bytes both ways between the accepted connection and a freshly dialed
+/// one to the requested address. It's opaque after that point, exactly like
+/// `LocalHTTPConnectProxy`'s own tunnel (`OutboundRelayHandler`, shared verbatim).
 ///
 /// The exact bytes this responds to were captured empirically, not assumed from RFC 1928 alone:
 /// `URLSession`, given only `SOCKSEnable`/`SOCKSProxy`/`SOCKSPort` (no `SOCKSVersion`), sends a
 /// SOCKS5 greeting offering no-authentication (`05 01 00`) and, for a domain-name destination, a
-/// `CONNECT` request with `ATYP=0x03` (`05 01 00 03 <len> <domain> <port>`) -- confirmed by
+/// `CONNECT` request with `ATYP=0x03` (`05 01 00 03 <len> <domain> <port>`). This was confirmed by
 /// capturing the raw bytes a bare listener received, not by reading CFNetwork source or docs
 /// (there is no public documentation of this default at all).
 struct LocalSOCKSProxy: Sendable {
@@ -29,7 +31,7 @@ struct LocalSOCKSProxy: Sendable {
     let host = "127.0.0.1"
     let port: Int
 
-    /// How many complete `CONNECT` requests this proxy has actually parsed, successful or not --
+    /// How many complete `CONNECT` requests this proxy has actually parsed, successful or not;
     /// same purpose as `LocalHTTPConnectProxy.connectAttempts`.
     let connectAttempts: ConnectAttemptCounter
 
@@ -70,15 +72,17 @@ struct LocalSOCKSProxy: Sendable {
 
 /// One instance per accepted connection. Walks `.awaitingGreeting` -> `.awaitingRequest` ->
 /// `.relaying(Channel)` in order, hand-parsing the binary SOCKS5 framing incrementally (unlike
-/// `LocalHTTPConnectProxy`'s line-oriented HTTP text, there is no delimiter to scan for -- each
+/// `LocalHTTPConnectProxy`'s line-oriented HTTP text, there is no delimiter to scan for: each
 /// message's own length fields say how many more bytes are needed).
 ///
 /// `@unchecked` rather than provably `Sendable`: NIO guarantees every `ChannelHandler` callback
 /// for one channel runs on that channel's own `EventLoop`, one at a time, so `mode`/`buffer` are
-/// never actually touched concurrently. `startRelay(...)`'s `[weak self]` capture (needed since
-/// `ClientBootstrap(...).connect(...)`'s completion isn't guaranteed to land back on that same
-/// `EventLoop`) is itself what actually needs this -- the write to `mode` inside it is explicitly
-/// hopped onto `clientChannel.eventLoop` (this handler's own) before touching it.
+/// never actually touched concurrently.
+///
+/// `startRelay(...)`'s `[weak self]` capture (needed since `ClientBootstrap(...).connect(...)`'s
+/// completion isn't guaranteed to land back on that same `EventLoop`) is itself what actually
+/// needs this: the write to `mode` inside it is explicitly hopped onto `clientChannel.eventLoop`
+/// (this handler's own) before touching it.
 private final class SOCKSHandler: ChannelInboundHandler, @unchecked Sendable {
     typealias InboundIn = ByteBuffer
     typealias OutboundOut = ByteBuffer
@@ -145,7 +149,7 @@ private final class SOCKSHandler: ChannelInboundHandler, @unchecked Sendable {
     }
 
     /// `VER(1)=0x05 NMETHODS(1) METHODS(NMETHODS)`. Refuses (`05 FF`, then closes) if
-    /// no-authentication (`0x00`) isn't among the offered methods -- this proxy supports nothing
+    /// no-authentication (`0x00`) isn't among the offered methods; this proxy supports nothing
     /// else, matching the NIO backend's own `.socksServer(host:port:)`, which takes no credentials
     /// either.
     private func processGreeting(context: ChannelHandlerContext) {
@@ -176,7 +180,7 @@ private final class SOCKSHandler: ChannelInboundHandler, @unchecked Sendable {
     }
 
     /// `VER(1)=0x05 CMD(1) RSV(1) ATYP(1) DST.ADDR(variable) DST.PORT(2)`. Only `CMD=0x01`
-    /// (`CONNECT`) is supported -- `BIND`/`UDP ASSOCIATE` reply `command not supported` (`0x07`).
+    /// (`CONNECT`) is supported; `BIND`/`UDP ASSOCIATE` reply `command not supported` (`0x07`).
     /// `ATYP` `0x01` (IPv4), `0x03` (domain name, length-prefixed), and `0x04` (IPv6) are all
     /// parsed; anything else replies `address type not supported` (`0x08`).
     private func processRequest(context: ChannelHandlerContext) {
@@ -246,12 +250,14 @@ private final class SOCKSHandler: ChannelInboundHandler, @unchecked Sendable {
         reply(channel: channel, bytes: [0x05, replyCode, 0x00, 0x01, 0, 0, 0, 0, 0, 0], thenClose: true)
     }
 
-    // Raw `ByteBuffer`, not `wrapOutboundOut(out)`'s `NIOAny` -- `Channel.writeAndFlush` has a
+    // Raw `ByteBuffer`, not `wrapOutboundOut(out)`'s `NIOAny`: `Channel.writeAndFlush` has a
     // generic `Sendable`-constrained overload for exactly this (`ByteBuffer` is `Sendable`), where
-    // the `NIOAny`-typed overload is deprecated. Takes `channel` rather than `context` throughout
-    // this handler's private helpers -- `Channel`, unlike `ChannelHandlerContext`, is `Sendable`,
-    // so it's safe to pass into `startRelay(...)`'s `[weak self]` completion, which isn't
-    // guaranteed to already be running on this handler's own `EventLoop`.
+    // the `NIOAny`-typed overload is deprecated.
+    //
+    // Takes `channel` rather than `context` throughout this handler's private helpers: `Channel`,
+    // unlike `ChannelHandlerContext`, is `Sendable`, so it's safe to pass into `startRelay(...)`'s
+    // `[weak self]` completion, which isn't guaranteed to already be running on this handler's own
+    // `EventLoop`.
     private func reply(channel: Channel, bytes: [UInt8], thenClose: Bool) {
         var out = channel.allocator.buffer(capacity: bytes.count)
         out.writeBytes(bytes)
@@ -264,14 +270,15 @@ private final class SOCKSHandler: ChannelInboundHandler, @unchecked Sendable {
     }
 
     /// Dials `host:port`, answers the request with success (`05 00`), and flips `mode` to
-    /// `.relaying` -- from here on `channelRead` forwards to `outboundChannel` directly. Mirrors
+    /// `.relaying`: from here on `channelRead` forwards to `outboundChannel` directly. Mirrors
     /// `LocalHTTPConnectProxy`'s own `startRelay(host:port:leftover:context:)` structurally (that
-    /// one keeps `context` -- it never needs to call a `context`-taking helper from inside the
+    /// one keeps `context`; it never needs to call a `context`-taking helper from inside the
     /// `[weak self]` completion the way `failRequest`/`reply` here do, so it never hits the same
-    /// non-`Sendable`-capture warning `channel` fixes here); the
-    /// bound address/port in the success reply are zeroed (`0.0.0.0:0`), which real SOCKS clients
-    /// -- `URLSession` included, confirmed by this file's own round-trip tests actually passing --
-    /// don't require to be meaningful.
+    /// non-`Sendable`-capture warning `channel` fixes here).
+    ///
+    /// The bound address/port in the success reply are zeroed (`0.0.0.0:0`), which real SOCKS
+    /// clients, `URLSession` included (confirmed by this file's own round-trip tests actually
+    /// passing), don't require to be meaningful.
     private func startRelay(host: String, port: Int, leftover: ByteBuffer?, channel clientChannel: Channel) {
         ClientBootstrap(group: group).connect(host: host, port: port).whenComplete { [weak self] result in
             guard let self else { return }
@@ -315,7 +322,7 @@ private final class SOCKSHandler: ChannelInboundHandler, @unchecked Sendable {
         case 0x01:
             return bytes.map { String($0) }.joined(separator: ".")
         case 0x04:
-            // No `Foundation`/`String(format:)` dependency needed for this rarely-hit branch --
+            // No `Foundation`/`String(format:)` dependency needed for this rarely-hit branch:
             // every test destination this proxy actually sees is a domain name (`0x03`).
             return stride(from: 0, to: bytes.count, by: 2)
                 .map { index -> String in
@@ -324,7 +331,7 @@ private final class SOCKSHandler: ChannelInboundHandler, @unchecked Sendable {
                     return String(repeating: "0", count: 4 - hex.count) + hex
                 }
                 .joined(separator: ":")
-        default:  // 0x03 -- domain name
+        default:  // 0x03: domain name
             return String(decoding: bytes, as: UTF8.self)
         }
     }

--- a/Tests/RequestDLTestSupport/SimulatorAffectedURLSessionRequestTimeout.swift
+++ b/Tests/RequestDLTestSupport/SimulatorAffectedURLSessionRequestTimeout.swift
@@ -6,18 +6,22 @@
 import Foundation
 
 /// `timeoutIntervalForRequest` deliberately kept short (not the 60s default) on tests that drive
-/// `Internals.URLSessionClient` directly against a real `LocalServer` -- cheap insurance against a
+/// `Internals.URLSessionClient` directly against a real `LocalServer`: cheap insurance against a
 /// future regression hanging the suite instead of failing fast, sized against CI Simulator
 /// scheduler jitter rather than against how long the request itself should actually take.
 ///
-/// Bumped once already (5s -> 15s -> 30s, see request-dl-nio#319) after CI flaked on it -- 30s
-/// still wasn't enough: a genuine `NSURLErrorTimedOut` was directly observed on tvOS at 30s under
+/// Bumped once already (5s -> 15s -> 30s, see request-dl-nio#319) after CI flaked on it: 30s
+/// still wasn't enough. A genuine `NSURLErrorTimedOut` was directly observed on tvOS at 30s under
 /// contention (request-dl-nio#327), a platform this margin previously wasn't even suspected of
-/// affecting. 90s gives real headroom on every Apple *Simulator* platform (iOS, iPadOS -- shares
-/// `os(iOS)` with iPhone --, tvOS, watchOS, visionOS), which unlike macOS/Mac Catalyst (host
+/// affecting.
+///
+/// 90s gives real headroom on every Apple *Simulator* platform (iOS, iPadOS, which shares
+/// `os(iOS)` with iPhone, tvOS, watchOS, visionOS), which unlike macOS/Mac Catalyst (host
 /// speed) or Linux/Android (don't run this suite under a simulator at all) have now each been
-/// directly observed stalling under CI contention. Non-Simulator platforms keep the original 30s:
-/// a real regression there still fails well short of the 60s default.
+/// directly observed stalling under CI contention.
+///
+/// Non-Simulator platforms keep the original 30s: a real regression there still fails well short
+/// of the 60s default.
 package let simulatorAffectedURLSessionRequestTimeout: TimeInterval = {
     #if (os(iOS) && !targetEnvironment(macCatalyst)) || os(tvOS) || os(watchOS) || os(visionOS)
     return 90

--- a/Tests/RequestDLTests/Properties/Sources/Headers/Authorization/Digest/Models/DigestChallengeTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Headers/Authorization/Digest/Models/DigestChallengeTests.swift
@@ -41,7 +41,7 @@ struct DigestChallengeTests {
 
     @Test
     func init_whenQopOffersAuthAndAuthInt_recognizesAuth() throws {
-        // Given -- a comma-separated qop list inside quotes, per RFC 7616 §3.3.
+        // Given: a comma-separated qop list inside quotes, per RFC 7616 §3.3.
         let header = #"Digest realm="test", qop="auth,auth-int", nonce="abc123""#
 
         // When
@@ -96,7 +96,7 @@ struct DigestChallengeTests {
 
     @Test
     func init_toleratesACommaInsideAQuotedValue() throws {
-        // Given -- a comma inside `opaque`, which RFC 7616 does not forbid.
+        // Given: a comma inside `opaque`, which RFC 7616 does not forbid.
         let header = #"Digest realm="test", nonce="abc123", opaque="left,right""#
 
         // When

--- a/Tests/RequestDLTests/Properties/Sources/Headers/Authorization/Digest/Models/DigestResponseTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Headers/Authorization/Digest/Models/DigestResponseTests.swift
@@ -9,7 +9,7 @@ import Testing
 struct DigestResponseTests {
 
     /// The worked SHA-256 example from RFC 7616 §3.9.1. The `response` value below is the
-    /// RFC's own published result -- independently cross-checked outside this codebase, feeding
+    /// RFC's own published result: independently cross-checked outside this codebase, feeding
     /// this same challenge/credential/`cnonce` chain through `shasum -a 256` by hand, and the two
     /// agreed byte for byte, before trusting it as this test's expectation.
     @Test

--- a/Tests/RequestDLTests/Properties/Sources/Headers/Headers/Header Node/HeaderNodeCommaSeparatedNamesTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Headers/Headers/Header Node/HeaderNodeCommaSeparatedNamesTests.swift
@@ -8,7 +8,7 @@ import Testing
 
 /// Regression coverage for `HeaderNode.commaSeparatedNames`: `Accept`, `Accept-Charset`,
 /// `Accept-Encoding`, `Accept-Language`, and `Cache-Control` must always combine with `,`, no
-/// matter what `.headerSeparator(_:)` is in scope -- RFC 9110/9111 define each of these as a
+/// matter what `.headerSeparator(_:)` is in scope: RFC 9110/9111 define each of these as a
 /// comma-separated list, and `;` in particular already means something inside the `Accept-*`
 /// family's own grammar (`q` parameters), so honoring an arbitrary separator there wouldn't just
 /// be non-standard, it would actively misparse.
@@ -18,7 +18,7 @@ struct HeaderNodeCommaSeparatedNamesTests {
 
     @Test
     func accept_whenCombinedUnderNonCommaSeparator_forcesComma() async throws {
-        // Given -- `;` already separates a media-range from its own `q` parameter; joining two
+        // Given: `;` already separates a media-range from its own `q` parameter; joining two
         // instances with it instead of `,` would misparse the second value as a parameter of the
         // first.
         let resolved = try await resolve(
@@ -49,7 +49,7 @@ struct HeaderNodeCommaSeparatedNamesTests {
             }
         )
 
-        // Then -- RFC 9111 §5.2: `1#cache-directive` is comma-delimited; joined with anything
+        // Then, per RFC 9111 §5.2: `1#cache-directive` is comma-delimited; joined with anything
         // else it would parse as one opaque, unrecognized directive.
         #expect(resolved.requestConfiguration.headers["Cache-Control"] == ["no-store,no-cache"])
     }
@@ -58,7 +58,7 @@ struct HeaderNodeCommaSeparatedNamesTests {
 
     @Test
     func cacheControl_whenHeaderSeparatorOverridden_stillJoinsOwnDirectivesWithComma() async throws {
-        // Given -- a single `CacheHeader` instance joins its *own* multiple directives before
+        // Given: a single `CacheHeader` instance joins its *own* multiple directives before
         // `HeaderNode` is ever involved, so this exercises `CacheHeader`'s own hardcoded `,`
         // rather than `HeaderNode.commaSeparatedNames`.
         let resolved = try await resolve(
@@ -94,7 +94,7 @@ struct HeaderNodeCommaSeparatedNamesTests {
 
     @Test
     func customHeader_whenCombinedUnderNonCommaSeparator_keepsItsOwnSeparator() async throws {
-        // Given -- an arbitrary header name RequestDL doesn't define the semantics of; forcing
+        // Given: an arbitrary header name RequestDL doesn't define the semantics of; forcing
         // comma here would be an overreach `commaSeparatedNames` deliberately doesn't make.
         let resolved = try await resolve(
             TestProperty {

--- a/Tests/RequestDLTests/Properties/Sources/Headers/Headers/Header Node/HeaderNodeSingleValuedNamesTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Headers/Headers/Header Node/HeaderNodeSingleValuedNamesTests.swift
@@ -13,14 +13,14 @@ import Testing
 ///
 /// Two failure modes existed before this fix, both reproduced here:
 /// - No separator in scope: `.adding` fell through to `headers.add(...)`, leaving two raw values
-///   on the same logical entry -- which, for a header a server or client is only allowed to see
-///   once (RFC 9110 §7.2 mandates a 400 for a duplicate `Host`, for instance), reaches the wire
+///   on the same logical entry. For a header a server or client is only allowed to see once
+///   (RFC 9110 §7.2 mandates a 400 for a duplicate `Host`, for instance), that reaches the wire
 ///   as either two field lines or a client-coalesced single line, neither of them what any of
 ///   these headers' own grammar defines.
 /// - A separator in scope: `.adding` spliced the new value directly into whatever was already
 ///   there, producing one *corrupted* string (e.g. a `Content-Type` reading
 ///   `"application/json; charset=UTF-8,application/xml"`) that fails to parse as anything valid
-///   at all -- strictly worse than the no-separator case, since even the original value is lost.
+///   at all: strictly worse than the no-separator case, since even the original value is lost.
 struct HeaderNodeSingleValuedNamesTests {
 
     // MARK: - Same property declared twice
@@ -38,7 +38,7 @@ struct HeaderNodeSingleValuedNamesTests {
             }
         )
 
-        // Then -- RFC 9110 §7.2: a server MUST 400 a request carrying more than one Host field.
+        // Then, per RFC 9110 §7.2: a server MUST 400 a request carrying more than one Host field.
         #expect(resolved.requestConfiguration.headers["Host"] == ["second.example.com"])
     }
 
@@ -55,7 +55,7 @@ struct HeaderNodeSingleValuedNamesTests {
             }
         )
 
-        // Then -- a single serialized origin (RFC 6454/Fetch), never a list.
+        // Then: a single serialized origin (RFC 6454/Fetch), never a list.
         #expect(resolved.requestConfiguration.headers["Origin"] == ["https://second.example.com"])
     }
 
@@ -72,7 +72,7 @@ struct HeaderNodeSingleValuedNamesTests {
             }
         )
 
-        // Then -- a single URI-reference (RFC 9110 §10.1.3), never a list.
+        // Then: a single URI-reference (RFC 9110 §10.1.3), never a list.
         #expect(resolved.requestConfiguration.headers["Referer"] == ["https://second.example.com/"])
     }
 
@@ -88,13 +88,13 @@ struct HeaderNodeSingleValuedNamesTests {
             }
         )
 
-        // Then -- a plain `.add()` would have left two raw values instead of one.
+        // Then: a plain `.add()` would have left two raw values instead of one.
         #expect(resolved.requestConfiguration.headers["Host"] == ["collided.example.com"])
     }
 
     @Test
     func authorization_whenCollidingWithDifferentlyCasedCustomHeader_overwritesWithoutDuplicating() async throws {
-        // Given -- `Authorization` writes via a direct `headers.set(...)`, bypassing `HeaderNode`
+        // Given: `Authorization` writes via a direct `headers.set(...)`, bypassing `HeaderNode`
         // entirely; that alone doesn't stop a later `CustomHeader` from appending onto it.
         let resolved = try await resolve(
             TestProperty {
@@ -110,7 +110,7 @@ struct HeaderNodeSingleValuedNamesTests {
 
     @Test
     func host_whenCollidingWithCustomHeaderUnderExplicitSeparator_overwritesWithoutCorrupting() async throws {
-        // Given -- the sharper failure mode: with a separator in scope, `.adding` used to splice
+        // Given (the sharper failure mode): with a separator in scope, `.adding` used to splice
         // the new value directly into the existing one instead of just duplicating it.
         let resolved = try await resolve(
             TestProperty {
@@ -126,7 +126,7 @@ struct HeaderNodeSingleValuedNamesTests {
 
     @Test
     func contentType_whenCollidingWithCustomHeaderUnderExplicitSeparator_overwritesWithoutCorrupting() async throws {
-        // Given -- the exact scenario that motivated this fix: `Payload` sets `Content-Type` via
+        // Given (the exact scenario that motivated this fix): `Payload` sets `Content-Type` via
         // a direct `.set()`, then a colliding `CustomHeader` with a separator in scope used to
         // splice its value directly into it, producing an unparseable single string
         // ("application/json; charset=UTF-8,application/xml").
@@ -140,7 +140,7 @@ struct HeaderNodeSingleValuedNamesTests {
             }
         )
 
-        // Then -- one valid value, not a garbled concatenation of both.
+        // Then: one valid value, not a garbled concatenation of both.
         #expect(resolved.requestConfiguration.headers["Content-Type"] == ["application/xml"])
     }
 }

--- a/Tests/RequestDLTests/Properties/Sources/Headers/Headers/User Agent/UserAgentHeaderTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Headers/Headers/User Agent/UserAgentHeaderTests.swift
@@ -136,14 +136,14 @@ struct UserAgentHeaderTests {
             }
         )
 
-        // Then -- once a custom value is folded in too, the header is no longer purely
+        // Then: once a custom value is folded in too, the header is no longer purely
         // RequestDL's untouched default, so it must not be reported as such.
         #expect(!resolved.requestConfiguration.hasDefaultUserAgent)
     }
 
     @Test
     func hasDefaultUserAgent_whenDefaultIsCombinedWithCustomHeaderUnderDifferentCasing() async throws {
-        // Given -- a plain `CustomHeader`, not `UserAgentHeader(_:)`, and lowercased, unlike
+        // Given: a plain `CustomHeader`, not `UserAgentHeader(_:)`, and lowercased, unlike
         // `UserAgentHeader`'s own hardcoded "User-Agent" key.
         let resolved = try await resolve(
             TestProperty {
@@ -155,13 +155,13 @@ struct UserAgentHeaderTests {
             }
         )
 
-        // Then -- `HeaderNode.make(_:)` matches "User-Agent" case-insensitively, so this still
+        // Then: `HeaderNode.make(_:)` matches "User-Agent" case-insensitively, so this still
         // counts as a second write and disqualifies the marker, exactly like combining with
         // another `UserAgentHeader(_:)` does above.
         #expect(!resolved.requestConfiguration.hasDefaultUserAgent)
 
         // `CustomHeader` defaults to `headerSeparator == nil`, unlike `UserAgentHeader`'s own
-        // hardcoded `" "` -- so this is stored as two separate values on one logical entry, not
+        // hardcoded `" "`: so this is stored as two separate values on one logical entry, not
         // joined into a single string the way `UserAgentHeader(_:)` combining is. See
         // `RawTaskExecutorDispatchTests.dataTask_defaultUserAgentCollidesWithCustomHeaderOverURLSession_mergesOntoTheWire`
         // for how `URLRequest` itself coalesces this into one comma-joined header on the wire.
@@ -183,7 +183,7 @@ struct UserAgentHeaderTests {
         withDefault.dropDefaultUserAgentForNativeReporting()
         withCustom.dropDefaultUserAgentForNativeReporting()
 
-        // Then -- URLSession synthesizes its own accurate User-Agent only when the request
+        // Then: URLSession synthesizes its own accurate User-Agent only when the request
         // carries none, so the untouched default is removed to let it do that, while a value
         // the caller actually asked for must reach the wire untouched.
         #expect(withDefault.headers["User-Agent"] == nil)

--- a/Tests/RequestDLTests/Properties/Sources/Secure Connection/Secure Connection/Models/ClientIdentityErrorTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Secure Connection/Secure Connection/Models/ClientIdentityErrorTests.swift
@@ -10,15 +10,18 @@ import Testing
 
 @testable import RequestDL
 
-/// Covers `ClientIdentityError`'s own rewrap/description logic -- independent of the real
+/// Covers `ClientIdentityError`'s own rewrap/description logic, independent of the real
 /// Keychain round-trip that actually triggers it (`RawTaskExecutorDispatchTests` covers that end
-/// to end through the public `DataTask` API). Without this type, `RawTask.result()` would let
+/// to end through the public `DataTask` API).
+///
+/// Without this type, `RawTask.result()` would let
 /// `Internals.RawBytesIdentityBuilder.Error`/`Internals.URLSessionIdentityPolicy.ConfigurationError`
-/// -- both package-visible, unreachable by name outside this package -- leak straight to a public
+/// (both package-visible, unreachable by name outside this package) leak straight to a public
 /// `DataTask`/`UploadTask`/`DownloadTask` caller, and `error.localizedDescription` on either one
 /// is Foundation's generic "The operation couldn't be completed" text, not the actionable message
-/// their own `CustomStringConvertible.description` carries. These tests pin both the rewrap and
-/// the `errorDescription`/`localizedDescription` fix in place.
+/// their own `CustomStringConvertible.description` carries.
+///
+/// These tests pin both the rewrap and the `errorDescription`/`localizedDescription` fix in place.
 struct ClientIdentityErrorTests {
 
     @Test
@@ -63,8 +66,8 @@ struct ClientIdentityErrorTests {
         #expect(error.description.contains("Using-a-Client-Certificate-with-URLSession.md"))
     }
 
-    /// The exact gap this type exists to close: `.localizedDescription` -- what most catch sites
-    /// actually print/display -- must carry the same actionable text `.description` does, not
+    /// The exact gap this type exists to close: `.localizedDescription` (what most catch sites
+    /// actually print/display) must carry the same actionable text `.description` does, not
     /// Foundation's generic NSError fallback. Confirmed failing before `LocalizedError`
     /// conformance was added (see the phase's own investigation), not assumed.
     @Test
@@ -103,7 +106,7 @@ struct ClientIdentityErrorTests {
         #expect(status == errSecItemNotFound)
         #expect(error.description.contains("SecItemCopyMatching(identity)"))
         #expect(error.description.contains("\(errSecItemNotFound)"))
-        // This bucket must not claim a missing entitlement -- it can be a genuinely different,
+        // This bucket must not claim a missing entitlement: it can be a genuinely different,
         // still-unresolved issue on non-sandboxed macOS (see <doc:Using-a-Client-Certificate-with-URLSession>'s
         // "Platforms" section), and telling someone to add a capability that won't fix it would be
         // actively misleading.

--- a/Tests/RequestDLTests/Properties/Sources/Secure Connection/Secure Connection/Models/SecureFileErrorTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Secure Connection/Secure Connection/Models/SecureFileErrorTests.swift
@@ -15,8 +15,8 @@ import struct Foundation.Data
 
 private struct SomeUnderlyingError: Error {}
 
-/// Covers `SecureFileError.init(resource:path:underlying:)`'s own classification logic --
-/// relative-path detection and "can't open" vs. "invalid contents" -- independent of which
+/// Covers `SecureFileError.init(resource:path:underlying:)`'s own classification logic
+/// (relative-path detection and "can't open" vs. "invalid contents"), independent of which
 /// caller (`Certificate`, `PrivateKey`) triggered it. `Internals.Certificate`/`Internals.PrivateKey`
 /// only need to get `resource`/`path`/`underlying` right; see `InternalsCertificateTests` and
 /// `InternalsPrivateKeyTests` in `RequestDLInternalsTests` for that half.

--- a/Tests/RequestDLTests/Properties/Sources/Session/Decompression/CustomDecompressorIntegrationTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Session/Decompression/CustomDecompressorIntegrationTests.swift
@@ -20,7 +20,7 @@ import Glibc
 #endif
 
 /// End-to-end coverage for a genuinely custom (non-native) `Decompressor`, run against a raw
-/// socket server that returns bytes exactly as configured -- not a unit test of the codec, but
+/// socket server that returns bytes exactly as configured: not a unit test of the codec, but
 /// of the manual-dispatch wiring itself: deriving `Accept-Encoding` from the configured
 /// algorithm, matching the response's `Content-Encoding` against it, and decoding through
 /// `Internals.AsyncResponse`'s transport-agnostic hook.
@@ -28,7 +28,7 @@ import Glibc
 /// Doesn't use the shared `LocalServer` test harness: its `HTTPHandler` always re-encodes every
 /// configured response body into a `{"receivedBytes": ..., "response": ...}` JSON envelope
 /// (`LocalServer.HTTPHandler.responseData()`), which silently discards a non-JSON body like a
-/// custom `Content-Encoding` payload -- it isn't built for raw-bytes-in, raw-bytes-out.
+/// custom `Content-Encoding` payload; it isn't built for raw-bytes-in, raw-bytes-out.
 struct CustomDecompressorIntegrationTests {
 
     /// A toy run-length codec: a flat sequence of (byte, count) pairs, count in `1...255`.
@@ -79,14 +79,14 @@ struct CustomDecompressorIntegrationTests {
     }
 
     /// A one-shot raw HTTP/1.1 server: accepts a single connection, ignores the request, and
-    /// writes back exactly the bytes given -- no framework in the middle re-encoding anything.
+    /// writes back exactly the bytes given; no framework in the middle re-encoding anything.
     private final class RawHTTPServer: @unchecked Sendable {
         let port: UInt16
         private let listenSocket: Int32
 
         init() throws {
             // `SOCK_STREAM` is a plain `Int32` constant on Darwin, but Glibc types it as
-            // `__socket_type` (a `RawRepresentable` enum with a `UInt32` `rawValue`) -- `socket`
+            // `__socket_type` (a `RawRepresentable` enum with a `UInt32` `rawValue`); `socket`
             // itself expects `Int32` either way.
             #if canImport(Darwin)
             let socketType = SOCK_STREAM
@@ -127,7 +127,7 @@ struct CustomDecompressorIntegrationTests {
 
         /// Serves exactly one request/response on a background thread, then closes.
         ///
-        /// - Note: `DispatchQueue`, not `Thread` -- `Thread` lives in full `Foundation`, not
+        /// - Note: `DispatchQueue`, not `Thread`: `Thread` lives in full `Foundation`, not
         /// `FoundationEssentials`, which is all that's guaranteed to `import` here (see the
         /// file-level `#if canImport(FoundationEssentials)` above). `Dispatch` is portable
         /// either way.
@@ -153,7 +153,7 @@ struct CustomDecompressorIntegrationTests {
     }
 
     /// Real gzip-compressed bytes, via the same `GzipAlgorithm` `Compressor` a real upload would
-    /// use -- not a fixture, so this stays correct if the codec's own output ever changes shape.
+    /// use: not a fixture, so this stays correct if the codec's own output ever changes shape.
     private static func gzipCompress(_ string: String) throws -> [UInt8] {
         let compressor: any Compressor = GzipAlgorithm()
         var stream = try compressor()
@@ -166,12 +166,15 @@ struct CustomDecompressorIntegrationTests {
     func decompressionAlgorithms_whenOnlyNativeAlgorithmConfigured_bypassesManualDispatchUnderURLSession()
         async throws
     {
-        // Given -- `.gzip` alone never forces `.urlSession` to take over `Accept-Encoding` (see
+        // Given: `.gzip` alone never forces `.urlSession` to take over `Accept-Encoding` (see
         // `isNativelyDecodedByURLSession`), unlike the other tests in this file that mix in a
-        // custom algorithm. This exercises `Internals.URLSessionClient.executeSessionTask`'s
-        // plain `.enabled` (bypass) branch specifically -- CFNetwork decodes the response
-        // entirely on its own, with `decompressionDispatch` never becoming `.dispatch`. No
-        // executor is forced here -- `.urlSession` is what this session resolves to by default.
+        // custom algorithm.
+        //
+        // This exercises `Internals.URLSessionClient.executeSessionTask`'s plain `.enabled`
+        // (bypass) branch specifically: CFNetwork decodes the response entirely on its own, with
+        // `decompressionDispatch` never becoming `.dispatch`.
+        //
+        // No executor is forced here; `.urlSession` is what this session resolves to by default.
         let server = try RawHTTPServer()
         let original = String(repeating: "hello native gzip, no custom algorithm in the mix. ", count: 200)
         let encoded = try Self.gzipCompress(original)
@@ -200,15 +203,16 @@ struct CustomDecompressorIntegrationTests {
 
     @Test
     func decompressionAlgorithms_whenOnlyNativeAlgorithmConfigured_bypassesManualDispatchUnderNIO() async throws {
-        // Given -- the `.nio` counterpart to the test above, regression coverage for a real bug:
-        // unlike `.urlSession`, `NIOHTTPResponseDecompressor` has no all-or-nothing
+        // Given: the `.nio` counterpart to the test above, regression coverage for a real bug.
+        // Unlike `.urlSession`, `NIOHTTPResponseDecompressor` has no all-or-nothing
         // `Accept-Encoding` constraint to work around, so `Internals.Client.execute` dispatched
         // manually for every configured algorithm unconditionally, on the assumption that
-        // `NIOHTTPResponseDecompressor` strips `Content-Encoding` once it decodes. It doesn't
-        // (confirmed against the vendored `swift-nio-extras` source) -- so a response compressed
-        // with a genuinely native-only algorithm like `.gzip` reached manual dispatch anyway and
-        // threw `NativeOnlyAlgorithmError`, exactly like a real caller configuring only `.gzip`
-        // under `.nio` would have hit on every request.
+        // `NIOHTTPResponseDecompressor` strips `Content-Encoding` once it decodes.
+        //
+        // It doesn't (confirmed against the vendored `swift-nio-extras` source), so a response
+        // compressed with a genuinely native-only algorithm like `.gzip` reached manual dispatch
+        // anyway and threw `NativeOnlyAlgorithmError`, exactly like a real caller configuring
+        // only `.gzip` under `.nio` would have hit on every request.
         let server = try RawHTTPServer()
         let original = String(repeating: "hello native gzip under NIO, no custom algorithm. ", count: 200)
         let encoded = try Self.gzipCompress(original)
@@ -282,7 +286,7 @@ struct CustomDecompressorIntegrationTests {
             """
         server.respondOnce(headers: headers, body: body)
 
-        // When / Then -- configuring a custom algorithm at all forces this package to take over
+        // When / Then: configuring a custom algorithm at all forces this package to take over
         // decoding for the whole request, so a server sending something that matches none of the
         // configured algorithms must fail loudly rather than hand back undecoded bytes silently.
         await #expect(throws: UnsupportedContentEncodingError.self) {
@@ -295,7 +299,7 @@ struct CustomDecompressorIntegrationTests {
         }
     }
 
-    /// Coverage for the real `BrotliURLSessionOnlyAlgorithm` type specifically -- not a mock --
+    /// Coverage for the real `BrotliURLSessionOnlyAlgorithm` type specifically (not a mock),
     /// confirming `InternalsDecompressionAlgorithmAdapter`'s `algorithm is
     /// BrotliURLSessionOnlyAlgorithm` check actually fires for it, end to end through the public
     /// API: pinning `.nio` while it's configured must fail before ever touching the network,
@@ -304,7 +308,7 @@ struct CustomDecompressorIntegrationTests {
     func decompressionAlgorithms_whenBrotliURLSessionOnlyConfiguredAndNIORequired_throwsExecutorRequirementError()
         async throws
     {
-        // Given -- a port nothing is listening on: if this reached the network at all, it would
+        // Given: a port nothing is listening on. If this reached the network at all, it would
         // fail with a connection error instead, not this one.
         await #expect(throws: ExecutorRequirementError.self) {
             _ = try await DataTask {

--- a/Tests/RequestDLTests/Properties/Sources/Session/Decompression/Models/InternalsDecompressionAlgorithmAdapterTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Session/Decompression/Models/InternalsDecompressionAlgorithmAdapterTests.swift
@@ -9,7 +9,7 @@ import Testing
 struct InternalsDecompressionAlgorithmAdapterTests {
 
     /// A genuinely custom `Decompressor` that happens to claim the same `contentEncodingValue`
-    /// as a built-in placeholder -- exactly the shape a caller would reach for to replace
+    /// as a built-in placeholder: exactly the shape a caller would reach for to replace
     /// ``GzipAlgorithm``'s (silent, OS-native) handling with their own logic.
     private struct CustomAlgorithm: Decompressor {
         let contentEncodingValue: String
@@ -42,9 +42,9 @@ struct InternalsDecompressionAlgorithmAdapterTests {
         contentEncodingValue: String
     ) {
         // A custom algorithm claiming "gzip"/"deflate"/"br" must NOT be mistaken for the built-in
-        // placeholder that shares its wire name -- otherwise `.urlSession` would let CFNetwork
+        // placeholder that shares its wire name; otherwise `.urlSession` would let CFNetwork
         // decode the response transparently and this algorithm would never actually run. Only
-        // the three built-in types above -- which do nothing themselves -- get `true`.
+        // the three built-in types above (which do nothing themselves) get `true`.
         let adapter = InternalsDecompressionAlgorithmAdapter(
             algorithm: CustomAlgorithm(contentEncodingValue: contentEncodingValue)
         )
@@ -64,7 +64,7 @@ struct InternalsDecompressionAlgorithmAdapterTests {
 
     @Test
     func isNativelyDecodedByNIO_whenBrotliURLSessionOnlyAlgorithm_isFalse() {
-        // `NIOHTTPCompression` has no brotli decoder at all, native or otherwise -- unlike
+        // `NIOHTTPCompression` has no brotli decoder at all, native or otherwise; unlike
         // `isNativelyDecodedByURLSession`, brotli is never natively decoded here.
         #expect(
             !InternalsDecompressionAlgorithmAdapter(algorithm: BrotliURLSessionOnlyAlgorithm())
@@ -77,7 +77,7 @@ struct InternalsDecompressionAlgorithmAdapterTests {
         contentEncodingValue: String
     ) {
         // A custom algorithm claiming "gzip"/"deflate" must NOT be mistaken for the built-in
-        // placeholder that shares its wire name -- otherwise `async-http-client`'s own
+        // placeholder that shares its wire name; otherwise `async-http-client`'s own
         // `NIOHTTPResponseDecompressor` would decode the response transparently and this
         // algorithm would never actually run.
         let adapter = InternalsDecompressionAlgorithmAdapter(

--- a/Tests/RequestDLTests/Properties/Sources/Session/Redirect/RedirectStrategyDataTaskTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Session/Redirect/RedirectStrategyDataTaskTests.swift
@@ -23,8 +23,8 @@ import struct Foundation.UUID
 /// `InternalsNIORedirectStrategyAdapterTests` and `InternalsURLSessionClientRedirectStrategyTests`
 /// (`RequestDLInternalsTests`) already cover the two transports' own redirect mechanics in
 /// isolation, each driving `Internals.RedirectStrategy` directly. What neither exercises is the
-/// bridge in between -- `InternalsRedirectStrategyAdapter`/`ClosureRedirectStrategy`, and the
-/// public `RedirectContext`/`RedirectRequest`/`RedirectHistoryEntry` themselves -- since a caller
+/// bridge in between: `InternalsRedirectStrategyAdapter`/`ClosureRedirectStrategy`, and the
+/// public `RedirectContext`/`RedirectRequest`/`RedirectHistoryEntry` themselves. A caller
 /// only ever reaches those through `Session`, not through `Internals` directly.
 struct RedirectStrategyDataTaskTests {
 
@@ -89,9 +89,9 @@ struct RedirectStrategyDataTaskTests {
     /// `.redirectStrategy`/`.onRedirect` over the `.nio`/`.nioTransportServices` executors drive
     /// AsyncHTTPClient's delegate-based `execute(request:delegate:...)` API, as opposed to its
     /// Concurrency `execute(_:deadline:logger:)` family that the `.urlSession` executor has no
-    /// need for. AsyncHTTPClient's own `.strategy` redirect mode is wired up for both --
+    /// need for. AsyncHTTPClient's own `.strategy` redirect mode is wired up for both:
     /// `RedirectHandler`/`RedirectStrategyDelegateBridge.swift` on its side bridge a strategy's
-    /// decision back into the delegate API's request/body types -- so this follows the redirect
+    /// decision back into the delegate API's request/body types. So this follows the redirect
     /// exactly like the `.urlSession` executor does above.
     @Test
     func dataTask_whenRedirectStrategyOverNIO_isInvokedAndControlsTheRedirect() async throws {
@@ -200,8 +200,8 @@ struct RedirectStrategyDataTaskTests {
     /// AsyncHTTPClient's delegate-based path used to fail the whole task for `.doNotFollow`
     /// (resuming normal delivery of the response that triggered the redirect had no route back
     /// from the state its response-delivery state machine had already committed to). Fixed by
-    /// asking the strategy the moment the response head arrives, before any body byte is read --
-    /// see `RedirectHandler.earlyStrategyDecision(head:)` on the async-http-client fork.
+    /// asking the strategy the moment the response head arrives, before any body byte is read.
+    /// See `RedirectHandler.earlyStrategyDecision(head:)` on the async-http-client fork.
     @Test
     func dataTask_whenRedirectStrategyDoesNotFollowOverNIO_returnsRedirectResponseUnfollowed() async throws {
         // Given

--- a/Tests/RequestDLTests/Properties/Sources/Session/Session/SessionTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Session/Session/SessionTests.swift
@@ -378,7 +378,7 @@ struct SessionTests {
         #expect(resolved.session.configuration.decompression == .disabled)
     }
 
-    // Compression moved off `Session` entirely -- see `CompressionEnvironmentTests` for its
+    // Compression moved off `Session` entirely. See `CompressionEnvironmentTests` for its
     // coverage now that it's environment/`Payload`-driven instead.
 
     @Test
@@ -435,7 +435,7 @@ struct SessionTests {
         // Then
         #expect((resolved.session.configuration.tracer as? RecordingTracer) != nil)
 
-        // `async-http-client`'s own built-in tracing is always suppressed -- RequestDL owns the
+        // `async-http-client`'s own built-in tracing is always suppressed; RequestDL owns the
         // span lifecycle itself, in `RawTask.result()`, using `resolved.session.configuration
         // .tracer` directly.
         let builtTracer = try resolved.session.configuration.build().httpClientConfiguration.tracing.tracer

--- a/Tests/RequestDLTests/Properties/Sources/Session/Timeout/Models/TimeoutSourceTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Session/Timeout/Models/TimeoutSourceTests.swift
@@ -31,8 +31,8 @@ struct TimeoutSourceTests {
         #expect(allTimeout == [.connect, .read])
     }
 
-    /// `.resource` means something different from `.connect`/`.read` -- a total end-to-end
-    /// deadline, not a per-phase one -- so it must never be folded into `.all`, or every existing
+    /// `.resource` means something different from `.connect`/`.read`: a total end-to-end
+    /// deadline, not a per-phase one. It must never be folded into `.all`, or every existing
     /// `.all` caller would silently start getting a resource-wide deadline they never asked for.
     @Test
     func allTimeout_neverIncludesResource() async throws {

--- a/Tests/RequestDLTests/Properties/Sources/Tracing/Service Context/RequestServiceContextTests.swift
+++ b/Tests/RequestDLTests/Properties/Sources/Tracing/Service Context/RequestServiceContextTests.swift
@@ -67,7 +67,7 @@ struct RequestServiceContextTests {
     /// `async-http-client`'s own built-in tracing loses `ServiceContext.current` because it only
     /// starts its span after hopping onto a SwiftNIO `EventLoop`. RequestDL sidesteps that entirely
     /// by owning the span lifecycle itself, in `RawTask.result()`, entirely within the caller's own
-    /// task -- no `EventLoop` hop involved -- so this now genuinely works, unlike when tracing was
+    /// task, with no `EventLoop` hop involved. So this now genuinely works, unlike when tracing was
     /// delegated to `async-http-client`.
     @Test
     func dataTask_whenServiceContextSet_shouldBeObservedByTracerDuringExecution() async throws {

--- a/Tests/RequestDLTests/Request/InternalsClientIdentityDescriptorTests.swift
+++ b/Tests/RequestDLTests/Request/InternalsClientIdentityDescriptorTests.swift
@@ -14,7 +14,7 @@ import Testing
 import Foundation
 import Security
 
-/// Covers `Internals.ClientIdentityDescriptor` -- what `BackgroundDownloadTask` persists for a
+/// Covers `Internals.ClientIdentityDescriptor`: what `BackgroundDownloadTask` persists for a
 /// client certificate (mTLS), and rebuilds fresh from disk on every challenge, live or after a
 /// relaunch alike.
 struct InternalsClientIdentityDescriptorTests {
@@ -154,15 +154,16 @@ struct InternalsClientIdentityDescriptorTests {
         #expect(decoded == descriptor)
     }
 
-    // MARK: - makeIdentity() -- real handshake, rebuilt identity
+    // MARK: - makeIdentity() (real handshake, rebuilt identity)
 
     /// The whole point of splitting this type out: an identity rebuilt from nothing but a
-    /// `Descriptor` -- just a certificate/key file path on disk, no `Internals.SecureConnection`,
-    /// no `Property` tree -- still has to genuinely authenticate against a real server requiring
-    /// a client certificate, not just hold the right bytes in memory. Known issue in this bare
-    /// SwiftPM test harness specifically (no Keychain Sharing entitlement), same gap
+    /// `Descriptor` (just a certificate/key file path on disk, no `Internals.SecureConnection`,
+    /// no `Property` tree) still has to genuinely authenticate against a real server requiring
+    /// a client certificate, not just hold the right bytes in memory.
+    ///
+    /// Known issue in this bare SwiftPM test harness specifically (no Keychain Sharing entitlement), same gap
     /// `RequestConfigurationURLSessionClientMTLSTests` already documents at the live-executor
-    /// layer -- this proves the same wiring one layer further removed (via a JSON round trip
+    /// layer. This proves the same wiring one layer further removed (via a JSON round trip
     /// simulating a relaunch), not a new one.
     @Test
     func rebuiltIdentity_whenPresentedToServerRequiringClientCertificate_completesHandshake() async throws {
@@ -236,7 +237,7 @@ struct InternalsClientIdentityDescriptorTests {
     }
 }
 
-/// Answers both halves of an mTLS handshake by hand -- the client-certificate credential directly
+/// Answers both halves of an mTLS handshake by hand: the client-certificate credential directly
 /// (this suite already has the identity in hand), and the server-trust half via
 /// `Internals.ServerTrustPolicy`, the same hookup `BackgroundDownloads.Session`'s own challenge
 /// delegate uses for each.

--- a/Tests/RequestDLTests/Request/InternalsServerTrustPolicyTests.swift
+++ b/Tests/RequestDLTests/Request/InternalsServerTrustPolicyTests.swift
@@ -15,7 +15,7 @@ import Testing
 import Foundation
 import Security
 
-/// Covers `Internals.ServerTrustPolicy` -- the server-trust half `Internals.URLSessionIdentityPolicy`
+/// Covers `Internals.ServerTrustPolicy`: the server-trust half `Internals.URLSessionIdentityPolicy`
 /// now composes rather than duplicates, and the piece `BackgroundDownloadTask` resolves at
 /// schedule time and rebuilds again from a persisted ``Internals/ServerTrustPolicy/Descriptor``,
 /// simulating what happens after a relaunch with nothing else in memory.
@@ -166,7 +166,7 @@ struct InternalsServerTrustPolicyTests {
         #expect(descriptor.spkiPinning == nil)
     }
 
-    /// `Internals.SPKIHash.KnownAlgorithm` only names SHA-256/384/512 -- anything else, like
+    /// `Internals.SPKIHash.KnownAlgorithm` only names SHA-256/384/512. Anything else, like
     /// `Insecure.SHA1` here, still works for live pinning (see
     /// `liveResolvedPolicy_whenSPKIPinningUsesUnnamedAlgorithm_stillMatchesRealServerCertificate`
     /// below) but can't be captured into a `Descriptor`.
@@ -221,7 +221,7 @@ struct InternalsServerTrustPolicyTests {
 
         let original = try Internals.ServerTrustPolicy.resolve(from: secureConnection)
 
-        // When -- exactly what survives a relaunch: the `Descriptor`, JSON round-tripped the same
+        // When: exactly what survives a relaunch. The `Descriptor` is JSON round-tripped the same
         // way `BackgroundDownloads.Session` persists it on `taskDescription`, then rebuilt from
         // that alone.
         let encoded = try JSONEncoder().encode(original.descriptor())
@@ -309,11 +309,11 @@ struct InternalsServerTrustPolicyTests {
         #expect(observer.decisions == [TrustDecision(isTrusted: false, pinsMatched: false)])
     }
 
-    // MARK: - handle(challenge:completionHandler:) -- real handshake, rebuilt policy
+    // MARK: - handle(challenge:completionHandler:) (real handshake, rebuilt policy)
 
     /// The whole point of splitting this type out: a policy rebuilt from nothing but a
-    /// `Descriptor` -- no `Internals.SecureConnection`, no `Property` tree, exactly what a
-    /// `BackgroundDownloadTask` delegate callback has after a relaunch -- still has to genuinely
+    /// `Descriptor` (no `Internals.SecureConnection`, no `Property` tree, exactly what a
+    /// `BackgroundDownloadTask` delegate callback has after a relaunch) still has to genuinely
     /// validate a real server certificate against real trust roots, not just hold the right bytes
     /// in memory.
     @Test
@@ -358,7 +358,7 @@ struct InternalsServerTrustPolicyTests {
 
     @Test
     func rebuiltPolicy_whenTrustRootsDoNotMatch_rejectsRealServerCertificate() async throws {
-        // Given -- the client fixture's own certificate is not the one `LocalServer` presents, so
+        // Given: the client fixture's own certificate is not the one `LocalServer` presents, so
         // anchoring to it specifically must fail the handshake.
         let unrelatedCertificate = Certificates().client()
         let localServer = try await LocalServer(.standard)
@@ -386,7 +386,7 @@ struct InternalsServerTrustPolicyTests {
         }
     }
 
-    // MARK: - handle(challenge:completionHandler:) -- SPKI pinning, real handshake
+    // MARK: - handle(challenge:completionHandler:) (SPKI pinning, real handshake)
 
     @Test
     func rebuiltPolicy_whenSPKIPinningMatchesServerCertificate_acceptsHandshake() async throws {
@@ -430,9 +430,9 @@ struct InternalsServerTrustPolicyTests {
 
     @Test
     func rebuiltPolicy_whenSPKIPinningDoesNotMatchUnderStrictPolicy_rejectsHandshake() async throws {
-        // Given -- trust roots anchor to the real server certificate (so plain chain validation
+        // Given: trust roots anchor to the real server certificate (so plain chain validation
         // passes), but the configured pin is some other certificate's SPKI, not the one
-        // `LocalServer` actually presents -- isolating the rejection to the pin check itself.
+        // `LocalServer` actually presents. This isolates the rejection to the pin check itself.
         let server = Certificates().server()
         let unrelatedCertificate = Certificates().client()
         let wrongPin = try hashSPKI(from: unrelatedCertificate.certificateURL, algorithm: SHA256.self)
@@ -464,7 +464,7 @@ struct InternalsServerTrustPolicyTests {
 
     @Test
     func rebuiltPolicy_whenSPKIPinningDoesNotMatchUnderAuditPolicy_stillAcceptsHandshake() async throws {
-        // Given -- same mismatch as the strict-policy test above, but `.audit` is meant to warn
+        // Given: same mismatch as the strict-policy test above, but `.audit` is meant to warn
         // rather than block, mirroring what `SPKIPinningConfiguration` already does on the
         // NIOSSL/AsyncHTTPClient side.
         let server = Certificates().server()
@@ -503,7 +503,7 @@ struct InternalsServerTrustPolicyTests {
     }
 
     /// `Internals.SPKIHash.KnownAlgorithm` (SHA-256/384/512) only gates what a `Descriptor` can
-    /// carry across a `BackgroundDownloadTask` relaunch -- a live, in-process
+    /// carry across a `BackgroundDownloadTask` relaunch. A live, in-process
     /// `Internals.ServerTrustPolicy` (`URLSessionClient`'s own case, never persisted) pins
     /// correctly with any `Crypto.HashFunction`.
     @Test
@@ -545,7 +545,7 @@ struct InternalsServerTrustPolicyTests {
 
 extension InternalsServerTrustPolicyTests {
 
-    /// Mirrors `SPKIPinningTests.hashSPKI(from:)` -- the exact same SPKI-DER-then-hash pipeline
+    /// Mirrors `SPKIPinningTests.hashSPKI(from:)`: the exact same SPKI-DER-then-hash pipeline
     /// `Internals.SPKIHash`/`Internals.ServerTrustPolicy` use, generalized over the hash algorithm
     /// so `descriptor_whenSPKIPinningUsesUnnamedAlgorithm_throwsUnpersistableAlgorithm` and
     /// `liveResolvedPolicy_whenSPKIPinningUsesUnnamedAlgorithm_stillMatchesRealServerCertificate`
@@ -557,7 +557,7 @@ extension InternalsServerTrustPolicyTests {
     }
 }
 
-/// Forwards a session's server-trust challenge straight to a `ServerTrustPolicy` -- the same
+/// Forwards a session's server-trust challenge straight to a `ServerTrustPolicy`: the same
 /// hookup `BackgroundDownloads.Session`'s own `urlSession(_:task:didReceive:completionHandler:)`
 /// does, minus the `taskDescription` decoding step, since this suite already has the policy in
 /// hand directly.

--- a/Tests/RequestDLTests/Request/RequestBodyBuildingTests.swift
+++ b/Tests/RequestDLTests/Request/RequestBodyBuildingTests.swift
@@ -101,7 +101,7 @@ struct RequestBodyBuildingTests {
 
     @Test
     func requestBody_whenBackedByASingleUnreadFile_wholeFileURLReturnsThatFile() async throws {
-        // Given -- forwards straight to `Internals.BodySequence.wholeFileURL`; see
+        // Given: forwards straight to `Internals.BodySequence.wholeFileURL`; see
         // `InternalsBodySequenceTests`/`InternalsFileBufferTests` for the underlying-buffer-level
         // coverage of what "qualifies" means. This test only confirms `RequestBody` itself
         // forwards it, since `Internals.URLSessionClient+RequestExecutingClient.swift` reads it

--- a/Tests/RequestDLTests/Request/RequestConfigurationCompressionTests.swift
+++ b/Tests/RequestDLTests/Request/RequestConfigurationCompressionTests.swift
@@ -85,7 +85,7 @@ struct RequestConfigurationCompressionTests {
         configuration.body = await RequestBody(buffers: [Internals.DataBuffer(payload)])
         configuration.shouldCompressBodyData = { $0 == payload.count }
 
-        // When -- the closure only agrees to compress if it was handed exactly the body's byte
+        // When: the closure only agrees to compress if it was handed exactly the body's byte
         // count, so a `Content-Encoding` header afterward is itself proof the right value arrived.
         try configuration.applyCompression()
 
@@ -107,7 +107,7 @@ struct RequestConfigurationCompressionTests {
         // Then
         #expect(configuration.headers.first(name: "Content-Encoding") == "gzip")
 
-        // The final, on-the-wire size is only known once the whole body has streamed through --
+        // The final, on-the-wire size is only known once the whole body has streamed through, so
         // `Content-Length` is removed rather than declared upfront, falling back to chunked
         // transfer encoding on both executors.
         #expect(configuration.headers.first(name: "Content-Length") == nil)
@@ -201,7 +201,7 @@ struct RequestConfigurationCompressionTests {
 
     @Test
     func applyCompression_whenBodyIsLarge_compressesInBoundedMemoryAcrossManyChunks() async throws {
-        // Given -- several times over `Internals.BodySequence`'s own chunking, so the compressor
+        // Given: several times over `Internals.BodySequence`'s own chunking, so the compressor
         // genuinely gets fed many separate calls, not one lucky single chunk.
         var configuration = RequestConfiguration()
         let payload = Data(String(repeating: "abcdefgh", count: 2_000_000).utf8)
@@ -211,7 +211,7 @@ struct RequestConfigurationCompressionTests {
         // When
         try configuration.applyCompression()
 
-        // Then -- draining the wrapped body chunk by chunk (rather than all at once) and
+        // Then: draining the wrapped body chunk by chunk (rather than all at once) and
         // reassembling still reproduces byte-identical gzip output, proving the per-chunk
         // `Compressor` state (window, checksum) survives correctly across many calls.
         var chunkCount = 0

--- a/Tests/RequestDLTests/Request/RequestConfigurationURLRequestTests.swift
+++ b/Tests/RequestDLTests/Request/RequestConfigurationURLRequestTests.swift
@@ -75,7 +75,7 @@ struct RequestConfigurationURLRequestTests {
 
     @Test
     func buildURLRequest_whenURLIsMalformed_throwsInvalidRequestURLError() async throws {
-        // Given -- no `BaseURL`, so `url` is empty, which `Foundation.URL(string:)` rejects.
+        // Given: no `BaseURL`, so `url` is empty, which `Foundation.URL(string:)` rejects.
         // Mirrors `BaseURL`'s own documented warning: omitting it is a real, reachable mistake,
         // not a hypothetical one.
         let configuration = RequestConfiguration()

--- a/Tests/RequestDLTests/Request/RequestConfigurationURLSessionClientDownloadTests.swift
+++ b/Tests/RequestDLTests/Request/RequestConfigurationURLSessionClientDownloadTests.swift
@@ -21,16 +21,17 @@ import Security
 /// Unlike the upload tests, there is no known issue here to work around: this uses
 /// `session.dataTask(with:)` under the hood, not `uploadTask(withStreamedRequest:)`, so it never
 /// triggers the resumable-uploads-draft auto-negotiation that made `LocalServer` hang for uploads
-/// (see `RequestConfigurationURLSessionClientUploadTests.swift`'s type doc comment) -- and the existing
+/// (see `RequestConfigurationURLSessionClientUploadTests.swift`'s type doc comment). The existing
 /// buffered `execute(request:delegate:)`, which is also backed by a plain data task, already
 /// confirmed as much.
 ///
-/// `Internals.DownloadBuffer` -- the exact same type `Internals.Session.execute(...)` builds for
-/// the NIO backend -- is reused verbatim rather than reimplemented (it consumes
-/// `Internals.AnyBuffer`, not a NIO `ByteBuffer`, so it was already transport-agnostic). That
-/// reuse is why the tests below assert **exact** chunk boundaries for `.length` mode, stronger
+/// `Internals.DownloadBuffer` is the exact same type `Internals.Session.execute(...)` builds for
+/// the NIO backend, and is reused verbatim rather than reimplemented (it consumes
+/// `Internals.AnyBuffer`, not a NIO `ByteBuffer`, so it was already transport-agnostic).
+///
+/// That reuse is why the tests below assert **exact** chunk boundaries for `.length` mode, stronger
 /// than the acceptance note's minimum bar ("final assembled data and total byte counts match, not
-/// exact chunk boundaries") -- `DownloadBuffer`'s own re-slicing guarantee doesn't depend on how
+/// exact chunk boundaries"). `DownloadBuffer`'s own re-slicing guarantee doesn't depend on how
 /// its *input* happened to be fragmented, so it should hold across executors, not just on NIO;
 /// these tests are what confirm that design assumption rather than just asserting the loosest
 /// possible bar.
@@ -85,8 +86,8 @@ struct RequestConfigurationURLSessionClientDownloadTests {
         // `step.bytes.totalSize` comes from the response's own `Content-Length`, which
         // `LocalServer` sets to the size of the envelope it actually sends (`HTTPResult`'s
         // `{"receivedBytes":...,"response":...}`, built server-side from what it received on the
-        // request), not `response.data.count` -- the size of just the configured "response" field
-        // this test set up. Comparing against what was actually assembled here is what proves
+        // request), not `response.data.count` (the size of just the configured "response" field
+        // this test set up). Comparing against what was actually assembled here is what proves
         // `totalSize` and the real transfer agree, not a fixture-shaped coincidence.
         #expect(step.bytes.totalSize == assembled.count)
 
@@ -99,7 +100,7 @@ struct RequestConfigurationURLSessionClientDownloadTests {
 
     @Test
     func urlSessionClient_whenStreamingDownload_splitsOnSeparatorAcrossChunkBoundaries() async throws {
-        // Given -- a payload sized so the separator (`,`) straddles wherever URLSession happens
+        // Given: a payload sized so the separator (`,`) straddles wherever URLSession happens
         // to slice `didReceive data:` calls, exercising `Internals.DownloadBuffer`'s rolling
         // window (see its own doc comment) with real, executor-determined arrival boundaries
         // instead of ones a test controls directly.
@@ -147,7 +148,7 @@ struct RequestConfigurationURLSessionClientDownloadTests {
         let decoded = try HTTPResult<String>(assembled)
         #expect(decoded.response == output)
 
-        // Every chunk but a possible last remainder ends with the separator -- proves the
+        // Every chunk but a possible last remainder ends with the separator, proving the
         // rechunking actually happened along `,` boundaries, not just that concatenation works.
         // (The `HTTPResult` envelope itself adds exactly one more `,` between its own fields, so
         // this holds for the whole wire payload, not just the `output` field inside it.)
@@ -156,7 +157,7 @@ struct RequestConfigurationURLSessionClientDownloadTests {
     }
 
     /// A refused redirect fires before any response ever reaches
-    /// `didReceive response:completionHandler:` for the *destination* -- it's the redirect
+    /// `didReceive response:completionHandler:` for the *destination*. It's the redirect
     /// itself `willPerformHTTPRedirection` refuses, so `redirectError` has to be checked in
     /// `resolveHead(with:downloadBuffer:)`, not just in the buffered/streamed-upload paths'
     /// `didCompleteWithError:`. This is what proves that wiring, not just that redirects work at
@@ -164,7 +165,7 @@ struct RequestConfigurationURLSessionClientDownloadTests {
     /// `InternalsURLSessionClientRedirectTests`, which shares the same `TaskDelegate` code path).
     @Test
     func urlSessionClient_whenRedirectChainExceedsMax_throwsBeforeYieldingAStep() async throws {
-        // Given -- two redirects (origin -> hop -> destination) against a client only willing to
+        // Given: two redirects (origin -> hop -> destination) against a client only willing to
         // follow one.
         let localServer = try await LocalServer(.standard)
         let origin = "/" + UUID().uuidString
@@ -209,12 +210,12 @@ struct RequestConfigurationURLSessionClientDownloadTests {
             )
             Issue.record("Not expecting success")
         } catch is Internals.URLSessionClient.RedirectLimitReachedError {
-            // Then -- expected
+            // Then: expected
         }
     }
 }
 
-/// Test-only stand-in for the real client's own TLS challenge handling -- `LocalServer` is
+/// Test-only stand-in for the real client's own TLS challenge handling. `LocalServer` is
 /// always TLS-terminated with a throwaway self-signed certificate, even outside any TLS feature
 /// under test, so *something* has to trust it for a plain, no-customization round trip to
 /// complete at all. Duplicated from `RequestConfigurationURLSessionClientTests.swift` (`private`

--- a/Tests/RequestDLTests/Request/RequestConfigurationURLSessionClientTests.swift
+++ b/Tests/RequestDLTests/Request/RequestConfigurationURLSessionClientTests.swift
@@ -21,7 +21,7 @@ import Security
 /// Mirrors `DataTaskTests.dataTask()` (same `LocalServer`/`ResponseConfiguration` fixtures, same
 /// `{"receivedBytes", "response"}` envelope), but drives `RequestConfiguration.buildURLRequest()`
 /// + `Internals.URLSessionClient` directly instead of `DataTask`, and skips `SecureConnection`
-/// entirely -- no TLS customization is in scope here, so trusting `LocalServer`'s self-signed
+/// entirely: no TLS customization is in scope here, so trusting `LocalServer`'s self-signed
 /// certificate is handled by a test-only `URLSessionTaskDelegate` instead.
 struct RequestConfigurationURLSessionClientTests {
 
@@ -68,37 +68,43 @@ struct RequestConfigurationURLSessionClientTests {
 }
 
 /// The TLS/mTLS challenge handling promoted from `Internals.RawBytesIdentityBuilder`/
-/// `Internals.URLSessionIdentityPolicy` -- built from whatever `Internals.SecureConnection` the
+/// `Internals.URLSessionIdentityPolicy`: built from whatever `Internals.SecureConnection` the
 /// resolved `Property` tree carries, same as the NIO backend, instead of the
 /// `AcceptAnyServerTrustDelegate` workaround the still-TLS-unaware test above needs.
 ///
 /// **The client-identity round trip (`urlSessionClient_whenMTLSConfigured_...` below) is a known
 /// issue running through this bare SwiftPM test harness on *any* platform, not macOS
-/// specifically** -- confirmed by actually running it both ways, not assumed: on macOS (`swift
+/// specifically.** This was confirmed by actually running it both ways, not assumed: on macOS (`swift
 /// test`, unsigned CLI binary) and on an iOS Simulator (`xcodebuild test -scheme request-dl`,
 /// SwiftPM's auto-generated scheme), both fail identically with
-/// `Internals.RawBytesIdentityBuilder.Error.missingKeychainSharingEntitlement`'s exact message --
+/// `Internals.RawBytesIdentityBuilder.Error.missingKeychainSharingEntitlement`'s exact message,
 /// which is itself the confirmation the actionable-error-wrapping half of that mapping works
-/// correctly on both. The common thread is not the OS, it's that neither run carries a Keychain
+/// correctly on both.
+///
+/// The common thread is not the OS, it's that neither run carries a Keychain
 /// Sharing entitlement: `swift test` produces a bare unsigned binary, and SwiftPM's
 /// auto-generated Xcode scheme has no `.entitlements` file to add the capability to (there is
-/// nowhere in a `Package.swift`-only project to configure it -- see
+/// nowhere in a `Package.swift`-only project to configure it; see
 /// `Sources/RequestDL/Documentation.docc/Advanced/Using-a-Client-Certificate-with-URLSession.md`,
 /// which is written for a real app target's Signing &
-/// Capabilities tab, not a SwiftPM test bundle). A properly configured Xcode *app* project/target
-/// (or extension) with Keychain Sharing added -- the setup that same article walks through, and
-/// what the original spike this promotes from was validated against -- is expected to complete
+/// Capabilities tab, not a SwiftPM test bundle).
+///
+/// A properly configured Xcode *app* project/target
+/// (or extension) with Keychain Sharing added (the setup that same article walks through, and
+/// what the original spike this promotes from was validated against) is expected to complete
 /// this same round trip for real; this suite cannot exercise that shape of project. The
 /// server-trust-only tests below it (no client identity involved) are unaffected by
-/// any of this and genuinely pass on macOS, iOS Simulator, and Linux (Docker, `swift:6.2`) alike
-/// -- Linux and Simulator confirmed directly, not assumed either. `Internals.URLSessionClient`
+/// any of this and genuinely pass on macOS, iOS Simulator, and Linux (Docker, `swift:6.2`) alike;
+/// Linux and Simulator were confirmed directly, not assumed either.
+///
+/// `Internals.URLSessionClient`
 /// and everything under `Sources/RequestDLInternals/.../URLSession Client/` is Apple-only
 /// (`canImport(Darwin)`-gated) by design, so this whole test file compiles to nothing on Linux;
 /// only `CertificateFixturesExpirationTests` (fixture-only, no TLS handshake) runs there, and
 /// does.
 struct RequestConfigurationURLSessionClientMTLSTests {
 
-    /// Direct port of `DataTaskTests.dataTask_whenCAEnabled` -- same `LocalServer`/`Certificates`
+    /// Direct port of `DataTaskTests.dataTask_whenCAEnabled`: same `LocalServer`/`Certificates`
     /// fixtures, same `Certificate`/`PrivateKey`/`TrustRoots` sources (file paths, PEM, RSA), but
     /// forced onto `.urlSession` instead of driven through `DataTask`. See the type doc comment
     /// for why this specific test is a known issue in this test harness, on every platform.
@@ -113,7 +119,7 @@ struct RequestConfigurationURLSessionClientMTLSTests {
         let localServer = try await LocalServer(
             LocalServer.Configuration(
                 host: "localhost",
-                // Dedicated port -- 8887/8888/8889 are already claimed by other
+                // Dedicated port: 8887/8888/8889 are already claimed by other
                 // LocalServer-backed suites (see LocalServer.Configuration.swift / DataTaskTests.swift).
                 port: 8892,
                 option: .client(client)
@@ -148,7 +154,7 @@ struct RequestConfigurationURLSessionClientMTLSTests {
 
         let request = try await resolved.requestConfiguration.buildURLRequest()
 
-        // Then -- see the type doc comment: known issue in this bare SwiftPM test harness on
+        // Then: see the type doc comment. Known issue in this bare SwiftPM test harness on
         // every platform (confirmed on macOS and iOS Simulator directly), not a defect in the
         // mapping this test otherwise exercises, and not specific to macOS.
         await withKnownIssue(
@@ -166,11 +172,11 @@ struct RequestConfigurationURLSessionClientMTLSTests {
         )
     }
 
-    /// `trustRoots` alone (no client identity) -- confirms the server-trust half of
+    /// `trustRoots` alone (no client identity): confirms the server-trust half of
     /// `Internals.URLSessionIdentityPolicy` works independently of the client-certificate half.
     ///
     /// Needs `.scripts/generate-test-certificates.sh`'s fixtures (SAN, `extendedKeyUsage`, a
-    /// validity period under Apple's enforced cap) to pass at all -- the original 30-year,
+    /// validity period under Apple's enforced cap) to pass at all. The original 30-year,
     /// EKU-less fixtures failed `SecTrustEvaluateWithError` outright even when explicitly
     /// anchored via `SecTrustSetAnchorCertificates`, a `SecPolicyCreateSSL` enforcement uniform
     /// across every Apple platform that NIOSSL's own validation (what
@@ -221,7 +227,7 @@ struct RequestConfigurationURLSessionClientMTLSTests {
     }
 
     /// `.none` verification accepts `LocalServer`'s self-signed certificate with no `TrustRoots`
-    /// configured at all -- and, unlike the two tests above, does so against a server whose
+    /// configured at all. Unlike the two tests above, it does so against a server whose
     /// certificate is not otherwise trusted, which is what makes this meaningfully different from
     /// `.fullVerification` rather than a tautology (see the paired rejection test below).
     @Test
@@ -268,7 +274,7 @@ struct RequestConfigurationURLSessionClientMTLSTests {
     /// Proves the two tests above are not tautological: with no `SecureConnection` at all (no
     /// `identityPolicy`, so the TLS challenge falls through to `URLSession`'s own default
     /// handling), `LocalServer`'s self-signed certificate is *not* trusted by the system and the
-    /// request fails -- the same shape of failure `.fullVerification`/no-`TrustRoots` would hit,
+    /// request fails: the same shape of failure `.fullVerification`/no-`TrustRoots` would hit,
     /// which is exactly why the tests above configure `TrustRoots`/`.none` explicitly.
     @Test
     func urlSessionClient_whenNoSecureConnectionConfigured_rejectsUntrustedServerCertificate() async throws {
@@ -306,7 +312,7 @@ struct RequestConfigurationURLSessionClientMTLSTests {
     }
 }
 
-/// Test-only stand-in for the real client's own TLS challenge handling -- `LocalServer` is
+/// Test-only stand-in for the real client's own TLS challenge handling. `LocalServer` is
 /// always TLS-terminated with a throwaway self-signed certificate, even outside any TLS feature
 /// under test, so *something* has to trust it for a plain, no-customization round trip to
 /// complete at all.

--- a/Tests/RequestDLTests/Request/RequestConfigurationURLSessionClientUploadTests.swift
+++ b/Tests/RequestDLTests/Request/RequestConfigurationURLSessionClientUploadTests.swift
@@ -22,30 +22,34 @@ import Security
 /// the total bytes it actually received, not per-chunk), but drives
 /// `RequestConfiguration.buildURLRequestWithoutBody()` + the streaming `execute` overload directly
 /// instead of `UploadTask`, and trusts `LocalServer`'s self-signed certificate via a test-only
-/// delegate the same way the non-streaming suite does -- no TLS customization is in scope here
+/// delegate the same way the non-streaming suite does. No TLS customization is in scope here
 /// either.
 ///
-/// **Both tests below used to be a confirmed `withKnownIssue`** -- the original bridge
+/// **Both tests below used to be a confirmed `withKnownIssue`.** The original bridge
 /// (`Internals.URLSessionUploadStream`, an `InputStream` subclass) drove
 /// `uploadTask(withStreamedRequest:)`, which on this OS build automatically negotiates the IETF
-/// "resumable uploads" draft for any streamed upload, and a from-scratch investigation confirmed
-/// the real cause runs deeper than that draft negotiation alone: no custom `InputStream` -- a
-/// Swift subclass or a genuine `CFReadStream` -- is ever recognized by CFNetwork as reaching
+/// "resumable uploads" draft for any streamed upload. A from-scratch investigation confirmed
+/// the real cause runs deeper than that draft negotiation alone: no custom `InputStream`, whether
+/// a Swift subclass or a genuine `CFReadStream`, is ever recognized by CFNetwork as reaching
 /// end-of-body, on `LocalServer`, two independent HTTP/2 servers, and `https://httpbin.org/post`
 /// alike. Every callback-level hypothesis (`copyProperty`/`setProperty`, `getBuffer`,
-/// object-identity) was ruled out without finding the mechanism. `Internals.URLSessionUploadFile`
+/// object-identity) was ruled out without finding the mechanism.
+///
+/// `Internals.URLSessionUploadFile`
 /// works around it instead of fixing it: it drains `body` and this now drives
 /// `uploadTask(with:from:)` (small bodies, kept in memory) or
 /// `uploadTask(with:fromFile:)` (anything past `Internals.URLSessionUploadFile.inMemoryThreshold`,
-/// spilled to a temporary file) -- both completely different `URLSession` code paths that never
+/// spilled to a temporary file). Both are completely different `URLSession` code paths that never
 /// touch `InputStream`/`needNewBodyStream` (or the resumable-uploads draft) at all. Both payloads
 /// in `urlSessionClient_whenStreamingUpload...` below (256 KiB, 128 KiB) sit comfortably under
 /// that threshold, so those two tests specifically exercise the in-memory branch;
 /// `InternalsURLSessionUploadFileTests` (`RequestDLInternalsTests`) covers the file-spillover
-/// branch directly, without a real network round trip. A third shape -- a `Payload(url:)` body
+/// branch directly, without a real network round trip.
+///
+/// A third shape, a `Payload(url:)` body
 /// that's already sitting in a file untouched, forwarded as `existingUploadFile` rather than
 /// drained at all (a same-day refinement past the memory/disk split, to avoid a redundant copy
-/// of a file that's already exactly right) -- is exercised by
+/// of a file that's already exactly right), is exercised by
 /// `urlSessionClient_whenStreamingUploadFromExistingFile_deliversWholeBodyIntact`.
 ///
 /// See `simulatorAffectedURLSessionRequestTimeout`'s doc comment (`RequestDLTestSupport`) for why
@@ -55,13 +59,15 @@ import Security
 /// `.serialized`: this suite's three tests all do real network I/O against a `LocalServer`, and
 /// unlike every other real-I/O suite here (`SessionExecutionTests`, `DataCacheTests`,
 /// `CachedRequestTests`, all already `.serialized`) this one ran its own tests concurrently with
-/// each other -- real, informative `NSURLErrorTimedOut` failures directly observed on CI Simulator
+/// each other. Real, informative `NSURLErrorTimedOut` failures directly observed on CI Simulator
 /// runners in `urlSessionClient_whenStreamingUploadFromExistingFile_deliversWholeBodyIntact`
 /// (request-dl-nio#327) tracked back partly to this suite adding to its *own* concurrent load, on
-/// top of whatever contention the rest of the job was already under. `.concurrent(
+/// top of whatever contention the rest of the job was already under.
+///
+/// `.concurrent(
 /// watchdogAffectedPlatformConcurrencyLimit)`/`.nonFatalWatchdog`: real network I/O on the same
 /// simulator runners `WatchdogAffectedPlatformConcurrencyLimit.swift` documents as prone to
-/// scheduler-contention `AsyncLock.Watchdog` false positives -- without these, a stall elsewhere
+/// scheduler-contention `AsyncLock.Watchdog` false positives. Without these, a stall elsewhere
 /// in the same job (this suite adding to the unthrottled concurrent load) can trip a watchdog
 /// fatally and crash the whole test process mid-run, taking every other in-flight test down with
 /// it, rather than surfacing as this suite's own (real, informative) timeout.
@@ -125,7 +131,7 @@ struct RequestConfigurationURLSessionClientUploadTests {
     /// body is backed by exactly one unread, non-temporary `Internals.FileBuffer`, so
     /// `RequestBody.wholeFileURL` resolves to the fixture file itself and
     /// `Internals.URLSessionClient+RequestExecutingClient.swift` passes it straight through as
-    /// `existingUploadFile` -- exercised directly here (rather than only at the `RequestBody`
+    /// `existingUploadFile`. It's exercised directly here (rather than only at the `RequestBody`
     /// unit-test level, `RequestBodyBuildingTests`) so a real round trip confirms the shortcut
     /// still delivers the exact right bytes, not just that the URL gets forwarded correctly.
     @Test
@@ -188,13 +194,13 @@ struct RequestConfigurationURLSessionClientUploadTests {
         #expect(decoded.receivedBytes == upload.count)
         #expect(decoded.response == output)
 
-        // The fixture file must survive the upload untouched -- unlike `.file`, `.existingFile`
+        // The fixture file must survive the upload untouched: unlike `.file`, `.existingFile`
         // is never this package's to remove.
         #expect(await fileURL.isReachable)
     }
 
-    /// Not exact chunk-by-chunk byte counts or timing (URLSession's own to pick, not RequestDL's)
-    /// -- just that `didSendBodyData` fires in a sequence whose cumulative total is monotonically
+    /// Not exact chunk-by-chunk byte counts or timing (URLSession's own to pick, not RequestDL's),
+    /// just that `didSendBodyData` fires in a sequence whose cumulative total is monotonically
     /// increasing and reaches the whole body, mirroring what `ModifiersProgressTests`'s looser
     /// upload assertion (`uploadMonitor.uploadedBytes.reduce(.zero, +) == data.count`, sum only)
     /// checks on the NIO backend. `uploadTask(with:fromFile:)` still fires `didSendBodyData` the
@@ -255,7 +261,7 @@ struct RequestConfigurationURLSessionClientUploadTests {
     }
 }
 
-/// Test-only stand-in for the real client's own TLS challenge handling -- `LocalServer` is
+/// Test-only stand-in for the real client's own TLS challenge handling. `LocalServer` is
 /// always TLS-terminated with a throwaway self-signed certificate, even outside any TLS feature
 /// under test, so *something* has to trust it for a plain, no-customization round trip to
 /// complete at all. Duplicated from `RequestConfigurationURLSessionClientTests.swift` (`private`
@@ -281,7 +287,7 @@ private final class AcceptAnyServerTrustDelegate: NSObject, URLSessionTaskDelega
     }
 }
 
-/// Collects `onUploadProgress` samples under a lock -- the callback is `@Sendable` and may be
+/// Collects `onUploadProgress` samples under a lock; the callback is `@Sendable` and may be
 /// invoked off the main actor.
 private final class ProgressRecorder: @unchecked Sendable {
 

--- a/Tests/RequestDLTests/Tasks/Sources/Background Download/BackgroundDownloadTaskTests.swift
+++ b/Tests/RequestDLTests/Tasks/Sources/Background Download/BackgroundDownloadTaskTests.swift
@@ -18,20 +18,22 @@ import struct Foundation.Data
 import struct Foundation.URL
 #endif
 
-/// Only covers `result()`'s validation guard -- the part that runs and throws (or doesn't) before
+/// Only covers `result()`'s validation guard: the part that runs and throws (or doesn't) before
 /// ever reaching `BackgroundDownloads.Session.shared.schedule(...)`. Actually scheduling a
 /// download would start a real `URLSessionConfiguration.background` session from this bare
 /// SwiftPM test harness, an unsigned CLI process with none of the entitlements a real app target
 /// has; that path is not exercised here, the same way this suite's mTLS tests don't exercise a
-/// real Keychain round trip either. A file-backed client certificate is legitimately *accepted*
-/// now (no longer a rejection case) -- see `InternalsClientIdentityDescriptorTests` for that half,
+/// real Keychain round trip either.
+///
+/// A file-backed client certificate is legitimately *accepted*
+/// now (no longer a rejection case); see `InternalsClientIdentityDescriptorTests` for that half,
 /// since proving it doesn't throw here would mean letting `result()` run all the way to
 /// `schedule(...)`.
 struct BackgroundDownloadTaskTests {
 
     @Test
     func result_whenClientCertificateIsBytesBacked_throwsUnsupportedConfigurationError() async throws {
-        // Given -- valid, complete, in-memory bytes rather than a file path.
+        // Given: valid, complete, in-memory bytes rather than a file path.
         let client = Certificates().client()
         let certificateBytes = try [UInt8](Data(contentsOf: client.certificateURL))
         let privateKeyBytes = try [UInt8](Data(contentsOf: client.privateKeyURL))
@@ -95,7 +97,7 @@ struct BackgroundDownloadTaskTests {
     }
 
     /// Only half a client identity configured (`Certificates` without `PrivateKey`) must still be
-    /// rejected -- it's just as unable to answer a challenge as any other unsupported shape.
+    /// rejected; it's just as unable to answer a challenge as any other unsupported shape.
     @Test
     func result_whenContentConfiguresOnlyCertificateChain_throwsUnsupportedConfigurationError() async throws {
         // Given
@@ -125,12 +127,12 @@ struct BackgroundDownloadTaskTests {
     }
 
     /// `Insecure.SHA1` isn't one of `Internals.SPKIHash.KnownAlgorithm`'s three cases, so it pins
-    /// correctly live (see `InternalsServerTrustPolicyTests`) but can't be captured for a relaunch
-    /// -- exactly the same "works live, not here" split `result_whenClientCertificateIsBytesBacked...`
+    /// correctly live (see `InternalsServerTrustPolicyTests`) but can't be captured for a relaunch.
+    /// This is exactly the same "works live, not here" split `result_whenClientCertificateIsBytesBacked...`
     /// above exercises for mTLS.
     @Test
     func result_whenSPKIPinningUsesUnnamedAlgorithm_throwsUnsupportedConfigurationError() async throws {
-        // Given -- any digest of the right byte count for the algorithm; SPKIHash's own length
+        // Given: any digest of the right byte count for the algorithm; SPKIHash's own length
         // validation, not a real match against a server certificate, is what this test needs.
         let dummyDigest = Data(repeating: 0, count: Insecure.SHA1.Digest.byteCount)
 

--- a/Tests/RequestDLTests/Tasks/Sources/Background Download/Models/BackgroundDownloadsSessionDelegateTests.swift
+++ b/Tests/RequestDLTests/Tasks/Sources/Background Download/Models/BackgroundDownloadsSessionDelegateTests.swift
@@ -13,16 +13,16 @@ import Testing
 import Foundation
 
 /// Covers `BackgroundDownloads.Session`'s `URLSessionDownloadDelegate` callbacks directly, against
-/// a task built from an ordinary (non-background) `URLSession.shared` -- never resumed, only ever
+/// a task built from an ordinary (non-background) `URLSession.shared`. It is never resumed, only ever
 /// used as a way to get a real `URLSessionDownloadTask` object to set `taskDescription` on and
 /// hand to the delegate method by hand. This exercises the same code a real background transfer
 /// would run through, without starting one: this SwiftPM test harness has none of the entitlements
 /// a real background session needs to actually schedule anything (the same gap already documented
-/// for Keychain-backed mTLS), so this is the ceiling of what can be verified here -- see
+/// for Keychain-backed mTLS), so this is the ceiling of what can be verified here. See
 /// `BackgroundDownloadTaskTests`'s own doc comment for the same reasoning applied to `result()`.
 ///
 /// Every delegate method under test is synchronous by contract (that's the whole reason `Session`
-/// isn't an `actor` -- see its own doc comment), so every assertion below runs immediately after
+/// isn't an `actor`; see its own doc comment), so every assertion below runs immediately after
 /// the call that's supposed to have triggered it, with no `await`/polling needed. Every test also
 /// builds its own `BackgroundDownloads.Session()` rather than reusing `.shared`, so `onEvent`
 /// assertions never race another test's.
@@ -68,7 +68,7 @@ struct BackgroundDownloadsSessionDelegateTests {
     func didFinishDownloadingTo_whenDestinationAlreadyExists_overwritesIt() async throws {
         try await withTemporaryFileURL("source.tmp") { location in
             try await withTemporaryFileURL("destination.bin") { destination in
-                // Given -- `withTemporaryFileURL` itself already creates an empty file at
+                // Given: `withTemporaryFileURL` itself already creates an empty file at
                 // `destination`, so this is already exercising the overwrite path; write
                 // something recognizable there first to make sure it really gets replaced, not
                 // just left alone as "already existing."
@@ -92,7 +92,7 @@ struct BackgroundDownloadsSessionDelegateTests {
     @Test
     func didFinishDownloadingTo_whenSourceFileIsMissing_reportsFailed() async throws {
         try await withTemporaryFileURL("destination.bin") { destination in
-            // Given -- `location` deliberately never gets a file written to it, so `moveItem`
+            // Given: `location` deliberately never gets a file written to it, so `moveItem`
             // has nothing to move.
             let missingLocation = temporaryDirectoryURL.appendingPathComponent("RequestDL.\(UUID()).missing")
 
@@ -122,7 +122,7 @@ struct BackgroundDownloadsSessionDelegateTests {
     @Test
     func didFinishDownloadingTo_whenTaskDescriptionMissing_doesNothing() async throws {
         try await withTemporaryFileURL("source.tmp") { location in
-            // Given -- no `taskDescription` set at all, the shape a task RequestDL didn't create
+            // Given: no `taskDescription` set at all, the shape a task RequestDL didn't create
             // would have.
             try Data("content".utf8).write(to: location)
 
@@ -135,7 +135,7 @@ struct BackgroundDownloadsSessionDelegateTests {
             // When
             session.urlSession(.shared, downloadTask: task, didFinishDownloadingTo: location)
 
-            // Then -- neither reported nor moved; this task simply isn't this delegate's to
+            // Then: neither reported nor moved; this task simply isn't this delegate's to
             // handle.
             #expect(events.all.isEmpty)
             #expect(FileManager.default.fileExists(atPath: location.path))
@@ -164,7 +164,7 @@ struct BackgroundDownloadsSessionDelegateTests {
                 totalBytesExpectedToWrite: 16_384
             )
 
-            // Then -- the running totals, not the size of this one callback.
+            // Then: the running totals, not the size of this one callback.
             let recorded = events.all
             #expect(recorded.count == 1)
 
@@ -214,7 +214,7 @@ struct BackgroundDownloadsSessionDelegateTests {
         }
     }
 
-    /// The delegate also fires this on success, with `error == nil` -- must not double-report on
+    /// The delegate also fires this on success, with `error == nil`; must not double-report on
     /// top of `didFinishDownloadingTo`'s own `.completed` event.
     @Test
     func didCompleteWithError_whenErrorIsNil_reportsNothing() async throws {
@@ -253,7 +253,7 @@ struct BackgroundDownloadsSessionDelegateTests {
         // Then
         #expect(firstCalled.wasCalled)
 
-        // And -- a second finish-events call with no new `handleEvents` in between must not
+        // And: a second finish-events call with no new `handleEvents` in between must not
         // re-invoke a stale handler.
         let secondCalled = CallBox()
         session.urlSessionDidFinishEvents(forBackgroundURLSession: .shared)
@@ -279,7 +279,7 @@ struct BackgroundDownloadsSessionDelegateTests {
 
 // MARK: - Test helpers
 
-/// Both helpers below are plain, lock-backed classes, not actors -- every callback under test
+/// Both helpers below are plain, lock-backed classes, not actors. Every callback under test
 /// (`onEvent`, `handleEvents`'s `completionHandler`) is synchronous by contract, so an `actor`
 /// would force an `await` onto assertions that need to run immediately, not after a hop.
 private final class EventBox: @unchecked Sendable {

--- a/Tests/RequestDLTests/Tasks/Sources/Background Download/Models/BackgroundDownloadsSessionTests.swift
+++ b/Tests/RequestDLTests/Tasks/Sources/Background Download/Models/BackgroundDownloadsSessionTests.swift
@@ -12,9 +12,11 @@ import Testing
 import Foundation
 
 /// Covers `BackgroundDownloads.Session`'s `taskDescription` encoding directly, independent of any
-/// real `URLSessionTask` -- this is what a delegate callback decodes after a relaunch, when
-/// nothing else about the original request survives, so it needs to round-trip correctly on its
-/// own merits, not just "happen to work" against whatever a live download produces.
+/// real `URLSessionTask`: this is what a delegate callback decodes after a relaunch, when
+/// nothing else about the original request survives.
+///
+/// It needs to round-trip correctly on its own merits, not just "happen to work" against
+/// whatever a live download produces.
 struct BackgroundDownloadsSessionTests {
 
     @Test
@@ -66,7 +68,7 @@ struct BackgroundDownloadsSessionTests {
 
     @Test
     func decodeServerTrust_whenNoneWasEncoded_returnsNil() async throws {
-        // Given -- the common case: a plain download, `serverTrust` defaulted to `nil`.
+        // Given: the common case, a plain download with `serverTrust` defaulted to `nil`.
         let encoded = BackgroundDownloads.Session.encode(
             id: "episode-42",
             destination: URL(fileURLWithPath: "/tmp/episode-42.mp3")
@@ -106,7 +108,7 @@ struct BackgroundDownloadsSessionTests {
 
     @Test
     func decodeClientIdentity_whenNoneWasEncoded_returnsNil() async throws {
-        // Given -- the common case: no client certificate configured.
+        // Given: the common case, no client certificate configured.
         let encoded = BackgroundDownloads.Session.encode(
             id: "episode-42",
             destination: URL(fileURLWithPath: "/tmp/episode-42.mp3")
@@ -123,7 +125,7 @@ struct BackgroundDownloadsSessionTests {
 
     @Test
     func encodeThenDecode_carriesBothServerTrustAndClientIdentityIndependently() async throws {
-        // Given -- both configured at once, the mTLS + custom-trust-roots combination.
+        // Given: both configured at once, the mTLS + custom-trust-roots combination.
         let serverTrust = Internals.ServerTrustPolicy.Descriptor(
             trustedRootCertificatesDER: [Data([0x01])],
             verification: .fullVerification
@@ -150,9 +152,10 @@ struct BackgroundDownloadsSessionTests {
     // MARK: - firstTask(matching:in:)
 
     /// `cancel(id:)`'s own matching logic, pulled out so it's testable against a plain array of
-    /// tasks instead of a real background `URLSession.allTasks`. Every task below comes from
-    /// `URLSession.shared`, created but never resumed -- just a way to get a real
-    /// `URLSessionTask` object to set `taskDescription` on.
+    /// tasks instead of a real background `URLSession.allTasks`.
+    ///
+    /// Every task below comes from `URLSession.shared`, created but never resumed; it's just a
+    /// way to get a real `URLSessionTask` object to set `taskDescription` on.
     @Test
     func firstTaskMatching_whenOneTaskHasMatchingID_returnsIt() async throws {
         // Given
@@ -200,7 +203,7 @@ struct BackgroundDownloadsSessionTests {
         let unrecognized = URLSession.shared.downloadTask(with: url)
         unrecognized.taskDescription = "not a descriptor"
 
-        // When / Then -- neither crashes nor false-matches; a task this type didn't create simply
+        // When / Then: neither crashes nor false-matches; a task this type didn't create simply
         // isn't a candidate.
         let match = BackgroundDownloads.Session.firstTask(
             matching: "episode-42",
@@ -218,7 +221,7 @@ struct BackgroundDownloadsSessionTests {
 
     @Test
     func cancel_whenNoDownloadHasEverBeenScheduled_returnsFalse() async throws {
-        // Given -- a fresh `Session` that has never scheduled anything, so there is no
+        // Given: a fresh `Session` that has never scheduled anything, so there is no
         // `URLSession` to even ask.
         let session = BackgroundDownloads.Session()
 

--- a/Tests/RequestDLTests/Tasks/Sources/Modifiers/Description/TaskDescriptorTests.swift
+++ b/Tests/RequestDLTests/Tasks/Sources/Modifiers/Description/TaskDescriptorTests.swift
@@ -14,10 +14,10 @@ import FoundationEssentials
 import struct Foundation.UUID
 #endif
 
-/// `CURLTaskDescriptor` is only the first conformance -- this proves the mechanism underneath
+/// `CURLTaskDescriptor` is only the first conformance. Conforming a second, unrelated
+/// `TaskDescriptor` right here in the test target proves the mechanism underneath
 /// `.description(_:)` (`TaskDescriptorContext`, and `FormNode`'s contribution to it) carries no
-/// curl-specific coupling, by conforming a second, unrelated `TaskDescriptor` right here in the
-/// test target.
+/// curl-specific coupling.
 private struct FieldNamesDescriptor: TaskDescriptor {
 
     func describe(_ context: TaskDescriptorContext) async throws -> [String] {
@@ -75,7 +75,7 @@ struct TaskDescriptorTests {
         #expect(fieldNames.isEmpty)
     }
 
-    /// `final class ... : @unchecked Sendable` guarded by `Lock` -- the same pattern
+    /// `final class ... : @unchecked Sendable` guarded by `Lock`: the same pattern
     /// `ModifiersProgressTests` uses to capture state from a `@Sendable` callback.
     private final class Box<Value: Sendable>: @unchecked Sendable {
 
@@ -126,14 +126,14 @@ struct TaskDescriptorTests {
             capturedDescription.set(description)
         }
 
-        // Then -- composing the task runs nothing by itself; `onDescribe` only fires once the
+        // Then: composing the task runs nothing by itself; `onDescribe` only fires once the
         // task is actually performed, the same way a `RequestTaskModifier` defers its `body(_:)`.
         #expect(capturedDescription.value == nil)
 
         let taskResult = try await task.result()
         let result = try HTTPResult<String>(taskResult.payload)
 
-        // Then -- `onDescribe` ran with the resolved request, and the real request also went
+        // Then: `onDescribe` ran with the resolved request, and the real request also went
         // through and produced its own result.
         #expect(capturedDescription.value?.url == "https://" + localServer.baseURL + uri)
         #expect(result.response == output)
@@ -173,16 +173,17 @@ struct TaskDescriptorTests {
 
         let result = try HTTPResult<String>(taskResult.payload)
 
-        // Then -- disabling the descriptor pass doesn't stop the real request from completing.
+        // Then: disabling the descriptor pass doesn't stop the real request from completing.
         #expect(!wasCalled.value)
         #expect(result.response == output)
     }
 
-    /// Unlike plain `description(_:)` -- only ever defined directly on `DataTask`/`DownloadTask`/
-    /// `UploadTask` -- `description(_:enabled:onDescribe:)` is a `RequestTask` extension that
-    /// queues its hook on the environment. That's what lets it sit anywhere in a chain, not just
-    /// at the very top: here it runs after `.extractPayload()` has already changed `Element` from
-    /// `TaskResult<Data>` to plain `Data`.
+    /// Unlike plain `description(_:)`, which is only ever defined directly on
+    /// `DataTask`/`DownloadTask`/`UploadTask`, `description(_:enabled:onDescribe:)` is a
+    /// `RequestTask` extension that queues its hook on the environment.
+    ///
+    /// That's what lets it sit anywhere in a chain, not just at the very top: here it runs after
+    /// `.extractPayload()` has already changed `Element` from `TaskResult<Data>` to plain `Data`.
     @Test
     func onDescribeWorksAfterAnotherModifierInTheChain() async throws {
         // Given

--- a/Tests/RequestDLTests/Tasks/Sources/Modifiers/Description/cURL/CURLTaskDescriptorTests.swift
+++ b/Tests/RequestDLTests/Tasks/Sources/Modifiers/Description/cURL/CURLTaskDescriptorTests.swift
@@ -12,7 +12,7 @@ import FoundationEssentials
 import struct Foundation.Data
 #endif
 
-/// No `LocalServer` anywhere here -- `.description(_:)` only resolves the `Property` graph
+/// No `LocalServer` anywhere here: `.description(_:)` only resolves the `Property` graph
 /// (`Resolve(...).partiallyBuild()`), it never builds a session or touches the network.
 struct CURLTaskDescriptorTests {
 
@@ -86,7 +86,7 @@ struct CURLTaskDescriptorTests {
         }
         .description(.cURL)
 
-        // Then -- one `-F` per field, not a flattened blob.
+        // Then: one `-F` per field, not a flattened blob.
         #expect(command.contains(#"-F 'name=John Doe'"#))
         #expect(command.contains("-F 'avatar=@avatar.png;type=image/png'"))
 
@@ -95,7 +95,7 @@ struct CURLTaskDescriptorTests {
         #expect(!command.contains("multipart/form-data"))
     }
 
-    /// A plain (no `filename`) form field's bytes aren't necessarily valid UTF-8 -- e.g. binary
+    /// A plain (no `filename`) form field's bytes aren't necessarily valid UTF-8, e.g. binary
     /// `Data` handed to `Form` without a filename. Regression test for a bug where those bytes
     /// were lossily decoded to `String` (replacing anything invalid with U+FFFD) before ever
     /// reaching `curlShellQuote`'s own byte-safe fallback, silently corrupting the value.

--- a/Tests/RequestDLTests/Tasks/Sources/Modifiers/Digest Authentication/ModifiersDigestAuthenticationTests.swift
+++ b/Tests/RequestDLTests/Tasks/Sources/Modifiers/Digest Authentication/ModifiersDigestAuthenticationTests.swift
@@ -61,7 +61,7 @@ struct ModifiersDigestAuthenticationTests {
 
     @Test
     func digestAuthentication_whenNoCredentialPassed_stillRetriesAndSucceeds() async throws {
-        // Given -- no DigestCredential constructed or passed anywhere; `.digestAuthentication()`
+        // Given: no DigestCredential constructed or passed anywhere; `.digestAuthentication()`
         // must create and thread its own through the environment for `DigestAuthentication` to
         // pick up.
         let attempts = InlineProperty(wrappedValue: 0)

--- a/Tests/RequestDLTests/Tasks/Sources/Modifiers/Environment/ModifiersEnvironmentTests.swift
+++ b/Tests/RequestDLTests/Tasks/Sources/Modifiers/Environment/ModifiersEnvironmentTests.swift
@@ -20,9 +20,9 @@ struct ModifiersEnvironmentTests {
     struct OuterTask: RequestTask {
 
         func result() async throws -> Int {
-            // Deliberately calls the plain `result()`, not the SPI `_result(environment:)` --
-            // this is what an unrelated `RequestTask` constructed inside another task's body
-            // would do, with no way to (and no reason to) reach for the SPI entry point.
+            // Deliberately calls the plain `result()`, not the SPI `_result(environment:)`: this
+            // is what an unrelated `RequestTask` constructed inside another task's body would
+            // do, with no way to (and no reason to) reach for the SPI entry point.
             try await NumberTask().result()
         }
     }
@@ -66,7 +66,7 @@ struct ModifiersEnvironmentTests {
             .environment(\.number, 2)
             .result()
 
-        // Then -- `NumberTask`, constructed fresh inside `OuterTask.result()`, never received
+        // Then: `NumberTask`, constructed fresh inside `OuterTask.result()`, never received
         // `OuterTask`'s own `.environment(\.number, 2)`, so it falls back to the key's default.
         #expect(value == 1)
     }

--- a/Tests/RequestDLTests/Tasks/Sources/Modifiers/Progress/ModifiersProgressTests.swift
+++ b/Tests/RequestDLTests/Tasks/Sources/Modifiers/Progress/ModifiersProgressTests.swift
@@ -230,9 +230,11 @@ struct ModifiersProgressTests {
 
         let result = try HTTPResult<String>(data)
 
-        // Then -- decoded-content equality, not a byte-count comparison against a hand-built
-        // envelope: the server's JSON response can grow additional optional fields over time
-        // (e.g. `receivedUserAgentHeader`), which would throw off a raw size comparison without
+        // Then: decoded-content equality, not a byte-count comparison against a hand-built
+        // envelope.
+        //
+        // The server's JSON response can grow additional optional fields over time (e.g.
+        // `receivedUserAgentHeader`), which would throw off a raw size comparison without
         // actually reflecting anything wrong with the response itself.
         #expect(result.response == message)
         #expect(downloadMonitor.totalSize == data.count)
@@ -275,12 +277,15 @@ struct ModifiersProgressTests {
 
             // Pinned to `.nio`: the assertion below expects upload progress to fire in exact
             // `payloadChunkSize(64)` increments, which is `Internals.BodySequence`'s own
-            // NIO/streaming-body chunking guarantee, not a portable one -- URLSession's
-            // `uploadTask(with:from:)` (used for a body this small) reports the whole upload in a
-            // single `didSendBodyData` callback instead, since individual upload chunk sizes are
-            // executor-specific. The download chunk-boundary assertion further below stays
-            // executor-portable on purpose (it holds on `.urlSession` too) -- only the upload
-            // half of this test is backend-specific.
+            // NIO/streaming-body chunking guarantee, not a portable one.
+            //
+            // URLSession's `uploadTask(with:from:)` (used for a body this small) reports the
+            // whole upload in a single `didSendBodyData` callback instead, since individual
+            // upload chunk sizes are executor-specific.
+            //
+            // The download chunk-boundary assertion further below stays executor-portable on
+            // purpose (it holds on `.urlSession` too); only the upload half of this test is
+            // backend-specific.
             Session.localServer
                 .requiredExecutor(.nio)
 

--- a/Tests/RequestDLTests/Tasks/Sources/Raw Task/Data/DataTaskTests.swift
+++ b/Tests/RequestDLTests/Tasks/Sources/Raw Task/Data/DataTaskTests.swift
@@ -56,7 +56,7 @@ struct DataTaskTests {
     }
 
     /// A deadline this short is guaranteed to already have elapsed by the time the request even
-    /// reaches the network -- deterministic without needing an artificially slow server, the same
+    /// reaches the network: deterministic without needing an artificially slow server, the same
     /// technique real-network cancellation tests elsewhere in this suite rely on.
     @Test
     func dataTask_whenResourceTimeoutAlreadyElapsed_throwsResourceTimeoutError() async throws {
@@ -126,12 +126,14 @@ struct DataTaskTests {
 
     /// Pinned to `.nio`: a real client-certificate handshake over `.urlSession` is a confirmed,
     /// unconditional `withKnownIssue` on this SwiftPM test harness (no Keychain Sharing
-    /// entitlement on any platform -- see `RequestConfigurationURLSessionClientMTLSTests`'s type
+    /// entitlement on any platform; see `RequestConfigurationURLSessionClientMTLSTests`'s type
     /// doc comment, which already tracks this exact gap at the `Internals.URLSessionClient`
-    /// layer). Since `resolveExecutor()` decides which backend a real `DataTask` runs over,
-    /// this test would otherwise hit that same unconditional gap by default and fail for a
-    /// reason that has nothing to do with what it's actually verifying -- that mTLS client-cert
-    /// auth works end to end through the public `DataTask` API, which NIO already does reliably.
+    /// layer).
+    ///
+    /// Since `resolveExecutor()` decides which backend a real `DataTask` runs over, this test
+    /// would otherwise hit that same unconditional gap by default and fail for a reason that has
+    /// nothing to do with what it's actually verifying: that mTLS client-cert auth works end to
+    /// end through the public `DataTask` API, which NIO already does reliably.
     @Test
     func dataTask_whenCAEnabled() async throws {
         // Given
@@ -495,11 +497,13 @@ extension DataTaskTests {
     }
 
     /// `Session.requiredExecutor(_:)` must fail loudly at request time, not silently run on a
-    /// different executor -- this is `RawTask`'s own validation throwing `ExecutorRequirementError`,
+    /// different executor: this is `RawTask`'s own validation throwing `ExecutorRequirementError`,
     /// exercised through the real public `DataTask` entry point rather than by calling
     /// `Internals.Session.Configuration.requireExecutor(_:)` directly (already covered in
-    /// `InternalsSessionConfigurationExecutorTests`). No `LocalServer` needed -- the throw happens
-    /// before any client is built or network I/O starts.
+    /// `InternalsSessionConfigurationExecutorTests`).
+    ///
+    /// No `LocalServer` needed: the throw happens before any client is built or network I/O
+    /// starts.
     @Test
     func dataTask_whenRequiredExecutorIsIncompatible_throwsActionableErrorBeforeAnyNetworkIO() async throws {
         // Given: a custom cipher suite has no Network.framework equivalent at all (silently
@@ -525,7 +529,7 @@ extension DataTaskTests {
             _ = try await task.result()
             Issue.record("Not expecting success")
         } catch let error as ExecutorRequirementError {
-            // Then -- actionable, not just "it throws": names the pinned executor, the
+            // Then: actionable, not just "it throws". Names the pinned executor, the
             // conflicting field, and points at the escape hatch.
             #expect(error.requiredExecutor == .nioTransportServices)
             #expect(error.reasons == [.cipherSuiteValues])
@@ -535,7 +539,7 @@ extension DataTaskTests {
     }
 
     /// Counterpart to the test above: a `requiredExecutor` the configuration *can* actually run
-    /// on must not throw -- proving the validation doesn't reject compatible configurations along
+    /// on must not throw, proving the validation doesn't reject compatible configurations along
     /// the way.
     @Test
     func dataTask_whenRequiredExecutorIsCompatible_doesNotThrowExecutorRequirementError() async throws {

--- a/Tests/RequestDLTests/Tasks/Sources/Raw Task/Download/DownloadTaskTests.swift
+++ b/Tests/RequestDLTests/Tasks/Sources/Raw Task/Download/DownloadTaskTests.swift
@@ -60,7 +60,7 @@ struct DownloadTaskTests {
 extension DownloadTaskTests {
 
     /// Forced deterministically rather than relying on `resolveExecutor()`'s own default
-    /// preference the way `dataTask()` above does -- same round trip, pinned explicitly to
+    /// preference the way `dataTask()` above does: same round trip, pinned explicitly to
     /// `.urlSession`. Darwin-only: `.urlSession` isn't a real executor anywhere else, so pinning
     /// it there is not this test's intent.
     @Test

--- a/Tests/RequestDLTests/Tasks/Sources/Raw Task/Mocked/MockedTaskTests.swift
+++ b/Tests/RequestDLTests/Tasks/Sources/Raw Task/Mocked/MockedTaskTests.swift
@@ -52,9 +52,9 @@ struct MockedTaskTests {
                     ("Accept", "application/json"),
                     ("Content-Type", "text/plain"),
                     ("Content-Length", String(data.count)),
-                    // `Payload` defaults the method to `"POST"` when nothing else sets one -- a
+                    // `Payload` defaults the method to `"POST"` when nothing else sets one: a
                     // body attached to a request that would otherwise default to GET fails
-                    // outright on `.urlSession` -- so the mirrored `rdl-request-method` header
+                    // outright on `.urlSession`. So the mirrored `rdl-request-method` header
                     // now reflects that resolved value.
                     ("rdl-request-method", "POST"),
                 ])

--- a/Tests/RequestDLTests/Tasks/Sources/Raw Task/Raw/RawTaskExecutorDispatchTests.swift
+++ b/Tests/RequestDLTests/Tasks/Sources/Raw Task/Raw/RawTaskExecutorDispatchTests.swift
@@ -27,20 +27,23 @@ import class Foundation.ProcessInfo
 ///
 /// `InternalsClientManagerExecutorTests` (`RequestDLInternalsTests`) already proved
 /// `Internals.ClientManager.resolvedClient(provider:sessionConfiguration:)` resolves and caches a
-/// working `.urlSession` client, using a hand-built `Internals.ClientManager`/`SessionProvider` --
+/// working `.urlSession` client, using a hand-built `Internals.ClientManager`/`SessionProvider`,
 /// deliberately isolated from the `Property`/`Resolve` pipeline and from `Internals.ClientManager
-/// .shared`. This file proves the layer above that: a real `DataTask`, resolved through an actual
+/// .shared`.
+///
+/// This file proves the layer above that: a real `DataTask`, resolved through an actual
 /// `Property` tree exactly as an app would build one, and dispatched via the *same* shared pool
-/// `RawTask.result()` itself reads from -- not a fresh, test-isolated manager.
+/// `RawTask.result()` itself reads from, not a fresh, test-isolated manager.
 struct RawTaskExecutorDispatchTests {
 
     @Test
     func dataTask_whenNoExecutorPreferenceSet_actuallyDispatchesOverURLSessionOnDarwin() async throws {
-        // Given -- a config compatible with every executor, so `.urlSession` is
-        // `resolveExecutor()`'s own default preference, not something forced here. A
-        // session id unique to this test run keeps it off `Session.localServer`'s shared pooled
-        // entry, so nothing else running concurrently can affect (or be affected by) the
-        // `Internals.ClientManager.shared` lookup below.
+        // Given: a config compatible with every executor, so `.urlSession` is
+        // `resolveExecutor()`'s own default preference, not something forced here.
+        //
+        // A session id unique to this test run keeps it off `Session.localServer`'s shared
+        // pooled entry, so nothing else running concurrently can affect (or be affected by)
+        // the `Internals.ClientManager.shared` lookup below.
         let localServer = try await LocalServer(.standard)
         let uri = "/" + UUID().uuidString
         let certificate = Certificates().server()
@@ -62,14 +65,14 @@ struct RawTaskExecutorDispatchTests {
             }
         }
 
-        // When -- through the real public API, exactly as an app would call it. No executor
+        // When: through the real public API, exactly as an app would call it. No executor
         // modifier anywhere in `content` above.
         let data = try await DataTask { content }.extractPayload().result()
 
         let result = try HTTPResult<String>(data)
         #expect(result.response == output)
 
-        // Then -- resolving the identical property tree again and asking
+        // Then: resolving the identical property tree again and asking
         // `Internals.ClientManager.shared` (the pool the `DataTask` call above actually used)
         // what it holds for this exact provider is what proves the *real* call dispatched over
         // `.urlSession`, rather than merely that `.urlSession` was resolvable in isolation.
@@ -83,11 +86,14 @@ struct RawTaskExecutorDispatchTests {
 
     @Test
     func dataTask_whenNIORequired_actuallyDispatchesOverNIOEvenThoughURLSessionWouldBeCompatible() async throws {
-        // Given -- same shape as above (would default to `.urlSession` on Darwin), but this time
-        // pinned to `.nio` explicitly. Regression coverage for the bug this phase's own testing
-        // caught: `requiredExecutor(.nio)` used to validate without ever actually being the
-        // executor a real request dispatched over -- `resolveExecutor()` read only
-        // `preferredExecutor`, so a `.urlSession`-compatible config kept resolving there anyway.
+        // Given: same shape as above (would default to `.urlSession` on Darwin), but this time
+        // pinned to `.nio` explicitly.
+        //
+        // Regression coverage for the bug this phase's own testing caught: `requiredExecutor(.nio)`
+        // used to validate without ever actually being the executor a real request dispatched
+        // over, since `resolveExecutor()` read only `preferredExecutor`, so a
+        // `.urlSession`-compatible config kept resolving there anyway.
+        //
         // See `InternalsSessionConfigurationExecutorTests`'s "resolveExecutor() with
         // requiredExecutor" section for the unit-level fix; this is the same fact proven one
         // layer up, through a real `DataTask` round trip.
@@ -130,13 +136,15 @@ struct RawTaskExecutorDispatchTests {
 
     /// Regression coverage for the gap `Session.compression(_:)` used to have: its
     /// `NIOHTTPRequestCompressor` was spliced into the `.nio` executor's own connection pipeline
-    /// (`Internals.Session.Configuration.build()`), which `.urlSession` never runs through --
+    /// (`Internals.Session.Configuration.build()`), which `.urlSession` never runs through.
     /// `compression` wasn't even listed in `urlSessionIncompatibilityReasons()`, so a session
     /// pinned (or, on Darwin, defaulted) to `.urlSession` silently sent the body uncompressed,
-    /// no error anywhere. `RequestConfiguration.applyCompression(_:onDuplicateHeader:)` now
-    /// compresses `RequestBody` itself, once, before either executor ever sees it -- this proves
-    /// that fix through the real, public `DataTask` API, pinned to `.urlSession` explicitly so
-    /// there is no ambiguity about which executor actually sent the request.
+    /// no error anywhere.
+    ///
+    /// `RequestConfiguration.applyCompression(_:onDuplicateHeader:)` now compresses `RequestBody`
+    /// itself, once, before either executor ever sees it. This proves that fix through the real,
+    /// public `DataTask` API, pinned to `.urlSession` explicitly so there is no ambiguity about
+    /// which executor actually sent the request.
     @Test
     func dataTask_whenCompressionEnabledOverURLSession_sendsCompressedBody() async throws {
         // Given
@@ -164,7 +172,7 @@ struct RawTaskExecutorDispatchTests {
                 TrustRoots(certificate.certificateURL.absolutePath(percentEncoded: false))
             }
 
-            // `.compression(_:)` is environment-driven, like `.payloadEncoder(_:)` -- it has to
+            // `.compression(_:)` is environment-driven, like `.payloadEncoder(_:)`: it has to
             // be attached to (or above) the `Payload` it should affect, not to an unrelated
             // sibling like `Session` above, whose own `.environment(_:_:)` mutation never
             // reaches anything outside its own subtree.
@@ -180,7 +188,7 @@ struct RawTaskExecutorDispatchTests {
         #expect(result.response == output)
 
         // The server only ever sees the wire bytes it read, so a `receivedBytes` well below the
-        // original payload size is proof the request body actually went out gzip-compressed --
+        // original payload size is proof the request body actually went out gzip-compressed,
         // over `.urlSession`, not just over `.nio`.
         #expect(result.receivedBytes < payload.count / 2)
 
@@ -227,7 +235,7 @@ struct RawTaskExecutorDispatchTests {
         let data = try await DataTask { content }.extractPayload().result()
         let result = try HTTPResult<String>(data)
 
-        // Then -- URLSession synthesizes its own accurate report once RequestDL's own default is
+        // Then: URLSession synthesizes its own accurate report once RequestDL's own default is
         // dropped, so the server sees *something*, just not RequestDL's neutral
         // `AppID/version OS/version` string.
         let receivedUserAgent = try #require(result.receivedUserAgentHeader)
@@ -273,7 +281,7 @@ struct RawTaskExecutorDispatchTests {
     }
 
     /// Companion to both tests above: NIO never synthesizes its own `User-Agent`, so dropping
-    /// RequestDL's default there -- the way `.urlSession` does -- would just send the request
+    /// RequestDL's default there, the way `.urlSession` does, would just send the request
     /// with none. RequestDL's neutral default must survive under `.nio`.
     @Test
     func dataTask_withDefaultUserAgentOverNIO_keepsRequestDLsNeutralDefault() async throws {
@@ -311,13 +319,15 @@ struct RawTaskExecutorDispatchTests {
 
     /// Regression coverage for combining RequestDL's default with a plain `CustomHeader(name:
     /// "user-agent", ...)`, not `UserAgentHeader(_:)`. `HeaderNode.make(_:)` matches "User-Agent"
-    /// case-insensitively, so this still disqualifies `hasDefaultUserAgent` -- see
+    /// case-insensitively, so this still disqualifies `hasDefaultUserAgent`; see
     /// `UserAgentHeaderTests.hasDefaultUserAgent_whenDefaultIsCombinedWithCustomHeaderUnderDifferentCasing`
     /// for that check at the graph-resolve level, where the two values are still stored
     /// separately (`CustomHeader` defaults to `headerSeparator == nil`, unlike `UserAgentHeader`'s
-    /// own hardcoded `" "`). This proves what actually reaches the wire once `URLRequest` gets
-    /// involved: `buildURLRequestWithoutBody()` calls `addValue(_:forHTTPHeaderField:)` once per
-    /// stored value, and `URLRequest` itself -- confirmed against a live instance, not assumed --
+    /// own hardcoded `" "`).
+    ///
+    /// This proves what actually reaches the wire once `URLRequest` gets involved:
+    /// `buildURLRequestWithoutBody()` calls `addValue(_:forHTTPHeaderField:)` once per stored
+    /// value, and `URLRequest` itself, confirmed against a live instance and not assumed,
     /// coalesces same-name fields (case-insensitively) into one comma-joined header, no space.
     @Test
     func dataTask_defaultUserAgentCollidesWithCustomHeaderOverURLSession_mergesOntoTheWire() async throws {
@@ -350,33 +360,36 @@ struct RawTaskExecutorDispatchTests {
         let data = try await DataTask { content }.extractPayload().result()
         let result = try HTTPResult<String>(data)
 
-        // Then -- neither value was dropped (a second write already disqualified
+        // Then: neither value was dropped (a second write already disqualified
         // `hasDefaultUserAgent`), and both landed on the wire merged into one header.
         #expect(result.receivedUserAgentHeader == "\(ProcessInfo.processInfo.userAgent),ABC")
     }
 
     /// Cancellation, validated for real. `Internals.TaskSeed` (transport-agnostic) cancels when
-    /// the response is *dropped*, not when the
-    /// awaiting `_Concurrency.Task` is marked cancelled -- nothing in the iteration path
-    /// (`AsyncBytes.AsyncIterator.next()`, `Internals.AsyncStream`) checks
-    /// `Task.isCancelled`/`Task.checkCancellation()`. So the whole round trip below runs inside
-    /// one scope: read the one chunk `withPartialResponseServer` ever sends, then let that scope
-    /// end -- dropping both the loop's iterator and the `TaskResult<AsyncBytes>` itself, the only
-    /// two things holding the seed alive.
+    /// the response is *dropped*, not when the awaiting `_Concurrency.Task` is marked cancelled:
+    /// nothing in the iteration path (`AsyncBytes.AsyncIterator.next()`, `Internals.AsyncStream`)
+    /// checks `Task.isCancelled`/`Task.checkCancellation()`.
+    ///
+    /// So the whole round trip below runs inside one scope: read the one chunk
+    /// `withPartialResponseServer` ever sends, then let that scope end, dropping both the loop's
+    /// iterator and the `TaskResult<AsyncBytes>` itself, the only two things holding the seed
+    /// alive.
     ///
     /// `LocalServer` always answers fully and immediately, and a "just make the body big" version
     /// of this test (tried first) turned out not to prove anything: over a local loopback
     /// connection, even a multi-megabyte body transfers, and the underlying `URLSessionTask`
     /// completes naturally, well before any scope-based cancellation logic gets a chance to do
-    /// anything -- the test passed whether or not cancellation actually worked. `withPartialResponseServer`
-    /// sends valid HTTP/1.1 headers plus a small body, then goes silent while declaring a
-    /// `Content-Length` it never finishes -- keeping the connection genuinely, indefinitely
-    /// "mid-transfer" until this test explicitly ends it, so the poll below can only pass because
-    /// dropping the response actually cancelled something still running.
+    /// anything. The test passed whether or not cancellation actually worked.
+    ///
+    /// `withPartialResponseServer` sends valid HTTP/1.1 headers plus a small body, then goes
+    /// silent while declaring a `Content-Length` it never finishes, keeping the connection
+    /// genuinely, indefinitely "mid-transfer" until this test explicitly ends it, so the poll
+    /// below can only pass because dropping the response actually cancelled something still
+    /// running.
     @Test
     func downloadTask_whenResponseDroppedMidFlight_actuallyCancelsTheUnderlyingURLSessionClient() async throws {
         try await withPartialResponseServer { port in
-            // Given -- plain HTTP: this server speaks raw bytes, not TLS, and `.urlSession`
+            // Given: plain HTTP. This server speaks raw bytes, not TLS, and `.urlSession`
             // reaches `127.0.0.1` over HTTP with no ATS issue in this test harness (confirmed by
             // running it, not assumed).
             let content = TestProperty {
@@ -386,7 +399,7 @@ struct RawTaskExecutorDispatchTests {
                     .requiredExecutor(.urlSession)
 
                 // The default reading mode (`.length(1_024)`) waits for a full 1024-byte chunk
-                // before yielding anything -- `withPartialResponseServer` only ever sends 19
+                // before yielding anything. `withPartialResponseServer` only ever sends 19
                 // bytes ("partial-body-bytes") before going silent, so the default would wait
                 // forever for a chunk boundary that can never arrive. A length well under that
                 // lets the first (and only) chunk surface promptly instead.
@@ -409,7 +422,7 @@ struct RawTaskExecutorDispatchTests {
                 let result = try await DownloadTask { content }.result()
                 for try await _ in result.payload {
                     // The server has already gone silent for good at this point, having declared
-                    // far more `Content-Length` than it will ever actually send -- genuinely
+                    // far more `Content-Length` than it will ever actually send: genuinely
                     // mid-flight, not a download that happened to finish before this loop got
                     // here.
                     observedRunningMidFlight = client.isRunning
@@ -419,7 +432,7 @@ struct RawTaskExecutorDispatchTests {
 
             #expect(observedRunningMidFlight)
 
-            // Then -- `didCompleteWithError:` releases the operation-queue slot asynchronously,
+            // Then: `didCompleteWithError:` releases the operation-queue slot asynchronously,
             // so poll briefly rather than asserting immediately after the scope above ends.
             var stillRunning = client.isRunning
             for _ in 0..<50 where stillRunning {
@@ -433,16 +446,16 @@ struct RawTaskExecutorDispatchTests {
 
     /// Companion to `DataTaskTests.dataTask_whenResourceTimeoutAlreadyElapsed_throwsResourceTimeoutError`:
     /// that one proves `Timeout(.resource)` throws `ResourceTimeoutError` at all, but with a
-    /// deadline so short it has already elapsed before the request even reaches the network --
-    /// it says nothing about whether the deadline actually tears down a connection that's
+    /// deadline so short it has already elapsed before the request even reaches the network.
+    /// It says nothing about whether the deadline actually tears down a connection that's
     /// genuinely still running, nor which executor it ran that proof against (`Session.localServer`
     /// carries no executor preference, so it only happens to resolve to `.urlSession` by Darwin's
-    /// own default -- see `dataTask_whenNoExecutorPreferenceSet_actuallyDispatchesOverURLSessionOnDarwin`
+    /// own default; see `dataTask_whenNoExecutorPreferenceSet_actuallyDispatchesOverURLSessionOnDarwin`
     /// above).
     ///
     /// This pins `.urlSession` explicitly, so this regression coverage can't silently go stale
-    /// if that default ever changes, and reuses `withPartialResponseServer` -- headers plus a
-    /// small body, then silence forever -- so the deadline has to fire against a connection
+    /// if that default ever changes, and reuses `withPartialResponseServer` (headers plus a
+    /// small body, then silence forever), so the deadline has to fire against a connection
     /// that's demonstrably still open, the same technique
     /// `downloadTask_whenResponseDroppedMidFlight_actuallyCancelsTheUnderlyingURLSessionClient`
     /// above uses to prove cancellation for real instead of merely asserting an error type.
@@ -469,13 +482,13 @@ struct RawTaskExecutorDispatchTests {
 
             #expect(!client.isRunning)
 
-            // When / Then -- the server never finishes the body, so this can only complete by the
+            // When / Then: the server never finishes the body, so this can only complete by the
             // deadline actually firing.
             await #expect(throws: ResourceTimeoutError.self) {
                 _ = try await DataTask { content }.extractPayload().result()
             }
 
-            // Then -- not just an error thrown at the caller: the live `URLSessionTask` behind it
+            // Then: not just an error thrown at the caller. The live `URLSessionTask` behind it
             // actually got torn down. `didCompleteWithError:` releases state asynchronously, so
             // poll briefly rather than asserting immediately.
             var stillRunning = client.isRunning
@@ -489,19 +502,20 @@ struct RawTaskExecutorDispatchTests {
     }
 
     /// Confirms the identity-building failure a real mTLS `DataTask` hits under `.urlSession` on
-    /// this SwiftPM test harness (no Keychain Sharing entitlement -- see
+    /// this SwiftPM test harness (no Keychain Sharing entitlement; see
     /// `RequestConfigurationURLSessionClientMTLSTests`'s own doc comment) surfaces through the
     /// *public* API as a documented ``ClientIdentityError``, not a raw
     /// `Internals.RawBytesIdentityBuilder.Error`/`Internals.URLSessionIdentityPolicy
-    /// .ConfigurationError` -- both package-visible types a real consumer app cannot even name,
+    /// .ConfigurationError`. Both are package-visible types a real consumer app cannot even name,
     /// and whose `localizedDescription` (Foundation's generic NSError fallback, absent this fix)
-    /// carries none of their own actionable `description` text. `ClientIdentityErrorTests` covers
-    /// the rewrap/description logic itself in isolation; this is the same fact proven end to end,
-    /// through the real `DataTask` entry point, the same way `dataTask_whenCAEnabled`
-    /// (`DataTaskTests`, pinned to `.nio` specifically to avoid this exact gap) already does for
-    /// the NIO backend.
+    /// carries none of their own actionable `description` text.
     ///
-    /// Deliberately does not assert on the *specific* ``ClientIdentityError/Reason`` -- this
+    /// `ClientIdentityErrorTests` covers the rewrap/description logic itself in isolation; this
+    /// is the same fact proven end to end, through the real `DataTask` entry point, the same way
+    /// `dataTask_whenCAEnabled` (`DataTaskTests`, pinned to `.nio` specifically to avoid this
+    /// exact gap) already does for the NIO backend.
+    ///
+    /// Deliberately does not assert on the *specific* ``ClientIdentityError/Reason``: this
     /// harness has been observed to hit this gap two different ways (`errSecMissingEntitlement`
     /// on `SecItemAdd`, or `errSecItemNotFound` on the identity lookup right after a successful
     /// add), and both are genuine, independently-reachable failure modes this test should pass
@@ -546,7 +560,7 @@ struct RawTaskExecutorDispatchTests {
             _ = try await DataTask { content }.extractPayload().result()
             Issue.record("Expected this SwiftPM test harness's missing Keychain Sharing entitlement to throw")
         } catch let error as ClientIdentityError {
-            // Then -- the public, documented type, not a leaked internal one, with the same
+            // Then: the public, documented type, not a leaked internal one, with the same
             // actionable text through both access paths a real caller might use.
             #expect(!error.description.isEmpty)
             #expect((error as any Error).localizedDescription == error.description)
@@ -557,7 +571,7 @@ struct RawTaskExecutorDispatchTests {
 
     /// Companion to the test above: confirms cancellation frees the throttle slot for real, not
     /// just that `isRunning` (a separate counter, released in the same completion callback but
-    /// not the same value) happens to drop -- the same bar `InternalsClientConcurrencyLimitTests`
+    /// not the same value) happens to drop, the same bar `InternalsClientConcurrencyLimitTests`
     /// already holds the NIO path to, one layer up through the public API. `Internals.ThrottledExecutor`
     /// exposes no inspectable count of its own, so this proves it indirectly: with
     /// `maximumConcurrentConnections(1)`, a second request genuinely cannot proceed while the
@@ -566,7 +580,7 @@ struct RawTaskExecutorDispatchTests {
     func downloadTask_whenCancelledWhileHoldingTheOnlyPermit_releasesItForAQueuedRequest() async throws {
         try await withPartialResponseServer { firstPort in
             try await withCompleteResponseServer { secondPort in
-                // Given -- both requests share one `Session` id/configuration (hence one pooled
+                // Given: both requests share one `Session` id/configuration (hence one pooled
                 // `Internals.URLSessionClient`, hence one throttle) even though they hit two
                 // different plain-HTTP servers.
                 let sessionID = "com.requestdl.tests.7b4-throttle.\(UUID())"
@@ -589,7 +603,7 @@ struct RawTaskExecutorDispatchTests {
                 let releaseSignal = ReleaseSignal()
                 let secondRequestState = SecondRequestState()
 
-                // When -- holds the only permit until explicitly told to let go, so this test
+                // When: holds the only permit until explicitly told to let go, so this test
                 // controls the moment of cancellation directly instead of racing a timeout
                 // against it.
                 async let firstDownload: Void = {
@@ -609,7 +623,7 @@ struct RawTaskExecutorDispatchTests {
                     await secondRequestState.markCompleted()
                 }()
 
-                // Then -- still queued behind the first request's held permit.
+                // Then: still queued behind the first request's held permit.
                 try await _Concurrency.Task.sleep(nanoseconds: 200_000_000)
                 #expect(await !secondRequestState.isCompleted)
 
@@ -626,7 +640,7 @@ struct RawTaskExecutorDispatchTests {
 }
 
 /// Lets a test hold a cancellation at an exact, chosen moment instead of racing a fixed delay
-/// against it -- used by `downloadTask_whenCancelledWhileHoldingTheOnlyPermit_releasesItForAQueuedRequest`
+/// against it. Used by `downloadTask_whenCancelledWhileHoldingTheOnlyPermit_releasesItForAQueuedRequest`
 /// to keep the first request's throttle permit held until the test is ready to observe the second
 /// request still being blocked by it.
 private actor ReleaseSignal {
@@ -657,8 +671,8 @@ private actor SecondRequestState {
 
 // MARK: - Raw servers for deterministic mid-flight state
 
-/// A server that answers with valid HTTP/1.1 headers -- including a `Content-Length` far larger
-/// than what it will ever actually send -- plus a small amount of body, then goes silent. The
+/// A server that answers with valid HTTP/1.1 headers, including a `Content-Length` far larger
+/// than what it will ever actually send, plus a small amount of body, then goes silent. The
 /// connection stays open, genuinely "mid-transfer," for as long as the test wants, until the
 /// client cancels it or the test closes the server. `LocalServer` always answers a request fully
 /// and immediately, so it cannot produce this state on its own.
@@ -668,7 +682,7 @@ private func withPartialResponseServer<Result>(
     try await withRawServer(PartialResponseHandler.init, body)
 }
 
-/// A server that answers a request fully and immediately, over plain HTTP -- the throttle test's
+/// A server that answers a request fully and immediately, over plain HTTP: the throttle test's
 /// second, "should actually complete once let through" request.
 private func withCompleteResponseServer<Result>(
     _ body: (Int) async throws -> Result
@@ -716,7 +730,7 @@ private final class PartialResponseHandler: ChannelInboundHandler, @unchecked Se
                 + "partial-body-bytes"
         )
         context.writeAndFlush(wrapOutboundOut(buffer), promise: nil)
-        // Deliberately writes nothing further -- see this file's own doc comment on
+        // Deliberately writes nothing further; see this file's own doc comment on
         // `withPartialResponseServer` for why.
     }
 }

--- a/Tests/RequestDLTests/Tasks/Sources/Raw Task/Raw/SessionExecutionTests.swift
+++ b/Tests/RequestDLTests/Tasks/Sources/Raw Task/Raw/SessionExecutionTests.swift
@@ -18,13 +18,14 @@ import struct Foundation.URL
 #endif
 
 /// Executes `requestConfiguration` through `session` with caching bypassed, mirroring the
-/// cache-then-execute orchestration `RawTask.result()` performs -- this file drives
+/// cache-then-execute orchestration `RawTask.result()` performs. This file drives
 /// `Internals.Session` directly (no `Property` tree to resolve), so it takes over just the
 /// `applyCompression()` + `client()` + `execute(client:request:...)` half of that pipeline
-/// (`RawTask.executeTraced` is the other caller of the first of those). Compression itself is no
-/// longer read off `session.configuration` -- it's already captured on `requestConfiguration`
-/// (via `Property.compression(_:onDuplicateHeader:shouldCompressBodyData:)`) by the time this
-/// runs, same as `RawTask.executeTraced` sees it.
+/// (`RawTask.executeTraced` is the other caller of the first of those).
+///
+/// Compression itself is no longer read off `session.configuration`: it's already captured on
+/// `requestConfiguration` (via `Property.compression(_:onDuplicateHeader:shouldCompressBodyData:)`)
+/// by the time this runs, same as `RawTask.executeTraced` sees it.
 private func execute(
     session: Internals.Session,
     requestConfiguration: RequestConfiguration

--- a/Tests/RequestDLTests/Tasks/Sources/Raw Task/Upload/UploadTaskTests.swift
+++ b/Tests/RequestDLTests/Tasks/Sources/Raw Task/Upload/UploadTaskTests.swift
@@ -65,7 +65,7 @@ struct UploadTaskTests {
 extension UploadTaskTests {
 
     /// Forced deterministically rather than relying on `resolveExecutor()`'s own default
-    /// preference the way `uploadTask()` above does -- same round trip, pinned explicitly to
+    /// preference the way `uploadTask()` above does: same round trip, pinned explicitly to
     /// `.urlSession`. Darwin-only: `.urlSession` isn't a real executor anywhere else, so pinning
     /// it there is not this test's intent.
     @Test

--- a/Tests/RequestDLTests/Tasks/Sources/Raw Task/cURL/CURLCommandParserTests.swift
+++ b/Tests/RequestDLTests/Tasks/Sources/Raw Task/cURL/CURLCommandParserTests.swift
@@ -261,7 +261,7 @@ struct CURLCommandParserTests {
         // Given / When
         let command = try await CURLCommandParser.parseCommand("curl https://example.com")
 
-        // Then -- a command using only the request-level subset must not touch
+        // Then: a command using only the request-level subset must not touch
         // `Make.sessionConfiguration` in any way, same as before these flags existed.
         #expect(command.sessionConfigurationEdit == nil)
     }
@@ -271,7 +271,7 @@ struct CURLCommandParserTests {
         // Given
         let command = try await CURLCommandParser.parseCommand("curl -k https://example.com")
 
-        // When -- any session-level flag (here just `-k`) makes the edit apply curl's own
+        // When: any session-level flag (here just `-k`) makes the edit apply curl's own
         // default for redirects too, not just leave this package's own (opposite) default in
         // place.
         var sessionConfiguration = Internals.Session.Configuration()
@@ -322,10 +322,10 @@ struct CURLCommandParserTests {
         let edit = try #require(command.sessionConfigurationEdit)
         edit(&sessionConfiguration)
 
-        // Then -- `.some(.none)`, not plain `.none`: the field is `CertificateVerification?`,
+        // Then: `.some(.none)`, not plain `.none`. The field is `CertificateVerification?`,
         // and `CertificateVerification` itself has a `.none` case, so unqualified `.none` here
         // would be inferred as `Optional.none` (nil) and pass vacuously whether or not the
-        // production code actually set anything -- exactly the bug this test exists to catch.
+        // production code actually set anything, exactly the bug this test exists to catch.
         #expect(sessionConfiguration.secureConnection?.certificateVerification == .some(.none))
     }
 
@@ -433,7 +433,7 @@ struct CURLCommandParserTests {
         let edit = try #require(command.sessionConfigurationEdit)
         edit(&sessionConfiguration)
 
-        // Then -- the port is validated but not carried into `dnsOverride`, which has no port
+        // Then: the port is validated but not carried into `dnsOverride`, which has no port
         // dimension.
         #expect(sessionConfiguration.dnsOverride == ["example.com": "127.0.0.1"])
     }
@@ -514,7 +514,7 @@ struct CURLCommandParserTests {
             "curl -o response.json -w '%{http_code}' https://example.com"
         )
 
-        // Then -- their arguments must not be mistaken for the URL or throw as unsupported.
+        // Then: their arguments must not be mistaken for the URL or throw as unsupported.
         #expect(configuration.url == "https://example.com")
     }
 
@@ -528,7 +528,7 @@ struct CURLCommandParserTests {
 
     @Test
     func repeatedURLFlagIsRejected() async throws {
-        // Given / When / Then -- `--url` used to silently overwrite a previous `url`/`--url`
+        // Given / When / Then: `--url` used to silently overwrite a previous `url`/`--url`
         // instead of rejecting it like a second bare URL does; both now reject consistently.
         await #expect(throws: CURLParsingError.self) {
             try await CURLCommandParser.parse("curl --url https://example.com --url https://example.org")

--- a/Tests/RequestDLTests/Tasks/Sources/Raw Task/cURL/CURLTaskTests.swift
+++ b/Tests/RequestDLTests/Tasks/Sources/Raw Task/cURL/CURLTaskTests.swift
@@ -16,7 +16,7 @@ import struct Foundation.UUID
 #endif
 
 /// `CURLCommandParserTests` already covers parsing itself in depth. Most of what's here only has
-/// to prove that `CURLTask` actually delegates to `CURLCommandParser` -- a parsing failure has to
+/// to prove that `CURLTask` actually delegates to `CURLCommandParser`: a parsing failure has to
 /// surface as `CURLParsingError` before any network I/O is attempted, which needs no
 /// `LocalServer`.
 struct CURLTaskTests {
@@ -54,7 +54,7 @@ struct CURLTaskTests {
         }
     }
 
-    /// The leading literal `curl` token has to be stripped before flag parsing begins -- if it
+    /// The leading literal `curl` token has to be stripped before flag parsing begins: if it
     /// weren't, the very first token would be read as an (unsupported) flag instead of being
     /// discarded, which this pins down by checking *which* token the error names.
     @Test
@@ -72,7 +72,7 @@ struct CURLTaskTests {
     }
 
     /// `CURLCommandParserTests` already checks the produced `sessionConfigurationEdit` closure in
-    /// isolation. This instead exercises the actual new integration point --
+    /// isolation. This instead exercises the actual new integration point:
     /// `RawRequestConfigurationProperty.Node.make()` calling that closure on
     /// `Make.sessionConfiguration` during a real `Resolve` walk, which is what `CURLTask.result()`
     /// relies on.
@@ -89,21 +89,21 @@ struct CURLTaskTests {
 
         let (_, make) = try await Resolve(root: property, environment: .init()).partiallyBuild()
 
-        // Then -- `.some(.none)`, not plain `.none`: `certificateVerification` is
+        // Then: `.some(.none)`, not plain `.none`. `certificateVerification` is
         // `NIOSSL.CertificateVerification?`, and that type itself has a `.none` case, so
         // unqualified `.none` here is inferred as `Optional.none` (nil) and would pass whether or
-        // not `-k` actually did anything -- this exact ambiguity is what let `-k` silently do
+        // not `-k` actually did anything. This exact ambiguity is what let `-k` silently do
         // nothing at all until it was caught by a real network round trip (see
         // `insecureFlagReachesASelfSignedLocalServer` below).
         #expect(make.sessionConfiguration.secureConnection?.certificateVerification == .some(.none))
         #expect(make.sessionConfiguration.redirectConfiguration == .follow(max: 50, allowCycles: false))
     }
 
-    /// A real, end-to-end network round trip through `CURLTask` -- `-k` reaching `LocalServer`'s
+    /// A real, end-to-end network round trip through `CURLTask`: `-k` reaching `LocalServer`'s
     /// self-signed certificate the same way `-k` would let a real curl reach it. This is the test
     /// that actually caught `-k` doing nothing (see the `.some(.none)` note above): asserting on
     /// `Internals.Session.Configuration` alone, however carefully, never proves the bytes that
-    /// reach NIOSSL/CFNetwork are what was intended -- only a live handshake against a genuinely
+    /// reach NIOSSL/CFNetwork are what was intended; only a live handshake against a genuinely
     /// untrusted certificate does.
     @Test
     func insecureFlagReachesASelfSignedLocalServer() async throws {


### PR DESCRIPTION
## Summary
- Replaces the ASCII double-hyphen `--` used as an em-dash stand-in in doc comments and inline comments across `Sources/`, `Tests/`, and `README.md` with punctuation that reads more naturally (commas, colons, semicolons, parentheses, or split sentences).
- Splits several overly dense, multi-idea comment paragraphs into lighter multi-paragraph doc comments.
- Deliberately leaves untouched: literal curl CLI flags (`--header`, `--data-raw`, etc.), PEM boundary markers (`-----BEGIN CERTIFICATE-----`), and real git command syntax (`git log ... -- <path>`).

Comment/doc-only change; no executable code was touched. `swift build` and `swift build --build-tests` both pass cleanly.

## Test plan
- [x] `swift build` succeeds
- [x] `swift build --build-tests` succeeds
- [x] Repo-wide grep confirms no remaining prose `--` in `///`/`//` comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)